### PR TITLE
check read/write to determine if SerialCommunication.is_possible

### DIFF
--- a/rosys/hardware/communication/serial_communication.py
+++ b/rosys/hardware/communication/serial_communication.py
@@ -5,6 +5,7 @@ from typing import Optional
 import serial
 from nicegui import ui
 from nicegui.events import ValueChangeEventArguments
+from serial.serialutil import SerialException
 
 from ... import rosys
 from .communication import Communication
@@ -36,7 +37,15 @@ class SerialCommunication(Communication):
 
     @staticmethod
     def is_possible() -> bool:
-        return SerialCommunication.get_device_path() is not None
+        device_path = SerialCommunication.get_device_path()
+        if device_path is None:
+            return False
+        try:
+            with serial.Serial(device_path) as ser:
+                pass  # Successfully opened the port
+            return True
+        except SerialException as e:
+            return False
 
     @staticmethod
     def get_device_path() -> Optional[str]:


### PR DESCRIPTION
This PR extends the `SerialCommunication.is_possible` check to also test for read/write permissions. The function is often used to probe weather we run on a real robot or just simulation. When starting on a blank Jetson the serial port may be there but because the serial is not connected, assumptions down the line break.