### PR TITLE
Consistently handle points behind the camera when projecting from and to an image

### DIFF
--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -50,7 +50,7 @@ class Calibration:
         return np.dot(self.extrinsics.rotation.R, self.intrinsics.rotation.R)
 
     @overload
-    def project_to_image(self, world_coordinates: Point3d) -> Point: ...
+    def project_to_image(self, world_coordinates: Point3d) -> Optional[Point]: ...
 
     @overload
     def project_to_image(self, world_coordinates: np.ndarray) -> np.ndarray: ...
@@ -74,7 +74,7 @@ class Calibration:
         return image_array.reshape(-1, 2)
 
     @overload
-    def project_from_image(self, image_coordinates: Point, target_height: float = 0) -> Point3d: ...
+    def project_from_image(self, image_coordinates: Point, target_height: float = 0) -> Optional[Point3d]: ...
 
     @overload
     def project_from_image(self, image_coordinates: np.ndarray, target_height: float = 0) -> np.ndarray: ...
@@ -99,7 +99,7 @@ class Calibration:
         reprojection = self.project_to_image(world_points)
         sign = objPoints[:, -1] * np.sign(Z)
         distance = np.linalg.norm(reprojection - image_coordinates, axis=1)
-        world_points[np.logical_or(sign > 0, distance > 2), :] = np.nan
+        world_points[np.logical_not(np.logical_and(sign < 0, distance < 2)), :] = np.nan
 
         return world_points
 

--- a/rosys/vision/camera_objects_.py
+++ b/rosys/vision/camera_objects_.py
@@ -18,7 +18,7 @@ class CameraObjects(Group):
     With `debug=True` camera IDs are shown (default: `False`).
     """
 
-    def __init__(self, camera_provider: CameraProvider, camera_projector: CameraProjector, *,
+    def __init__(self, camera_provider: CameraProvider[CalibratableCamera], camera_projector: CameraProjector, *,
                  px_per_m: float = 10000, debug: bool = False) -> None:
         super().__init__()
 

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -54,7 +54,7 @@ class CameraProjector:
         c, r = np.meshgrid(np.linspace(0, camera.calibration.intrinsics.size.width, columns),
                            np.linspace(0, camera.calibration.intrinsics.size.height, rows))
         image_points = np.stack((c.flatten(), r.flatten()), axis=1)
-        floor_points = camera.calibration.project_array_from_image(image_points).reshape(rows, columns, 3)
+        floor_points = camera.calibration.project_from_image(image_points).reshape(rows, columns, 3)
         invalid = np.isnan(floor_points).any(axis=2)
         return [
             [

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -25,7 +25,7 @@ class CameraProjector:
     It is mainly used for visualization purposes.
     """
 
-    def __init__(self, camera_provider: CameraProvider) -> None:
+    def __init__(self, camera_provider: CameraProvider[CalibratableCamera]) -> None:
         self.camera_provider = camera_provider
 
         self.projections: dict[str, Projection] = {}

--- a/rosys/vision/detector_simulation.py
+++ b/rosys/vision/detector_simulation.py
@@ -83,6 +83,8 @@ class DetectorSimulation(Detector):
             if np.dot(viewing_direction, object_direction) < 0:
                 continue
             image_point = camera.calibration.project_to_image(obj.position)
+            if image_point is None:
+                continue
             if not (0 <= image_point.x < image.size.width and 0 <= image_point.y < image.size.height):
                 continue
 
@@ -103,6 +105,8 @@ class DetectorSimulation(Detector):
                     for dz in [-obj.size[2] / 2, obj.size[2] / 2]
                 ])
                 image_points = camera.calibration.project_to_image(world_points)
+                if np.any(np.isnan(image_points)):
+                    continue
                 detections.boxes.append(BoxDetection(
                     category_name=obj.category_name,
                     model_name='simulation',

--- a/rosys/vision/detector_simulation.py
+++ b/rosys/vision/detector_simulation.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from .. import rosys
 from ..geometry import Point3d
+from .camera import CalibratableCamera
 from .camera_provider import CameraProvider
 from .detections import BoxDetection, Detections, PointDetection
 from .detector import Detector
@@ -34,7 +35,7 @@ class DetectorSimulation(Detector):
     An optional `noise` parameter controls the spatial accuracy in pixels.
     """
 
-    def __init__(self, camera_provider: CameraProvider, *, noise: float = 1.0, name: Optional[str] = None) -> None:
+    def __init__(self, camera_provider: CameraProvider[CalibratableCamera], *, noise: float = 1.0, name: Optional[str] = None) -> None:
         super().__init__(name=name)
 
         self.camera_provider = camera_provider
@@ -101,7 +102,7 @@ class DetectorSimulation(Detector):
                     for dy in [-obj.size[1] / 2, obj.size[1] / 2]
                     for dz in [-obj.size[2] / 2, obj.size[2] / 2]
                 ])
-                image_points = camera.calibration.project_array_to_image(world_points)
+                image_points = camera.calibration.project_to_image(world_points)
                 detections.boxes.append(BoxDetection(
                     category_name=obj.category_name,
                     model_name='simulation',

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -50,3 +50,10 @@ def test_array_projection():
         assert np.allclose(image_point.tuple, image_point_array[i])  # pylint: disable=unsubscriptable-object
     world_point_array_ = cam.calibration.project_from_image(image_point_array, target_height=1)
     assert np.allclose(world_point_array, world_point_array_, atol=1e-6)
+
+
+def test_project_from_behind():
+    cam = CalibratableCamera(id='1')
+    cam.set_perfect_calibration(z=1, roll=np.deg2rad(180 + 10))
+    assert cam.calibration.project_to_image(Point3d(x=0, y=1, z=1)) is not None
+    assert cam.calibration.project_to_image(Point3d(x=0, y=-1, z=1)) is None

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -22,6 +22,7 @@ def test_calibration_from_points():
     image_size = cam.calibration.intrinsics.size
 
     image_points = [cam.calibration.project_to_image(p) for p in world_points]
+    assert not any(p is None for p in image_points)
     focal_length = cam.calibration.intrinsics.matrix[0][0]
     calibration = Calibration.from_points(world_points, image_points, image_size, focal_length)
 
@@ -35,6 +36,7 @@ def test_projection():
     cam, world_points = demo_data()
     for world_point in world_points:
         image_point = cam.calibration.project_to_image(world_point)
+        assert image_point is not None
         world_point_ = cam.calibration.project_from_image(image_point, target_height=world_point.z)
         assert np.allclose(world_point.tuple, world_point_.tuple, atol=1e-6)
 

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -44,9 +44,9 @@ def test_array_projection():
     world_points = [p for p in world_points if p.z == 1]
 
     world_point_array = np.array([p.tuple for p in world_points])
-    image_point_array = cam.calibration.project_array_to_image(world_point_array)
+    image_point_array = cam.calibration.project_to_image(world_point_array)
     for i, world_point in enumerate(world_points):
         image_point = cam.calibration.project_to_image(world_point)
-        assert np.allclose(image_point.tuple, image_point_array[i])
-    world_point_array_ = cam.calibration.project_array_from_image(image_point_array, target_height=1)
+        assert np.allclose(image_point.tuple, image_point_array[i])  # pylint: disable=unsubscriptable-object
+    world_point_array_ = cam.calibration.project_from_image(image_point_array, target_height=1)
     assert np.allclose(world_point_array, world_point_array_, atol=1e-6)


### PR DESCRIPTION
This PR solves issue #72 by adding the behind-the-camera check from `project_from_image` to `project_to_image`.