### PR TITLE
More static cameras

### DIFF
--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -28,7 +28,7 @@ class MjpegCamera(TransformableCamera):
                  ) -> None:
         super().__init__(id=id, name=name, connect_after_init=connect_after_init, streaming=streaming,
                          image_grab_interval=image_grab_interval, base_path_overwrite=base_path_overwrite, **kwargs)
-        self.logger = logging.getLogger(f'rosys.vision.mjpeg_camera.{self.id}')
+        self.log = logging.getLogger(f'rosys.vision.mjpeg_camera.{self.id}')
         self.username = username
         self.password = password
 
@@ -62,7 +62,7 @@ class MjpegCamera(TransformableCamera):
             return
 
         if not self.ip:
-            self.logger.error('No IP address provided')
+            self.log.error('No IP address provided')
             return
 
         self.device = MjpegDevice(self.mac, self.ip, index=self.index, username=self.username, password=self.password)

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Optional
 
 from typing_extensions import Self
@@ -7,7 +8,6 @@ from ..camera import TransformableCamera
 from ..image import Image
 from ..image_processing import get_image_size_from_bytes, process_jpeg_image
 from ..image_rotation import ImageRotation
-from ..rtsp_camera.arp_scan import find_ip
 from .mjpeg_device import MjpegDevice
 
 
@@ -23,12 +23,16 @@ class MjpegCamera(TransformableCamera):
                  base_path_overwrite: str | None = None,
                  username: str | None = None,
                  password: str | None = None,
+                 ip: str | None = None,
                  **kwargs: Any,
                  ) -> None:
         super().__init__(id=id, name=name, connect_after_init=connect_after_init, streaming=streaming,
                          image_grab_interval=image_grab_interval, base_path_overwrite=base_path_overwrite, **kwargs)
+        self.logger = logging.getLogger(f'rosys.vision.mjpeg_camera.{self.id}')
         self.username = username
         self.password = password
+
+        self.ip = ip
 
         self.index: Optional[int] = None
         parts = self.id.split('-')
@@ -42,6 +46,7 @@ class MjpegCamera(TransformableCamera):
         return super().to_dict() | {
             'username': self.username,
             'password': self.password,
+            'ip': self.ip,
         }
 
     @classmethod
@@ -52,16 +57,15 @@ class MjpegCamera(TransformableCamera):
     def is_connected(self) -> bool:
         return self.device is not None and self.device.capture_task is not None
 
-    async def connect(self, ip: Optional[str] = None) -> None:
+    async def connect(self) -> None:
         if self.is_connected:
             return
 
-        if not ip:
-            ip = await find_ip(self.mac)
-        if ip is None:
+        if not self.ip:
+            self.logger.error('No IP address provided')
             return
 
-        self.device = MjpegDevice(self.mac, ip, index=self.index, username=self.username, password=self.password)
+        self.device = MjpegDevice(self.mac, self.ip, index=self.index, username=self.username, password=self.password)
 
     async def disconnect(self) -> None:
         if self.device is None:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
@@ -13,6 +13,12 @@ from .vendors import VendorType, mac_to_vendor
 class MjpegCameraProvider(CameraProvider[MjpegCamera], persistence.PersistentModule):
 
     def __init__(self, username: Optional[str] = None, password: Optional[str] = None, network_interface: Optional[str] = None) -> None:
+        '''CameraProvider for MJpegCamera
+
+        :param username: username to assgin for new cameras
+        :param password: password to assign for new cameras
+        :param network_interface: network interface used to scan for cameras
+        '''
         super().__init__()
 
         self.username = username
@@ -25,8 +31,6 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera], persistence.PersistentMod
 
     def restore(self, data: dict[str, dict]) -> None:
         for camera_data in data.get('cameras', {}).values():
-            camera_data['password'] = self.password
-            camera_data['username'] = self.username
             camera = MjpegCamera.from_dict(camera_data)
             self.add_camera(camera)
         for camera in self._cameras.values():
@@ -69,11 +73,12 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera], persistence.PersistentMod
         for camera_id, ip in await self.scan_for_cameras():
             if camera_id not in self._cameras:
                 self.add_camera(MjpegCamera(id=camera_id, username=self.username,
-                                password=self.password, connect_after_init=False))
+                                password=self.password, ip=ip))
             camera = self._cameras[camera_id]
             if not camera.is_connected:
                 self.log.info('activating authorized camera "%s" at ip "%s" ...', camera.id, ip)
-                await camera.connect(ip=ip)
+                camera.ip = ip
+                await camera.connect()
 
     async def shutdown(self) -> None:
         for camera in self._cameras.values():

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -30,7 +30,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
                          streaming=streaming,
                          **kwargs)
 
-        self.logger = logging.getLogger(f'rosys.vision.rtsp_camera.{self.id}')
+        self.log = logging.getLogger(f'rosys.vision.rtsp_camera.{self.id}')
 
         self.device: Optional[RtspDevice] = None
         self.jovision_profile: int = jovision_profile
@@ -69,7 +69,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
             return
 
         if not self.ip:
-            self.logger.error('no IP address provided for camera %s', self.id)
+            self.log.error('no IP address provided for camera %s', self.id)
             return
 
         self.device = RtspDevice(mac=self.id, ip=self.ip, jovision_profile=self.jovision_profile)

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -42,11 +42,12 @@ class RtspCameraProvider(CameraProvider[RtspCamera], persistence.PersistentModul
     async def update_device_list(self) -> None:
         for mac, ip in await find_known_cameras(network_interface=self.network_interface):
             if mac not in self._cameras:
-                self.add_camera(RtspCamera(id=mac, fps=self.frame_rate, jovision_profile=self.jovision_profile))
+                self.add_camera(RtspCamera(id=mac, fps=self.frame_rate, jovision_profile=self.jovision_profile, ip=ip))
             camera = self._cameras[mac]
             if not camera.is_connected:
                 self.log.info('activating authorized camera %s...', camera.id)
-                await camera.connect(ip)
+                camera.ip = ip
+                await camera.connect()
 
     async def shutdown(self) -> None:
         for camera in self._cameras.values():


### PR DESCRIPTION
Two changes that I felt were hard to find a good name for:

- ip is now stored in both Rtsp and Mjpeg Network cameras such that they can quickly reconnect on startup and are less dependent on network scans
- username and passwords are not overwritten by the `MJpegCameraProvider` when loading cameras from persistence

An app should now be able to set up and configure cameras and have everything be loaded and setup as-is on the next start.