### PR TITLE
Log problematic content if backup fails

### DIFF
--- a/rosys/persistence/registry.py
+++ b/rosys/persistence/registry.py
@@ -39,7 +39,10 @@ def backup(force: bool = False) -> None:
         if not backup_path.exists():
             backup_path.mkdir(parents=True)
         filepath = backup_path / f'{name}.json'
-        filepath.write_text(json.dumps(module.backup(), indent=4, cls=Encoder))
+        try:
+            filepath.write_text(json.dumps(module.backup(), indent=4, cls=Encoder))
+        except Exception:
+            log.exception('failed to backup %s: %s', module, str(module.backup()))
         module.needs_backup = False
 
 


### PR DESCRIPTION
If somehow the content of a backup is not serializable the error message was quite cryptic:

```
rosys_1       | 2024-05-02 07:21:44.142 [ERROR] nicegui/app/app.py:118: Object of type Decimal is not JSON serializable
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/nicegui/background_tasks.py", line 52, in _handle_task_result
rosys_1       |     task.result()
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/nicegui/client.py", line 290, in result_with_client
rosys_1       |     await result
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/rosys.py", line 225, in shutdown
rosys_1       |     await persistence.backup(force=True)
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/run.py", line 43, in inner
rosys_1       |     return await io_bound(func, *args, **kwargs)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/run.py", line 31, in io_bound
rosys_1       |     return await loop.run_in_executor(thread_pool, partial(callback, *args, **kwargs))
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
rosys_1       |     result = self.fn(*self.args, **self.kwargs)
rosys_1       |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 42, in backup
rosys_1       |     filepath.write_text(json.dumps(module.backup(), indent=4, cls=Encoder))
rosys_1       |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/json/__init__.py", line 238, in dumps
rosys_1       |     **kw).encode(obj)
rosys_1       |           ^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 202, in encode
rosys_1       |     chunks = list(chunks)
rosys_1       |              ^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 432, in _iterencode
rosys_1       |     yield from _iterencode_dict(o, _current_indent_level)
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict
rosys_1       |     yield from chunks
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 406, in _iterencode_dict
rosys_1       |     yield from chunks
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 439, in _iterencode
rosys_1       |     o = _default(o)
rosys_1       |         ^^^^^^^^^^^
rosys_1       |   File "/home/zauberzeug/.local/lib/python3.11/site-packages/rosys/persistence/registry.py", line 31, in default
rosys_1       |     return json.JSONEncoder.default(self, o)
rosys_1       |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1       |   File "/usr/local/lib/python3.11/json/encoder.py", line 180, in default
rosys_1       |     raise TypeError(f'Object of type {o.__class__.__name__} '
rosys_1       | TypeError: Object of type Decimal is not JSON serializable
```

To find the problematic module and the attribute which is not serializable, this pull request now logs it to the console:

```
rosys_1       | 2024-05-02 07:22:58.310 [ERROR] rosys/persistence/registry.py:45: failed to backup <field_friend.navigation.gnss.GnssHardware object at 0xffff729b2c50>: {'record': {'timestamp': 1714627373.2, 'latitude': 51.958309238333335, 'longitude': 7.470849475, 'mode': 'AAAA', 'gps_qual': 1, 'altitude': 69.1095, 'separation': '47.2520', 'heading': Decimal('79.773'), 'speed_kmh': 0.0}}
```