### PR TITLE
Rtsp camera ip connect

### DIFF
--- a/rosys/vision/rtsp_camera/arp_scan.py
+++ b/rosys/vision/rtsp_camera/arp_scan.py
@@ -37,9 +37,9 @@ async def find_cameras() -> AsyncIterator[tuple[str, str]]:
         yield mac, ip
 
 
-async def find_known_cameras() -> list[str]:
+async def find_known_cameras() -> list[tuple[str, str]]:
     """Find all cameras of known vendors and return MAC addresses."""
-    return [mac async for mac, _ in find_cameras() if mac_to_vendor(mac) != VendorType.OTHER]
+    return [(mac, ip) async for mac, ip in find_cameras() if mac_to_vendor(mac) != VendorType.OTHER]
 
 
 async def find_ip(mac: str) -> Optional[str]:

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -59,11 +59,12 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
         return self.device.url
 
-    async def connect(self) -> None:
+    async def connect(self, ip: Optional[str] = None) -> None:
         if self.is_connected:
             return
 
-        ip = await find_ip(self.id)
+        if not ip:
+            ip = await find_ip(self.id)
         if ip is None:
             raise RuntimeError(f'could not find IP address for {self.id}')
 

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -40,7 +40,7 @@ class RtspCameraProvider(CameraProvider[RtspCamera], persistence.PersistentModul
 
     @staticmethod
     async def scan_for_cameras() -> list[str]:
-        return [mac for mac, ip in await find_known_cameras()]
+        return [mac for mac, _ in await find_known_cameras()]
 
     async def update_device_list(self) -> None:
         if self.last_scan is not None and rosys.time() < self.last_scan + SCAN_INTERVAL:

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -15,7 +15,6 @@ from .vendors import VendorType, mac_to_url, mac_to_vendor
 class RtspDevice:
 
     def __init__(self, mac: str, ip: str, jovision_profile: int) -> None:
-
         self.log = logging.getLogger('rosys.vision.rtsp_camera.rtsp_device')
 
         self.mac = mac

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -15,6 +15,9 @@ from .vendors import VendorType, mac_to_url, mac_to_vendor
 class RtspDevice:
 
     def __init__(self, mac: str, ip: str, jovision_profile: int) -> None:
+
+        self.log = logging.getLogger('rosys.vision.rtsp_camera.rtsp_device')
+
         self.mac = mac
 
         self.capture_task: Optional[asyncio.Task] = None
@@ -29,15 +32,15 @@ class RtspDevice:
             self.settings_interface = JovisionInterface(ip)
             self.fps = self.settings_interface.get_fps(stream_id=jovision_profile)
         else:
-            logging.warning(f'no settings interface for vendor type {vendor_type}')
-            logging.warning('using default fps of 10')
+            self.log.warning('[%s] No settings interface for vendor type %s', self.mac, vendor_type)
+            self.log.warning('[%s] Using default fps of 10', self.mac)
             self.fps = 10
 
         url = mac_to_url(mac, ip, jovision_profile)
         if url is None:
             raise ValueError(f'could not determine RTSP URL for {mac}')
         self.url = url
-        logging.info(f'Starting VideoStream for {self.url}')
+        self.log.info('[%s] Starting VideoStream for %s', self.mac, self.url)
         self.start_gstreamer_task()
 
     @property
@@ -122,5 +125,7 @@ class RtspDevice:
 
         async for image in stream(url):
             self._image_buffer = image
+
+        self.log.info('[%s] stream ended', self.mac)
 
         self.capture_task = None


### PR DESCRIPTION
This pull request adds and uses an optional ip parameter to the RtspCamera.
It mirrors the same functionality in the MjpegCamera and respective Provider.
Essentially, this uses the ip from the scan that is done anyway which saves one arp-scan per camera that is connected.