### PR TITLE
Make asyncio warnings ui container accessible and hide controls

### DIFF
--- a/rosys/analysis/asyncio_warnings.py
+++ b/rosys/analysis/asyncio_warnings.py
@@ -51,5 +51,5 @@ class AsyncioWarnings:
             ui.number('coro limit',
                       value=loop.slow_callback_duration, format='%.3f',
                       on_change=lambda e: self.set_threshold(e.value)) \
-                .props('suffix=s hide-controls').classes('w-16')
+                .props('suffix=s').classes('w-16')
         return content

--- a/rosys/analysis/asyncio_warnings.py
+++ b/rosys/analysis/asyncio_warnings.py
@@ -44,9 +44,12 @@ class AsyncioWarnings:
         loop = asyncio.get_running_loop()
         loop.slow_callback_duration = seconds
 
-    def ui(self) -> None:
-        with ui.row().classes('items-end'):
+    def ui(self) -> ui.element:
+        with ui.row().classes('items-end') as content:
             loop = asyncio.get_running_loop()
             ui.checkbox(on_change=self.toggle)
-            ui.number('coro limit', value=loop.slow_callback_duration, format='%.3f',
-                      on_change=lambda e: self.set_threshold(e.value)).props('suffix=s').classes('w-16')
+            ui.number('coro limit',
+                      value=loop.slow_callback_duration, format='%.3f',
+                      on_change=lambda e: self.set_threshold(e.value)) \
+                .props('suffix=s hide-controls').classes('w-16')
+        return content


### PR DESCRIPTION
This pull request improves the `asyncio_warnings.ui()`.