### PR TITLE
Mjpeg multiple cameras

### DIFF
--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Self, overload
+from typing import Any, Optional, Self
 
 from ... import rosys
 from ..camera import TransformableCamera
@@ -50,16 +50,7 @@ class MjpegCamera(TransformableCamera):
     def is_connected(self) -> bool:
         return self.device is not None and self.device.capture_task is not None
 
-    @overload
-    async def connect(self) -> None:
-        ...
-
-    @overload
-    async def connect(self, ip: str):
-        ...
-
-    async def connect(self, ip: Optional[str] = None):
-
+    async def connect(self, ip: Optional[str] = None) -> None:
         if self.is_connected:
             return
 

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -33,8 +33,6 @@ class MjpegCamera(TransformableCamera):
         if len(parts) == 2 and parts[1].isdigit():
             self.index = int(parts[1])
 
-        print(f'ID: {self.id}')
-
         self.mac = parts[0]
         self.device: Optional[MjpegDevice] = None
 

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Self
+from typing import Any, Optional, Self, overload
 
 from ... import rosys
 from ..camera import TransformableCamera
@@ -50,11 +50,21 @@ class MjpegCamera(TransformableCamera):
     def is_connected(self) -> bool:
         return self.device is not None and self.device.capture_task is not None
 
+    @overload
     async def connect(self) -> None:
+        ...
+
+    @overload
+    async def connect(self, ip: str):
+        ...
+
+    async def connect(self, ip: Optional[str] = None):
+
         if self.is_connected:
             return
 
-        ip = await find_ip(self.mac)
+        if not ip:
+            ip = await find_ip(self.mac)
         if ip is None:
             return
 

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -27,6 +27,15 @@ class MjpegCamera(TransformableCamera):
                          image_grab_interval=image_grab_interval, base_path_overwrite=base_path_overwrite, **kwargs)
         self.username = username
         self.password = password
+
+        self.index: Optional[int] = None
+        parts = self.id.split('-')
+        if len(parts) == 2 and parts[1].isdigit():
+            self.index = int(parts[1])
+
+        print(f'ID: {self.id}')
+
+        self.mac = parts[0]
         self.device: Optional[MjpegDevice] = None
 
     def to_dict(self) -> dict:
@@ -47,11 +56,11 @@ class MjpegCamera(TransformableCamera):
         if self.is_connected:
             return
 
-        ip = await find_ip(self.id)
+        ip = await find_ip(self.mac)
         if ip is None:
             return
 
-        self.device = MjpegDevice(self.id, ip, username=self.username, password=self.password)
+        self.device = MjpegDevice(self.mac, ip, index=self.index, username=self.username, password=self.password)
 
     async def disconnect(self) -> None:
         if self.device is None:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
@@ -34,25 +34,27 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera], persistence.PersistentMod
     async def scan_for_cameras(self) -> list[tuple[str, str]]:
         ids_ips: list[tuple[str, str]] = []
         async for mac, ip in find_cameras():
-            if mac_to_vendor(mac) == VendorType.AXIS:
-                authentication = None if self.username is None or self.password is None else httpx.DigestAuth(
-                    self.username, self.password)
-                url = f'http://{ip}/axis-cgi/videostatus.cgi'
-                try:
-                    async with httpx.AsyncClient() as client:
-                        response = await client.get(url, auth=authentication)
-                except httpx.HTTPError as e:
-                    self.log.warning(f'Error while looking for cameras at axis router ({url}): {e}')
-                    continue
+            if mac_to_vendor(mac) != VendorType.AXIS:
+                continue
 
-                if response.status_code == 200:
-                    camera_infos = response.text.split('\n')
-                    for info_line in camera_infos:
-                        if 'video' in info_line:
-                            video_name, status = info_line.split(' = ')
-                            if status == 'video':
-                                i = int(video_name.split(' ')[1])
-                                ids_ips.append((f'{mac}-{i}', ip))
+            authentication = None if self.username is None or self.password is None else \
+                httpx.DigestAuth(self.username, self.password)
+            url = f'http://{ip}/axis-cgi/videostatus.cgi'
+            try:
+                async with httpx.AsyncClient() as client:
+                    response = await client.get(url, auth=authentication)
+            except httpx.HTTPError as e:
+                self.log.warning(f'Error while looking for cameras at axis router ({url}): {e}')
+                continue
+            if response.status_code != 200:
+                continue
+
+            camera_infos = response.text.split('\n')
+            for info_line in camera_infos:
+                if info_line.endswith(' = video'):
+                    video_name = info_line.removesuffix(' = video')
+                    index = video_name.split(' ')[1]
+                    ids_ips.append((f'{mac}-{index}', ip))
         return ids_ips
 
     async def update_device_list(self) -> None:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
@@ -44,8 +44,11 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera], persistence.PersistentMod
                     camera_infos = response.text.split('\n')
                     for info_line in camera_infos:
                         if 'video' in info_line:
