### PR TITLE
Change image detections to dict.

### DIFF
--- a/rosys/vision/detector.py
+++ b/rosys/vision/detector.py
@@ -2,9 +2,9 @@ import abc
 import logging
 from enum import Enum
 from typing import Optional
+from uuid import uuid4
 
 from ..event import Event
-from .detections import Detections
 from .image import Image
 from .uploads import Uploads
 
@@ -28,13 +28,14 @@ class Detector(abc.ABC):
     It also holds an upload queue for sending images with uncertain results to an active learning infrastructure like the [Zauberzeug Learning Loop](https://zauberzeug.com/learning-loop.html).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, name: Optional[str] = None) -> None:
+        self.name = name or str(uuid4())
         self.NEW_DETECTIONS = Event()
         """detection on an image is completed (argument: image)"""
         self.log = logging.getLogger('rosys.detector')
 
     @abc.abstractmethod
-    async def detect(self, image: Image, autoupload: Autoupload = Autoupload.FILTERED) -> Optional[Detections]:
+    async def detect(self, image: Image, autoupload: Autoupload = Autoupload.FILTERED) -> None:
         pass
 
     @abc.abstractmethod

--- a/rosys/vision/image.py
+++ b/rosys/vision/image.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import ClassVar, Optional
 
 import PIL.Image
@@ -26,10 +26,24 @@ class Image:
     size: ImageSize
     time: float  # time of recording
     data: Optional[bytes] = None
-    detections: Optional[Detections] = None
+    _detections: dict[str, Detections] = field(default_factory=dict)
     is_broken: Optional[bool] = None
 
     DEFAULT_PLACEHOLDER_SIZE: ClassVar[tuple[int, int]] = (320, 240)
+
+    @property
+    def detections(self) -> Optional[Detections]:
+        if not self._detections:
+            return None
+        if len(self._detections) > 1:
+            raise RuntimeError('Image has multiple detection types. Use `get_detections` instead.')
+        return list(self._detections.values())[0]
+
+    def get_detections(self, detector_id: str) -> Optional[Detections]:
+        return self._detections.get(detector_id)
+
+    def set_detections(self, detector_id: str, detections: Detections) -> None:
+        self._detections[detector_id] = detections
 
     @property
     def id(self) -> str:


### PR DESCRIPTION
This change allows to associate multiple detections (groups of detections) with an image, e.g. when multiple detectors are used. The default behavior should be mostly unchanged: if there is only one detections in the dict, the property 'image.detections' can still be used to access the detections. The dict keys are strings that correspond to the detector names. Here, this PR introduces the attribute name for the detector which, however, is optional to maintain downward compatibility.