### PR TITLE
Emitting events should call non-async functions synchronously

### DIFF
--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -19,19 +19,13 @@ class Automator:
     (e.g. via an "Play"-button like offered by the [automation controls](https://rosys.io/reference/rosys/automation/#rosys.automation.automation_controls)). 
     The passed function should return a new coroutine on every call (see [Play-pause-stop](https://rosys.io/examples/play-pause-stop/) example).
 
-    _on_interrupt_: Optional callback that will be called when an automation pauses or stops.
+    _on_interrupt_: Optional callback that will be called when an automation pauses or stops (the cause is provided as string parameter).
     """
 
     def __init__(self,
                  steerer: Optional[Steerer], *,
                  default_automation: Optional[Callable] = None,
                  on_interrupt: Optional[Callable] = None) -> None:
-        """Initializes the automator.
-
-        :param steerer: If provided, manually steering the robot will pause a currently running automation.
-        :param default_automation: If provided, the automator will start this automation when start() is called without parameter.
-        :param on_interrupt: Optional callback that will be called when an automation pauses or stops (the cause is provided as string parameter).
-        """
         self.AUTOMATION_STARTED = Event()
         """an automation has been started"""
 

--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -55,8 +55,8 @@ class Automator:
             steerer.STEERING_STARTED.register(lambda: self.pause(because='steering started'))
 
         if on_interrupt:
-            self.AUTOMATION_PAUSED.register(lambda _: cast(Callable, on_interrupt)())
-            self.AUTOMATION_STOPPED.register(lambda _: cast(Callable, on_interrupt)())
+            self.AUTOMATION_PAUSED.register(on_interrupt)
+            self.AUTOMATION_STOPPED.register(on_interrupt)
 
         rosys.on_shutdown(lambda: self.stop(because='automator is shutting down'))
 

--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -26,6 +26,12 @@ class Automator:
                  steerer: Optional[Steerer], *,
                  default_automation: Optional[Callable] = None,
                  on_interrupt: Optional[Callable] = None) -> None:
+        """Initializes the automator.
+
+        :param steerer: If provided, manually steering the robot will pause a currently running automation.
+        :param default_automation: If provided, the automator will start this automation when start() is called without parameter.
+        :param on_interrupt: Optional callback that will be called when an automation pauses or stops (the cause is provided as string parameter).
+        """
         self.AUTOMATION_STARTED = Event()
         """an automation has been started"""
 
@@ -55,8 +61,8 @@ class Automator:
             steerer.STEERING_STARTED.register(lambda: self.pause(because='steering started'))
 
         if on_interrupt:
-            self.AUTOMATION_PAUSED.register(lambda _: rosys.background_tasks.create(cast(Callable, on_interrupt)()))
-            self.AUTOMATION_STOPPED.register(lambda _: rosys.background_tasks.create(cast(Callable, on_interrupt)()))
+            self.AUTOMATION_PAUSED.register(on_interrupt)
+            self.AUTOMATION_STOPPED.register(on_interrupt)
 
         rosys.on_shutdown(lambda: self.stop(because='automator is shutting down'))
 

--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -61,8 +61,8 @@ class Automator:
             steerer.STEERING_STARTED.register(lambda: self.pause(because='steering started'))
 
         if on_interrupt:
-            self.AUTOMATION_PAUSED.register(on_interrupt)
-            self.AUTOMATION_STOPPED.register(on_interrupt)
+            self.AUTOMATION_PAUSED.register(lambda _: cast(Callable, on_interrupt)())
+            self.AUTOMATION_STOPPED.register(lambda _: cast(Callable, on_interrupt)())
 
         rosys.on_shutdown(lambda: self.stop(because='automator is shutting down'))
 

--- a/rosys/event.py
+++ b/rosys/event.py
@@ -70,7 +70,7 @@ class Event:
         """Fires event without waiting for the result."""
         for listener in self.listeners:
             try:
-                result = invoke(listener.callback, *args)
+                result = listener.callback(*args)
                 if isinstance(result, Awaitable):
                     if core.loop and core.loop.is_running():
                         name = f'{listener.filepath}:{listener.line}'

--- a/rosys/testing/fixtures.py
+++ b/rosys/testing/fixtures.py
@@ -51,7 +51,7 @@ async def driver(wheels: Wheels, odometer: Odometer, integration: None) -> Drive
 
 @pytest.fixture
 async def automator(wheels: Wheels, integration: None) -> Automator:
-    helpers.automator = Automator(None, on_interrupt=wheels.stop)
+    helpers.automator = Automator(None, on_interrupt=lambda _: wheels.stop())
     return helpers.automator
 
 


### PR DESCRIPTION
This pull request ensures that non-async functions are called immediately. The usage of `invoke` was wrong because it's an async function itself and hence will always be awaitable.