-                            i = int(info_line.split(' ')[1])
-                            ids_ips.append((f'{mac}-{i}', ip))
+                            video_name, status = info_line.split(' = ')
+                            print(status)
+                            if status == 'video':
+                                i = int(video_name.split(' ')[1])
+                                ids_ips.append((f'{mac}-{i}', ip))
         return ids_ips
 
     async def update_device_list(self) -> None:
@@ -59,6 +62,7 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera], persistence.PersistentMod
             camera = self._cameras[camera_id]
             if not camera.is_connected:
                 self.log.info(f'activating authorized camera {camera.id}...')
+                print(f'connecting to {camera.id} at {ip}')
                 await camera.connect(ip=ip)
 
         for mac in newly_disconnected_cameras:

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -4,7 +4,6 @@ from asyncio.subprocess import Process
 from io import BytesIO
 from typing import AsyncGenerator, Optional
 
-import httpcore
 import httpx
 from nicegui import background_tasks
 

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -13,7 +13,7 @@ from .vendors import mac_to_url
 
 class MjpegDevice:
 
-    def __init__(self, mac: str, ip: str, username: Optional[str] = None, password: Optional[str] = None) -> None:
+    def __init__(self, mac: str, ip: str, *, index: Optional[int] = None, username: Optional[str] = None, password: Optional[str] = None) -> None:
         self.mac = mac
         self.ip = ip
         self.capture_task: Optional[Task] = None
@@ -22,7 +22,8 @@ class MjpegDevice:
         self._authorized: bool = True
         self.authentication = None if username is None or password is None else httpx.DigestAuth(username, password)
         self.log = logging.getLogger('rosys.mjpeg_device ' + self.mac)
-        url = mac_to_url(mac, ip)
+        url = mac_to_url(mac, ip, index=index)
+        print(f'URL: {url}')
         if url is None:
             raise ValueError(f'could not determine URL for {mac}')
         self.url = url

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -23,7 +23,6 @@ class MjpegDevice:
         self.authentication = None if username is None or password is None else httpx.DigestAuth(username, password)
         self.log = logging.getLogger('rosys.mjpeg_device ' + self.mac)
         url = mac_to_url(mac, ip, index=index)
-        print(f'URL: {url}')
         if url is None:
             raise ValueError(f'could not determine URL for {mac}')
         self.url = url

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -13,7 +13,8 @@ from .vendors import mac_to_url
 
 class MjpegDevice:
 
-    def __init__(self, mac: str, ip: str, *, index: Optional[int] = None, username: Optional[str] = None, password: Optional[str] = None) -> None:
+    def __init__(self, mac: str, ip: str, *,
+                 index: Optional[int] = None, username: Optional[str] = None, password: Optional[str] = None) -> None:
         self.mac = mac
         self.ip = ip
         self.capture_task: Optional[Task] = None
@@ -75,10 +76,8 @@ class MjpegDevice:
                                         header = None
                         except httpx.ReadTimeout:
                             self.log.warning(f'Connection to {self.url} timed out')
-                            return
                 except Exception:
                     self.log.warning(f'Initial connection to {self.url} failed. Was something disconnected?')
-                    return
 
         async for image in stream():
             self._image_buffer = image

--- a/rosys/vision/mjpeg_camera/vendors.py
+++ b/rosys/vision/mjpeg_camera/vendors.py
@@ -12,8 +12,8 @@ def mac_to_vendor(mac: str) -> int:
     return VendorType.OTHER
 
 
-def mac_to_url(mac: str, ip: str) -> Optional[str]:
+def mac_to_url(mac: str, ip: str, index: Optional[int]) -> Optional[str]:
     vendor = mac_to_vendor(mac)
     if vendor == VendorType.AXIS:
-        return f'http://{ip}/axis-cgi/mjpg/video.cgi'
+        return f'http://{ip}/axis-cgi/mjpg/video.cgi' + (f'?camera={index}' if index is not None else '')
     return None

--- a/rosys/vision/mjpeg_camera/vendors.py
+++ b/rosys/vision/mjpeg_camera/vendors.py
@@ -12,7 +12,7 @@ def mac_to_vendor(mac: str) -> int:
     return VendorType.OTHER
 
 
-def mac_to_url(mac: str, ip: str, index: Optional[int]) -> Optional[str]:
+def mac_to_url(mac: str, ip: str, *, index: Optional[int] = None) -> Optional[str]:
     vendor = mac_to_vendor(mac)
     if vendor == VendorType.AXIS:
         return f'http://{ip}/axis-cgi/mjpg/video.cgi' + (f'?camera={index}' if index is not None else '')


### PR DESCRIPTION
Adds support for multiple cameras connected through a single ip.
In particular, ids now have an index after the mac.
For axis devices (the only ones supported right now), we ask for the the video status at 'axis-cgi/videostatus.cgi' during camera discovery and create cameras based on that rather then a single one.

The option to supply an ip to Camera.connect is also added to avoid triggering a slow arp-scan for the same ip multiple times.