### PR TITLE
Add Motec as a mjpeg-vendor and refactor camera providers

### DIFF
--- a/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
@@ -62,20 +62,14 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera], persistence.PersistentMod
         return ids_ips
 
     async def update_device_list(self) -> None:
-        newly_disconnected_cameras = {id for id, camera in self._cameras.items() if camera.is_connected}
         for camera_id, ip in await self.scan_for_cameras():
             if camera_id not in self._cameras:
                 self.add_camera(MjpegCamera(id=camera_id, username=self.username,
                                 password=self.password, connect_after_init=False))
-            if camera_id in newly_disconnected_cameras:
-                newly_disconnected_cameras.remove(camera_id)
             camera = self._cameras[camera_id]
             if not camera.is_connected:
                 self.log.info('activating authorized camera "%s" at ip "%s" ...', camera.id, ip)
                 await camera.connect(ip=ip)
-
-        for mac in newly_disconnected_cameras:
-            await self._cameras[mac].disconnect()
 
     async def shutdown(self) -> None:
         for camera in self._cameras.values():

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -84,4 +84,4 @@ class MjpegDevice:
     def shutdown(self) -> None:
         if self.capture_task is not None:
             self.capture_task.cancel()
-        self.capture_task = None
+            self.capture_task = None

--- a/rosys/vision/mjpeg_camera/vendors.py
+++ b/rosys/vision/mjpeg_camera/vendors.py
@@ -4,12 +4,15 @@ from typing import Optional
 
 class VendorType(IntEnum):
     AXIS = 1
+    MOTEC = 2
     OTHER = -1
 
 
 def mac_to_vendor(mac: str) -> VendorType:
     if any(mac.startswith(prefix) for prefix in ['00:40:8c', 'ac:cc:8e', 'b8:a4:4f', 'e8:27:25']):
         return VendorType.AXIS
+    if mac.startswith('2c:26:5f'):
+        return VendorType.MOTEC
     return VendorType.OTHER
 
 
