### PR TITLE
Handle None value from io_bound capture.read in usb_camera.py

### DIFF
--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -85,8 +85,10 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
             return None
 
         assert self.device is not None
-
-        capture_success, captured_image = await rosys.run.io_bound(self.device.capture.read)
+        result = await rosys.run.io_bound(self.device.capture.read)
+        if result is None:  # NOTE this can happen when shutting down and the thread is aborted before opencv has returned
+            return
+        capture_success, captured_image = result
         image_is_MJPG = 'MJPG' in self.device.video_formats
 
         if not capture_success:


### PR DESCRIPTION
This PR fixes a ugly error which can happen on shutdown.