### PR TITLE
Ensure no zombie processes are left over by run.sh

### DIFF
--- a/rosys/run.py
+++ b/rosys/run.py
@@ -74,7 +74,9 @@ async def sh(command: list[str] | str, *,
                 start_new_session=True,
             ) as proc:
                 running_sh_processes.append(cast(Popen, proc))
-                stdout, *_ = proc.communicate()
+                stdout, stderr = proc.communicate()
+                proc.stdout.close()
+                proc.stderr.close()
                 _kill(cast(Popen, proc))
                 running_sh_processes.remove(cast(Popen, proc))
                 return stdout.decode('utf-8')

--- a/rosys/run.py
+++ b/rosys/run.py
@@ -82,7 +82,8 @@ async def sh(command: list[str] | str, *,
                 return stdout.decode('utf-8')
         except Exception:
             log.exception(f'failed to run command "{cmd}"')
-            _kill(cast(Popen, proc))
+            if 'proc' in locals() and proc:
+                _kill(cast(Popen, proc))
             return ''
 
     if is_stopping():

--- a/rosys/run.py
+++ b/rosys/run.py
@@ -79,7 +79,7 @@ async def sh(command: list[str] | str, *,
                 proc.stderr.close()
                 _kill(cast(Popen, proc))
                 running_sh_processes.remove(cast(Popen, proc))
-                return stdout.decode('utf-8')
+                return stdout.decode('utf-8') if proc.returncode == 0 else stderr.decode('utf-8')
         except Exception:
             log.exception(f'failed to run command "{cmd}"')
             if 'proc' in locals() and proc:

--- a/rosys/run.py
+++ b/rosys/run.py
@@ -61,7 +61,7 @@ async def sh(command: list[str] | str, *,
     def popen() -> str:
         cmd_list = command if isinstance(command, list) else shlex.split(command)
         if timeout is not None:
-            cmd_list = ['timeout', '--signal=SIGKILL', str(timeout)] + cmd_list
+            cmd_list = ['timeout', '--signal=SIGTERM', str(timeout)] + cmd_list
         cmd = ' '.join(cmd_list) if shell else cmd_list
         # log.info(f'running sh: "{cmd}"')
         try:

--- a/rosys/vision/rtsp_camera_provider_hardware.py
+++ b/rosys/vision/rtsp_camera_provider_hardware.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import logging
+import os
 import shlex
 import subprocess
 import sys
@@ -47,10 +48,13 @@ class RtspCameraProviderHardware(CameraProvider, persistence.PersistentModule):
         self._cameras: dict[str, RtspCamera] = {}
         self._capture_tasks: dict[str, asyncio.Task] = {}
         self._processes: list[Process] = []
+
         if sys.platform.startswith('darwin'):
-            self.arpscan_cmd = 'sudo arp-scan'
+            self.arpscan_cmd = 'arp-scan'
         else:
-            self.arpscan_cmd = 'sudo /usr/sbin/arp-scan'
+            self.arpscan_cmd = '/usr/sbin/arp-scan'
+        if os.getuid() != 0:
+            self.arpscan_cmd = f'sudo {self.arpscan_cmd}'
 
         rosys.on_shutdown(self.shutdown)
         rosys.on_repeat(self.update_device_list, 1)

--- a/scripts/watch_wifi_configs.py
+++ b/scripts/watch_wifi_configs.py
@@ -11,7 +11,7 @@ PATH = Path('~/.rosys/wifi').expanduser()
 
 
 def nmcli(cmd: str) -> None:
-    cmd = 'nmcli connection ' + cmd
+    cmd = f'nmcli connection {cmd}'
     if os.getuid() != 0:
         cmd = f'sudo {cmd}'
     subprocess.Popen(cmd, shell=True)

--- a/scripts/watch_wifi_configs.py
+++ b/scripts/watch_wifi_configs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import subprocess
 import time
 from pathlib import Path
@@ -10,7 +11,9 @@ PATH = Path('~/.rosys/wifi').expanduser()
 
 
 def nmcli(cmd: str) -> None:
-    cmd = 'sudo nmcli connection ' + cmd
+    cmd = 'nmcli connection ' + cmd
+    if os.getuid() != 0:
+        cmd = f'sudo {cmd}'
     subprocess.Popen(cmd, shell=True)
 
 


### PR DESCRIPTION
This PR applies some additional checks to ensure we do not create zombie processes. In one of our projects we saw many of these:

```
message+  725270  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [exim4] <defunct>
message+  725271  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [exim4] <defunct>
root      725282  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [sudo] <defunct>
root      725285  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [sudo] <defunct>
message+  725288  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [exim4] <defunct>
message+  725289  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [exim4] <defunct>
root      725297  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [sudo] <defunct>
root      725300  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [sudo] <defunct>
message+  725303  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [exim4] <defunct>
message+  725304  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [exim4] <defunct>
root      725309  0.0  0.0      0     0 ?        Z    Okt19   0:00 [sudo] <defunct>
root      725311  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [sudo] <defunct>
root      725314  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [sudo] <defunct>
root      725316  0.0  0.0      0     0 ?        Z    Okt19   0:00 [arp-scan] <defunct>
message+  725317  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [exim4] <defunct>
message+  725318  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [exim4] <defunct>
root      725326  0.0  0.0      0     0 ?        Z    Okt19   0:00 [sudo] <defunct>
root      725328  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [sudo] <defunct>
root      725331  0.0  0.0      0     0 ?        Zs   Okt19   0:00 [sudo] <defunct>
root      725333  0.0  0.0      0     0 ?        Z    Okt19   0:00 [arp-scan] <defunct>
```

Which leads to `BlockingIOError: [Errno 11] Resource temporarily unavailable` down the road (when Linux can't create any more processes).