### PR TITLE
Provide method to abort current driving loop

### DIFF
--- a/rosys/driving/__init__.py
+++ b/rosys/driving/__init__.py
@@ -1,5 +1,5 @@
 from .drivable import Drivable
-from .driver import Driver
+from .driver import Driver, DrivingAbortedException
 from .driver_object import DriverObject as driver_object
 from .joystick_ import Joystick as joystick
 from .keyboard_control_ import KeyboardControl as keyboard_control

--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -33,6 +33,10 @@ class DriveState:
     turn_angle: float
 
 
+class DrivingAbortedException(Exception):
+    pass
+
+
 class Driver:
     """The driver module allows following a given path.
 
@@ -46,6 +50,7 @@ class Driver:
         self.odometer = odometer
         self.parameters = DriveParameters()
         self.state: Optional[DriveState] = None
+        self.abort_driving = False
 
     @analysis.track
     async def drive_square(self) -> None:
@@ -106,6 +111,9 @@ class Driver:
         carrot = Carrot(spline=spline, offset=carrot_offset)
 
         while True:
+            if self.abort_driving:
+                self.abort_driving = False
+                raise DrivingAbortedException()
             dYaw = self.parameters.hook_bending_factor * self.odometer.current_velocity.angular if self.odometer.current_velocity else 0
             hook = self.odometer.prediction.transform_pose(Pose(yaw=dYaw)).transform(hook_offset)
             if self.parameters.can_drive_backwards:

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -63,3 +63,16 @@ async def test_driving_a_spline(driver: Driver, automator: Automator, robot: Rob
     automator.start(driver.drive_spline(spline))
     await forward(x=dx)
     assert_pose(dx, 1, deg=0, deg_tolerance=5)
+
+
+async def test_aborting_a_drive(driver: Driver, automator: Automator, robot: Robot):
+    assert_pose(0, 0, deg=0)
+    automator.start(driver.drive_spline(Spline.from_poses(Pose(x=0), Pose(x=2))))
+    cause: list[str] = []
+    automator.AUTOMATION_STOPPED.register(cause.append)
+    await forward(x=1)
+    assert_pose(1, 0, deg=0)
+    driver.abort()
+    await forward(seconds=1)
+    assert_pose(1, 0, deg=0)
+    assert cause == ['an exception occurred in an automation']


### PR DESCRIPTION
This PR introduces a flag `driver.abort_driving` which interrupts the current driving loop. This can be used if the current driving path becomes invalid. For example due to a suddenly appearing obstacle or large position shifts.