### PR TITLE
Speedup Test-Execution

### DIFF
--- a/rosys/__init__.py
+++ b/rosys/__init__.py
@@ -77,22 +77,30 @@ async def sleep(seconds: float) -> None:
             await asyncio.sleep(0)
 
 
+def _run_handler(handler: Callable) -> None:
+    try:
+        result = handler()
+        if isinstance(result, Awaitable):
+            tasks.append(create_task(result, name=handler.__qualname__))
+    except:
+        log.exception(f'error while starting handler "{handler.__qualname__}"')
+
+
+def _start_loop(handler: Callable, interval: float) -> None:
+    log.debug(f'starting loop "{handler.__qualname__}" with interval {interval:.3f}s')
+    tasks.append(create_task(_repeat_one_handler(handler, interval), name=handler.__qualname__))
+
+
 def on_repeat(handler: Callable, interval: float) -> None:
-    if tasks:  # rosys has already started
-        log.debug(f'starting loop "{handler.__qualname__}" with interval {interval:.3f}s')
-        tasks.append(create_task(_repeat_one_handler(handler, interval), name=handler.__qualname__))
+    if tasks:  # RoSys is already running
+        _start_loop(handler, interval)
     else:
         repeat_handlers.append((handler, interval))
 
 
 def on_startup(handler: Callable) -> None:
-    if tasks:  # rosys has already started
-        try:
-            result = handler()
-            if isinstance(result, Awaitable):
-                tasks.append(create_task(result, name=handler.__qualname__))
-        except:
-            log.exception(f'error while starting handler "{handler.__qualname__}"')
+    if tasks:  # RoSys is already running
+        _run_handler(handler)
     else:
         startup_handlers.append(handler)
 
@@ -108,18 +116,13 @@ async def startup() -> None:
     persistence.restore()
 
     for handler in startup_handlers:
-        try:
-            await invoke(handler)
-        except:
-            log.exception(f'error while starting handler "{handler.__qualname__}"')
-            continue
+        _run_handler(handler)
 
     for coroutine in event.startup_coroutines:
         await coroutine
 
     for handler, interval in repeat_handlers:
-        log.debug(f'starting loop "{handler.__qualname__}" with interval {interval:.3f}s')
-        tasks.append(create_task(_repeat_one_handler(handler, interval), name=handler.__qualname__))
+        _start_loop(handler, interval)
 
 
 async def _garbage_collection(mbyte_limit: float = 300) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ from rosys.test import helpers, log_configuration
 log_configuration.setup()
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture
 async def integration() -> Generator:
     rosys.reset_before_test()
     await rosys.startup()
@@ -21,34 +21,34 @@ async def integration() -> Generator:
     rosys.reset_after_test()
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture
 async def odometer(wheels: Wheels, integration: None) -> Odometer:
     helpers.odometer = Odometer(wheels)
     return helpers.odometer
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture
 async def wheels(integration: None) -> Wheels:
     return WheelsSimulation()
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture
 async def driver(wheels: Wheels, odometer: Odometer, integration: None) -> Driver:
     helpers.driver = Driver(wheels, odometer)
     return helpers.driver
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture
 async def automator(wheels: Wheels, integration: None) -> Automator:
     helpers.automator = Automator(wheels, None)
     return helpers.automator
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture
 def shape() -> Prism:
     return Prism.default_robot_shape()
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture
 async def path_planner(shape: Prism, integration: None) -> PathPlanner:
     return PathPlanner(shape)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,43 +12,43 @@ from rosys.test import helpers, log_configuration
 log_configuration.setup()
 
 
-@pytest.fixture(autouse=True)
-async def run_around_tests(odometer: Odometer, driver: Driver, automator: Automator) -> Generator:
+@pytest.fixture(autouse=False)
+async def integration() -> Generator:
     rosys.reset_before_test()
-    helpers.odometer = odometer
-    helpers.driver = driver
-    helpers.automator = automator
     await rosys.startup()
     yield
     await rosys.shutdown()
     rosys.reset_after_test()
 
 
