### PR TITLE
Keyboard control timeouts

### DIFF
--- a/rosys/driving/keyboard_control_.py
+++ b/rosys/driving/keyboard_control_.py
@@ -15,13 +15,14 @@ class KeyboardControl:
     You can change the speed with the number keys 1 to 9 and the initial speed via the `default_speed` argument.
     """
 
-    def __init__(self, steerer: Steerer, *, default_speed: float = 2.0) -> None:
+    def __init__(self, steerer: Steerer, *, default_speed: float = 2.0, connection_timeout: float = 0.5, check_connection_interval: float = 0.5) -> None:
         self.steerer = steerer
         self.log = logging.getLogger('rosys.ui.keyboard_control')
         ui.keyboard(on_key=self.handle_keys, repeating=False)
         self.direction = Point(x=0, y=0)
         self.speed = default_speed
-        ui.timer(0.5, self._check_connection)
+        self.connection_timeout = connection_timeout
+        ui.timer(check_connection_interval, self._check_connection)
 
     def handle_keys(self, e: KeyEventArguments) -> None:
         self.log.debug(f'{e.key.name} -> {e.action} {e.modifiers}')
@@ -62,7 +63,7 @@ class KeyboardControl:
         if self.steerer.state != State.STEERING:
             return
         try:
-            await ui.run_javascript('Date()', timeout=0.5)
+            await ui.run_javascript('Date()', timeout=self.connection_timeout)
         except TimeoutError:
             self.log.warning('lost connection to browser')
             self.steerer.stop()

--- a/rosys/driving/keyboard_control_.py
+++ b/rosys/driving/keyboard_control_.py
@@ -5,6 +5,7 @@ import numpy as np
 from nicegui import ui
 from nicegui.events import KeyEventArguments
 
+from ..event import Event
 from ..geometry import Point
 from .steerer import State, Steerer
 
@@ -16,7 +17,14 @@ class KeyboardControl:
     You can change the speed with the number keys 1 to 9 and the initial speed via the `default_speed` argument.
     """
 
-    def __init__(self, steerer: Steerer, *, default_speed: float = 2.0, connection_timeout: float = 1.0, check_connection_interval: float = 1.0) -> None:
+    def __init__(self,
+                 steerer: Steerer, *,
+                 default_speed: float = 2.0,
+                 connection_timeout: float = 1.0,
+                 check_connection_interval: float = 1.0) -> None:
+        self.CONNECTION_INTERRUPTED = Event()
+        """the keyboard control has lost connection to the browser."""
+
         self.steerer = steerer
         self.log = logging.getLogger('rosys.ui.keyboard_control')
         ui.keyboard(on_key=self.handle_keys, repeating=False)
@@ -70,4 +78,5 @@ class KeyboardControl:
         except TimeoutError:
             print('took:', time.time() - t)
             self.log.warning('lost connection to browser')
+            self.CONNECTION_INTERRUPTED.emit()
             self.steerer.stop()

--- a/rosys/driving/keyboard_control_.py
+++ b/rosys/driving/keyboard_control_.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 import numpy as np
 from nicegui import ui
@@ -72,11 +71,8 @@ class KeyboardControl:
         if self.steerer.state != State.STEERING:
             return
         try:
-            t = time.time()
             await ui.run_javascript('Date()', timeout=self.connection_timeout)
-            print('took:', time.time() - t)
         except TimeoutError:
-            print('took:', time.time() - t)
             self.log.warning('lost connection to browser')
             self.CONNECTION_INTERRUPTED.emit()
             self.steerer.stop()

--- a/rosys/driving/keyboard_control_.py
+++ b/rosys/driving/keyboard_control_.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 import numpy as np
 from nicegui import ui
@@ -15,7 +16,7 @@ class KeyboardControl:
     You can change the speed with the number keys 1 to 9 and the initial speed via the `default_speed` argument.
     """
 
-    def __init__(self, steerer: Steerer, *, default_speed: float = 2.0, connection_timeout: float = 0.5, check_connection_interval: float = 0.5) -> None:
+    def __init__(self, steerer: Steerer, *, default_speed: float = 2.0, connection_timeout: float = 1.0, check_connection_interval: float = 1.0) -> None:
         self.steerer = steerer
         self.log = logging.getLogger('rosys.ui.keyboard_control')
         ui.keyboard(on_key=self.handle_keys, repeating=False)
@@ -63,7 +64,10 @@ class KeyboardControl:
         if self.steerer.state != State.STEERING:
             return
         try:
+            t = time.time()
             await ui.run_javascript('Date()', timeout=self.connection_timeout)
+            print('took:', time.time() - t)
         except TimeoutError:
+            print('took:', time.time() - t)
             self.log.warning('lost connection to browser')
             self.steerer.stop()


### PR DESCRIPTION
Parameterize the connection checking behavior of the keyboard control:
* add `connection_timeout` to specify the amount of time the health response is allowed to take
* add `check_connection_interval` to specify the interval the keyboard control performs this a connection test
* defaults are set to 1.0s (0.5s has proven to be too short in practice)
* add event `CONNECTION_INTERRUPTED` that is emitted when a connection test encounters a TimeoutError