### PR TITLE
Videos Page: Use existing media url for download

### DIFF
--- a/rosys/analysis/videos_page_.py
+++ b/rosys/analysis/videos_page_.py
@@ -11,18 +11,16 @@ class VideosPage:
     def __init__(self) -> None:
         @ui.page('/videos', title='Videos')
         async def page():
-
             @ui.refreshable
             async def videos():
                 for mp4 in sorted(await run.io_bound(VIDEO_FILES.glob, '*.mp4'), reverse=True):
                     with ui.row():
                         with ui.card().tight():
                             video = ui.video(mp4).classes('w-[800px]')
+                            src = video._props['src']  # pylint: disable=protected-access
                         with ui.column():
-                            ui.button(on_click=lambda mp4=mp4: mp4.unlink()) \
-                                .props('icon=delete flat')
-                            ui.button(on_click=lambda mp4=mp4: ui.download(video._props['src'])) \
-                                .props('icon=download flat')
+                            ui.button(on_click=lambda mp4=mp4: mp4.unlink()).props('icon=delete flat')
+                            ui.button(on_click=lambda src=src: ui.download(src)).props('icon=download flat')
 
             async def watch_videos():
                 async for _ in watchfiles.awatch(VIDEO_FILES):

--- a/rosys/analysis/videos_page_.py
+++ b/rosys/analysis/videos_page_.py
@@ -17,10 +17,12 @@ class VideosPage:
                 for mp4 in sorted(VIDEO_FILES.glob('*.mp4'), reverse=True):
                     with ui.row():
                         with ui.card().tight():
-                            ui.video(mp4).classes('w-[800px]')
+                            video = ui.video(mp4).classes('w-[800px]')
                         with ui.column():
-                            ui.button(on_click=lambda mp4=mp4: mp4.unlink()).props('icon=delete flat')
-                            ui.button(on_click=lambda mp4=mp4: ui.download(mp4)).props('icon=download flat')
+                            ui.button(on_click=lambda mp4=mp4: mp4.unlink()) \
+                                .props('icon=delete flat')
+                            ui.button(on_click=lambda mp4=mp4: ui.download(video._props['src'])) \
+                                .props('icon=download flat')
 
             async def watch_videos():
                 async for _ in watchfiles.awatch(VIDEO_FILES):

--- a/rosys/analysis/videos_page_.py
+++ b/rosys/analysis/videos_page_.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import watchfiles
-from nicegui import background_tasks, ui
+from nicegui import background_tasks, run, ui
 
 VIDEO_FILES = Path('~/.rosys/timelapse/videos').expanduser()
 
@@ -10,11 +10,11 @@ class VideosPage:
 
     def __init__(self) -> None:
         @ui.page('/videos', title='Videos')
-        def page():
+        async def page():
 
             @ui.refreshable
-            def videos():
-                for mp4 in sorted(VIDEO_FILES.glob('*.mp4'), reverse=True):
+            async def videos():
+                for mp4 in sorted(await run.io_bound(VIDEO_FILES.glob, '*.mp4'), reverse=True):
                     with ui.row():
                         with ui.card().tight():
                             video = ui.video(mp4).classes('w-[800px]')
@@ -28,5 +28,5 @@ class VideosPage:
                 async for _ in watchfiles.awatch(VIDEO_FILES):
                     videos.refresh()
 
-            videos()
+            await videos()
             background_tasks.create(watch_videos(), name='watch videos files')


### PR DESCRIPTION
This PR uses the existing media file url from the `ui.video` element for `ui.download` because the media url allows chunked download and caching through NiceGUI On Air.