### PR TITLE
Use `rosys.on_startup()` instead of `app.on_startup()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Modules can depend on other modules which is mostly implemented by passing them 
 
 ### Lifecycle Hooks and Loops
 
-Modules can register functions via `rosys.on_startup` or `rosys.on_shutdown` as well as repeatedly with a given interval with `on_repeat`.
+Modules can register functions via `rosys.on_startup` or `rosys.on_shutdown` as well as repeatedly with a given interval with `rosys.on_repeat`.
 
 <!-- prettier-ignore-start -->
 !!! note

--- a/README.md
+++ b/README.md
@@ -54,7 +54,15 @@ Modules can depend on other modules which is mostly implemented by passing them 
 
 ### Lifecycle Hooks and Loops
 
-Modules can register functions for being called `on_startup` or `on_shutdown` as well as repeatedly with a given interval with `on_repeat`.
+Modules can register functions via `rosys.on_startup` or `rosys.on_shutdown` as well as repeatedly with a given interval with `on_repeat`.
+
+<!-- prettier-ignore-start -->
+!!! note
+    Note that NiceGUI's `app` object also provides methods `app.on_startup` and `app.on_shutdown`, but it is recommended to use RoSys' counterparts:
+    `rosys.on_startup` ensures the callback is executed _after_ persistent modules have been loaded from storage.
+    If you, e.g., set the `rosys.config.simulation_speed` programmatically via `app.on_startup()` instead of `rosys.on_startup`,
+    the change is overwritten by RoSys' `persistence.restore()`.
+<!-- prettier-ignore-end -->
 
 ### Events
 

--- a/docs/generate_reference.py
+++ b/docs/generate_reference.py
@@ -25,7 +25,7 @@ def extract_events(filepath: str) -> dict[str, str]:
 
 for path in sorted(Path('.').rglob('__init__.py')):
     identifier = str(path.parent).replace('/', '.')
-    if identifier in ['rosys', 'rosys.test', 'rosys.hardware.communication']:
+    if identifier in ['rosys', 'rosys.test', 'rosys.hardware.communication', 'rosys.persistence']:
         continue
 
     try:

--- a/docs/src/example_cameras_remote.py
+++ b/docs/src/example_cameras_remote.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from nicegui import app, ui
+from nicegui import ui
 
 import rosys
 
@@ -16,7 +16,7 @@ else:
     camera_provider = rosys.vision.UsbCameraProviderSimulation()
     camera_provider.restore = lambda _: None  # NOTE: disable persistence
     test_cam = camera_provider.create_calibrated('test_cam', width=800, height=600)
-    app.on_startup(lambda: camera_provider.add_camera(test_cam))
+    rosys.on_startup(lambda: camera_provider.add_camera(test_cam))
 steerer = rosys.driving.Steerer(wheels)
 odometer = rosys.driving.Odometer(wheels)
 

--- a/docs/src/example_simulation_speed.py
+++ b/docs/src/example_simulation_speed.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import random
 
-from nicegui import app, ui
+from nicegui import ui
 
 import rosys
 from rosys.automation import Automator
@@ -34,6 +34,6 @@ async def move_around():
     while True:
         await driver.drive_to(Point(x=random.uniform(-size, size), y=random.uniform(-size, size)))
 
-app.on_startup(lambda: automator.start(move_around()))
+rosys.on_startup(lambda: automator.start(move_around()))
 
 ui.run(title='RoSys')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,6 @@ plugins:
             show_signature_annotations: true
             merge_init_into_class: true
             separate_signature: true
-      watch:
-        - rosys
-        - README.md
+watch:
+  - rosys
+  - README.md


### PR DESCRIPTION
This PR follows up on discussion #45 and propagates the consequent use of RoSys' own lifecycle registration functions.

I had to update the mkdocs config a little bit. We'll have to see if the doc generation and deployment still works.