### PR TITLE
Add base consumption attribute to BmsHardware

### DIFF
--- a/rosys/hardware/bms.py
+++ b/rosys/hardware/bms.py
@@ -53,11 +53,11 @@ class BmsHardware(Bms, ModuleHardware):
                  tx_pin: int = 27,
                  baud: int = 9600,
                  num: int = 1,
-                 base_consumption: float = -0.4
+                 charge_detect_threshold: float = -0.4,
                  ) -> None:
         self.name = name
         self.expander = expander
-        self.base_consumption = base_consumption
+        self.charge_detect_threshold = charge_detect_threshold
         lizard_code = remove_indentation(f'''
             {name} = {expander.name + "." if expander else ""}Serial({rx_pin}, {tx_pin}, {baud}, {num})
             {name}.unmute()
@@ -80,7 +80,7 @@ class BmsHardware(Bms, ModuleHardware):
         self.state.voltage = result.get('total voltage')
         self.state.current = result.get('current')
         self.state.temperature = np.mean(result['temperatures']) if 'temperatures' in result else None
-        self.state.is_charging = (self.state.current or 0) > self.base_consumption
+        self.state.is_charging = (self.state.current or 0) > self.charge_detect_threshold
         self.state.last_update = rosys.time()
         self.raw_data = result
 

--- a/rosys/hardware/bms.py
+++ b/rosys/hardware/bms.py
@@ -52,9 +52,12 @@ class BmsHardware(Bms, ModuleHardware):
                  rx_pin: int = 26,
                  tx_pin: int = 27,
                  baud: int = 9600,
-                 num: int = 1) -> None:
+                 num: int = 1,
+                 base_consumption: float = -0.4
+                 ) -> None:
         self.name = name
         self.expander = expander
+        self.base_consumption = base_consumption
         lizard_code = remove_indentation(f'''
             {name} = {expander.name + "." if expander else ""}Serial({rx_pin}, {tx_pin}, {baud}, {num})
             {name}.unmute()
@@ -77,7 +80,7 @@ class BmsHardware(Bms, ModuleHardware):
         self.state.voltage = result.get('total voltage')
         self.state.current = result.get('current')
         self.state.temperature = np.mean(result['temperatures']) if 'temperatures' in result else None
-        self.state.is_charging = (self.state.current or 0) > -0.4
+        self.state.is_charging = (self.state.current or 0) > self.base_consumption
         self.state.last_update = rosys.time()
         self.raw_data = result
 


### PR DESCRIPTION
This PR adds a `base_consumption` attribute to the `BmsHardware` class with a default value of -0.4. This enhancement refines the charging state determination by comparing the current consumption against the `base_consumption`, thereby improving the accuracy of monitoring the `is_charging` state.