@@ -17,4 +20,6 @@ def mac_to_url(mac: str, ip: str, *, index: Optional[int] = None) -> Optional[st
     vendor = mac_to_vendor(mac)
     if vendor == VendorType.AXIS:
         return f'http://{ip}/axis-cgi/mjpg/video.cgi' + (f'?camera={index}' if index is not None else '')
+    if vendor == VendorType.MOTEC:
+        return f'http://{ip}:1001/stream.mjpg'
     return None

--- a/rosys/vision/mjpeg_camera/vendors.py
+++ b/rosys/vision/mjpeg_camera/vendors.py
@@ -1,12 +1,13 @@
+from enum import IntEnum
 from typing import Optional
 
 
-class VendorType:
+class VendorType(IntEnum):
     AXIS = 1
     OTHER = -1
 
 
-def mac_to_vendor(mac: str) -> int:
+def mac_to_vendor(mac: str) -> VendorType:
     if any(mac.startswith(prefix) for prefix in ['00:40:8c', 'ac:cc:8e', 'b8:a4:4f', 'e8:27:25']):
         return VendorType.AXIS
     return VendorType.OTHER

--- a/rosys/vision/mjpeg_camera/vendors.py
+++ b/rosys/vision/mjpeg_camera/vendors.py
@@ -1,8 +1,8 @@
-from enum import IntEnum
+from enum import Enum
 from typing import Optional
 
 
-class VendorType(IntEnum):
+class VendorType(Enum):
     AXIS = 1
     MOTEC = 2
     OTHER = -1

--- a/rosys/vision/rtsp_camera/arp_scan.py
+++ b/rosys/vision/rtsp_camera/arp_scan.py
@@ -34,7 +34,7 @@ async def find_cameras() -> AsyncIterator[tuple[str, str]]:
             continue
         mac = infos[1]
         ip = infos[0]
-        if mac in ['packets', 'arp-scan'] or ip == "Interface:":
+        if mac in ['packets', 'arp-scan'] or ip == 'Interface:':
             continue
         yield mac, ip
 

--- a/rosys/vision/rtsp_camera/arp_scan.py
+++ b/rosys/vision/rtsp_camera/arp_scan.py
@@ -34,6 +34,8 @@ async def find_cameras() -> AsyncIterator[tuple[str, str]]:
             continue
         mac = infos[1]
         ip = infos[0]
+        if mac in ['packets', 'arp-scan'] or ip == "Interface:":
+            continue
         yield mac, ip
 
 

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -43,9 +43,6 @@ class RtspCameraProvider(CameraProvider[RtspCamera], persistence.PersistentModul
         return [mac for mac, _ in await find_known_cameras()]
 
     async def update_device_list(self) -> None:
-        if self.last_scan is not None and rosys.time() < self.last_scan + SCAN_INTERVAL:
-            return
-        self.last_scan = rosys.time()
         for mac, ip in await find_known_cameras():
             if mac not in self._cameras:
                 self.add_camera(RtspCamera(id=mac, fps=self.frame_rate, jovision_profile=self.jovision_profile))

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -1,12 +1,9 @@
 import logging
-from typing import Optional
 
 from ... import persistence, rosys
 from ..camera_provider import CameraProvider
 from .arp_scan import find_known_cameras
 from .rtsp_camera import RtspCamera
-
-SCAN_INTERVAL = 10
 
 
 class RtspCameraProvider(CameraProvider[RtspCamera], persistence.PersistentModule):
@@ -19,8 +16,6 @@ class RtspCameraProvider(CameraProvider[RtspCamera], persistence.PersistentModul
         self.jovision_profile = jovision_profile
 
         self.log = logging.getLogger('rosys.rtsp_camera_provider')
-
-        self.last_scan: Optional[float] = None
 
         rosys.on_shutdown(self.shutdown)
         rosys.on_repeat(self.update_device_list, 10.)

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -46,19 +46,13 @@ class RtspCameraProvider(CameraProvider[RtspCamera], persistence.PersistentModul
         if self.last_scan is not None and rosys.time() < self.last_scan + SCAN_INTERVAL:
             return
         self.last_scan = rosys.time()
-        newly_disconnected_cameras = {id for id, camera in self._cameras.items() if camera.is_connected}
         for mac, ip in await find_known_cameras():
             if mac not in self._cameras:
                 self.add_camera(RtspCamera(id=mac, fps=self.frame_rate, jovision_profile=self.jovision_profile))
-            if mac in newly_disconnected_cameras:
-                newly_disconnected_cameras.remove(mac)
             camera = self._cameras[mac]
             if not camera.is_connected:
                 self.log.info('activating authorized camera %s...', camera.id)
                 await camera.connect(ip)
-
-        for mac in newly_disconnected_cameras:
-            await self._cameras[mac].disconnect()
 
     async def shutdown(self) -> None:
         for camera in self._cameras.values():

--- a/rosys/vision/rtsp_camera/vendors.py
+++ b/rosys/vision/rtsp_camera/vendors.py
@@ -1,8 +1,8 @@
-from enum import IntEnum
+from enum import Enum
 from typing import Optional
 
 
-class VendorType(IntEnum):
+class VendorType(Enum):
     JOVISION = 1
     DAHUA = 2
     AXIS = 3

--- a/rosys/vision/rtsp_camera/vendors.py
+++ b/rosys/vision/rtsp_camera/vendors.py
@@ -1,14 +1,15 @@
+from enum import IntEnum
 from typing import Optional
 
 
-class VendorType:
+class VendorType(IntEnum):
     JOVISION = 1
     DAHUA = 2
     AXIS = 3
     OTHER = -1
 
 
-def mac_to_vendor(mac: str) -> int:
+def mac_to_vendor(mac: str) -> VendorType:
     if mac.startswith('e0:62:90'):
         return VendorType.JOVISION
     if mac.startswith('e4:24:6c') or mac.startswith('3c:e3:6b'):


### PR DESCRIPTION
This PR adds support for mjpeg-based [Motec ip cameras](https://www.motec-cameras.com/)

The changes are:
- add Motec as a mjpeg vendor
- change VendorType to ~~IntEnum~~ Enum for both mjpeg and rtsp
- remove check that disconnects cameras which are not in the arp-scan but are still connected
- clean up find_cameras return values
- refactor mjpeg_device.py

~~IntEnum can be changed to Enum, but may lead to errors in other projects~~