-@pytest.fixture(autouse=True)
-def odometer(wheels: Wheels) -> Odometer:
-    return Odometer(wheels)
+@pytest.fixture(autouse=False)
+async def odometer(wheels: Wheels, integration: None) -> Odometer:
+    helpers.odometer = Odometer(wheels)
+    return helpers.odometer
 
 
-@pytest.fixture(autouse=True)
-def wheels() -> Wheels:
+@pytest.fixture(autouse=False)
+async def wheels(integration: None) -> Wheels:
     return WheelsSimulation()
 
 
-@pytest.fixture(autouse=True)
-def driver(wheels: Wheels, odometer: Odometer) -> Driver:
-    return Driver(wheels, odometer)
+@pytest.fixture(autouse=False)
+async def driver(wheels: Wheels, odometer: Odometer, integration: None) -> Driver:
+    helpers.driver = Driver(wheels, odometer)
+    return helpers.driver
 
 
-@pytest.fixture(autouse=True)
-def automator(wheels: Wheels) -> Automator:
-    return Automator(wheels, None)
+@pytest.fixture(autouse=False)
+async def automator(wheels: Wheels, integration: None) -> Automator:
+    helpers.automator = Automator(wheels, None)
+    return helpers.automator
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=False)
 def shape() -> Prism:
     return Prism.default_robot_shape()
 
 
-@pytest.fixture(autouse=True)
-def path_planner(shape: Prism) -> PathPlanner:
+@pytest.fixture(autouse=False)
+async def path_planner(shape: Prism, integration: None) -> PathPlanner:
     return PathPlanner(shape)

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -32,6 +32,7 @@ async def test_registering_lambdas():
     assert numbers == [42]
 
 
+@pytest.mark.usefixtures('integration')
 async def test_fire_and_forget_with_emit():
 
     class TestActor:

--- a/tests/test_path_planning.py
+++ b/tests/test_path_planning.py
@@ -22,6 +22,7 @@ def create_obstacle(*, x: float, y: float, radius: float = 0.5) -> Obstacle:
 
 
 async def test_basic_path_planning(path_planner: PathPlanner) -> None:
+    await asyncio.sleep(1)
     await forward(1.0)
 
     goal = Pose(x=1.0, y=1.0)

--- a/tests/test_path_planning.py
+++ b/tests/test_path_planning.py
@@ -22,7 +22,6 @@ def create_obstacle(*, x: float, y: float, radius: float = 0.5) -> Obstacle:
 
 
 async def test_basic_path_planning(path_planner: PathPlanner) -> None:
-    await asyncio.sleep(1)
     await forward(1.0)
 
     goal = Pose(x=1.0, y=1.0)

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -1,9 +1,11 @@
 import numpy as np
+import pytest
 import rosys
 from rosys.hardware import Wheels, WheelsSimulation
 from rosys.test import assert_pose, forward
 
 
+@pytest.mark.usefixtures('odometer')
 async def test_drive(wheels: Wheels) -> None:
     assert_pose(0, 0, deg=0)
 
@@ -23,6 +25,7 @@ async def test_drive(wheels: Wheels) -> None:
     assert_pose(2.0, 1.0, deg=45, position_tolerance=0.1)
 
 
+@pytest.mark.usefixtures('odometer')
 async def test_stopping_robot_when_rosys_stops(wheels: Wheels) -> None:
     await wheels.drive(1, 0)
     await forward(x=1.0, y=0.0)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -3,6 +3,7 @@ import rosys
 from rosys.test import forward
 
 
+@pytest.mark.usefixtures('integration')
 async def test_time():
     assert rosys.time() == 0.0
 
@@ -19,6 +20,7 @@ async def test_time():
     assert rosys.uptime() == pytest.approx(5.0, abs=0.1)
 
 
+@pytest.mark.usefixtures('integration')
 async def test_sleep():
     assert rosys.time() == 0.0
     sleep = rosys.create_task(rosys.sleep(1.0))


### PR DESCRIPTION
By not auto-using all fixtures we can greatly reduce test execution time.