### PR TITLE
Axis Settings (MjpegDevice Subclasses)

### DIFF
--- a/docs/src/example_camera_control.py
+++ b/docs/src/example_camera_control.py
@@ -62,6 +62,7 @@ def create_camera_settings_panel(camera: rosys.vision.ConfigurableCamera) -> Non
 def update_camera_cards() -> None:
     providers: list[rosys.vision.CameraProvider] = [
         rtsp_camera_provider,
+        mjpeg_camera_provider,
         usb_camera_provider,
         simulated_camera_provider,
     ]
@@ -76,6 +77,7 @@ camera_cards: dict[str, ui.card] = {}
 camera_grid = ui.row()
 
 rtsp_camera_provider = rosys.vision.RtspCameraProvider()
+mjpeg_camera_provider = rosys.vision.MjpegCameraProvider()
 usb_camera_provider = rosys.vision.UsbCameraProvider()
 simulated_camera_provider = rosys.vision.SimulatedCameraProvider()
 

--- a/rosys/geometry/point3d.py
+++ b/rosys/geometry/point3d.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from typing import Sequence
 
 from .point import Point
 
@@ -11,6 +12,11 @@ class Point3d:
     x: float
     y: float
     z: float
+
+    @staticmethod
+    def from_tuple(t: Sequence[float]) -> Point3d:
+        """Create a Point3d from the three first elements of a sequence."""
+        return Point3d(x=t[0], y=t[1], z=t[2])
 
     @property
     def tuple(self) -> tuple[float, float, float]:

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -36,34 +36,28 @@ class AxisMjpegDevice(MjpegDevice):
         if vendor != VendorType.AXIS:
             raise ValueError(f'AxisMjpegDevice can only be used with AXIS devices. Got {vendor} for mac="{mac}"')
 
-    @property
-    def fps(self) -> int:
+    async def get_fps(self) -> int:
         return self.axis_settings.fps
 
-    @fps.setter
-    def fps(self, fps: int) -> None:
+    async def set_fps(self, fps: int) -> None:
         self.url = re.sub(r'fps=\d+', f'fps={fps}', self.url)
         if 'fps=' not in self.url:
             self.url += f'&fps={fps}'
         self.restart_capture()
 
-    @property
-    def resolution(self) -> tuple[int, int]:
+    async def get_resolution(self) -> tuple[int, int]:
         return self.axis_settings.resolution
 
-    @resolution.setter
-    def resolution(self, width: int, height: int) -> None:
+    async def set_resolution(self, width: int, height: int) -> None:
         self.url = re.sub(r'resolution=\d+x\d+', f'resolution={width}x{height}', self.url)
         if 'resolution=' not in self.url:
             self.url += f'&resolution={width}x{height}'
         self.restart_capture()
 
-    @property
-    def mirrored(self) -> bool:
+    async def get_mirrored(self) -> bool:
         return self.axis_settings.mirrored
 
-    @mirrored.setter
-    def mirrored(self, mirrored: bool) -> None:
+    async def set_mirrored(self, mirrored: bool) -> None:
         value = 1 if mirrored else 0
         self.url = re.sub(r'mirror=\d', f'mirror={value}', self.url)
         if 'mirror=' not in self.url:

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -1,0 +1,71 @@
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from .mjpeg_device import MjpegDevice
+from .vendors import VendorType, mac_to_vendor
+
+
+@dataclass(slots=True, kw_only=True)
+class AxisSettings:
+    fps: int
+    resolution: tuple[int, int]
+    mirrored: bool
+
+    def __post_init__(self):
+        if self.fps <= 0:
+            raise ValueError(f'fps must be positive. Got {self.fps}')
+        if self.resolution[0] <= 0 or self.resolution[1] <= 0:
+            raise ValueError(f'resolution must be positive. Got {self.resolution}')
+        if not isinstance(self.mirrored, bool):
+            raise ValueError(f'mirrored must be a boolean. Got {self.mirrored}')
+
+
+class AxisMjpegDevice(MjpegDevice):
+    def __init__(self, mac: str, ip: str, *,
+                 index: Optional[int] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None) -> None:
+        super().__init__(mac, ip,
+                         index=index,
+                         username=username, password=password)
+
+        self.axis_settings = AxisSettings(fps=6, resolution=(640, 480), mirrored=False)
+
+        vendor = mac_to_vendor(mac)
+        if vendor != VendorType.AXIS:
+            raise ValueError(f'AxisMjpegDevice can only be used with AXIS devices. Got {vendor} for mac="{mac}"')
+
+    @property
+    def fps(self) -> int:
+        return self.axis_settings.fps
+
+    @fps.setter
+    def fps(self, fps: int) -> None:
+        self.url = re.sub(r'fps=\d+', f'fps={fps}', self.url)
+        if 'fps=' not in self.url:
+            self.url += f'&fps={fps}'
+        self.restart_capture()
+
+    @property
+    def resolution(self) -> tuple[int, int]:
+        return self.axis_settings.resolution
+
+    @resolution.setter
+    def resolution(self, width: int, height: int) -> None:
+        self.url = re.sub(r'resolution=\d+x\d+', f'resolution={width}x{height}', self.url)
+        if 'resolution=' not in self.url:
+            self.url += f'&resolution={width}x{height}'
+        self.restart_capture()
+
+    @property
+    def mirrored(self) -> bool:
+        return self.axis_settings.mirrored
+
+    @mirrored.setter
+    def mirrored(self, mirrored: bool) -> None:
+        value = 1 if mirrored else 0
+        self.url = re.sub(r'mirror=\d', f'mirror={value}', self.url)
+        if 'mirror=' not in self.url:
+            self.url += f'&mirror={value}'
+        self.restart_capture()

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -45,6 +45,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
 
         self._register_parameter('fps', self._get_fps, self._set_fps, default_value=10)
         self._register_parameter('resolution', self._get_resolution, self._set_resolution, default_value=(640, 480))
+        self._register_parameter('mirrored', self._get_mirrored, self._set_mirrored, default_value=False)
 
     def to_dict(self) -> dict:
         return super().to_dict() | {
@@ -128,3 +129,15 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
             raise ValueError('Device is not connected')
 
         return await self.device.get_resolution()
+
+    async def _set_mirrored(self, mirrored: bool) -> None:
+        if self.device is None:
+            raise ValueError('Device is not connected')
+
+        await self.device.set_mirrored(mirrored)
+
+    async def _get_mirrored(self) -> bool:
+        if self.device is None:
+            raise ValueError('Device is not connected')
+
+        return await self.device.get_mirrored()

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -9,6 +9,7 @@ from ..image import Image
 from ..image_processing import get_image_size_from_bytes, process_jpeg_image
 from ..image_rotation import ImageRotation
 from .mjpeg_device import MjpegDevice
+from .mjpeg_device_factory import MjpegDeviceFactory
 
 
 class MjpegCamera(TransformableCamera, ConfigurableCamera):
@@ -68,7 +69,12 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
             self.log.error('No IP address provided')
             return
 
-        self.device = MjpegDevice(self.mac, self.ip, index=self.index, username=self.username, password=self.password)
+        try:
+            self.device = MjpegDeviceFactory.create(self.mac, self.ip, index=self.index, username=self.username,
+                                                    password=self.password)
+        except ValueError as error:
+            self.log.error('Could not connect to device: %s', error)
+            return
 
     async def disconnect(self) -> None:
         if self.device is None:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -59,7 +59,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
 
     @property
     def is_connected(self) -> bool:
-        return self.device is not None and self.device.capture_task is not None
+        return (self.device is not None) and (self.device.capture_task is not None) and (not self.device.capture_task.done())
 
     async def connect(self) -> None:
         if self.is_connected:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -107,27 +107,23 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
     async def _set_fps(self, fps: int) -> None:
         if self.device is None:
             raise ValueError('Device is not connected')
-        assert self.device.settings_interface is not None
 
-        await self.device.settings_interface.set_fps(fps)
+        await self.device.set_fps(fps)
 
     async def _get_fps(self) -> int:
         if self.device is None:
             raise ValueError('Device is not connected')
-        assert self.device.settings_interface is not None
 
-        return await self.device.settings_interface.get_fps()
+        return await self.device.get_fps()
 
     async def _set_resolution(self, resolution: tuple[int, int]) -> None:
         if self.device is None:
             raise ValueError('Device is not connected')
-        assert self.device.settings_interface is not None
 
-        await self.device.settings_interface.set_stream_resolution(*resolution)
+        await self.device.set_resolution(*resolution)
 
     async def _get_resolution(self) -> tuple[int, int]:
         if self.device is None:
             raise ValueError('Device is not connected')
-        assert self.device.settings_interface is not None
 
-        return await self.device.settings_interface.get_stream_resolution()
+        return await self.device.get_resolution()

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -109,6 +109,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
             raise ValueError('Device is not connected')
 
         await self.device.set_fps(fps)
+        self.polling_interval = 1.0 / fps
 
     async def _get_fps(self) -> int:
         if self.device is None:

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -125,3 +125,9 @@ class MjpegDevice:
 
     async def set_resolution(self, width: int, height: int) -> None:
         pass
+
+    async def get_mirrored(self) -> bool:
+        return False
+
+    async def set_mirrored(self, mirrored: bool) -> None:
+        pass

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -113,3 +113,15 @@ class MjpegDevice:
         if self.capture_task is not None:
             self.capture_task.cancel()
             self.capture_task = None
+
+    async def get_fps(self) -> int:
+        return 0
+
+    async def set_fps(self, fps: int) -> None:
+        pass
+
+    async def get_resolution(self) -> tuple[int, int]:
+        return 0, 0
+
+    async def set_resolution(self, width: int, height: int) -> None:
+        pass

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -7,8 +7,7 @@ import httpx
 
 from ...rosys import on_startup
 from ..image_processing import remove_exif
-from .motec_settings_interface import MotecSettingsInterface
-from .vendors import VendorType, mac_to_url, mac_to_vendor
+from .vendors import mac_to_url
 
 
 class MjpegDevice:
@@ -16,10 +15,10 @@ class MjpegDevice:
     def __init__(self, mac: str, ip: str, *,
                  index: Optional[int] = None,
                  username: Optional[str] = None,
-                 password: Optional[str] = None,
-                 control_port: int = 8885) -> None:
+                 password: Optional[str] = None) -> None:
         self.mac = mac
         self.ip = ip
+        self.index = index
         self.capture_task: Optional[Task] = None
         self._image_buffer: Optional[bytearray] = None
         self.authentication = None if username is None or password is None else httpx.DigestAuth(username, password)
@@ -29,9 +28,6 @@ class MjpegDevice:
             raise ValueError(f'could not determine URL for {mac}')
         self.url = url
 
-        if mac_to_vendor(mac) == VendorType.MOTEC:
-            self.settings_interface = MotecSettingsInterface(ip, port=control_port)
-
         self.start_capture_task()
 
     def start_capture_task(self) -> None:
@@ -40,7 +36,7 @@ class MjpegDevice:
             self.capture_task = loop.create_task(self.run_capture_task())
         on_startup(create_capture_task)
 
-    async def restart_capture(self) -> None:
+    def restart_capture(self) -> None:
         self.shutdown()
         self.start_capture_task()
 

--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from .axis_mjpeg_device import AxisMjpegDevice
+from .mjpeg_device import MjpegDevice
+from .motec_mjpeg_device import MotecMjpegDevice
+from .vendors import VendorType, mac_to_vendor
+
+
+class MjpegDeviceFactory:
+    @staticmethod
+    def create(mac: str, ip: str, *,
+               index: Optional[int] = None,
+               username: Optional[str] = None,
+               password: Optional[str] = None,
+               control_port: Optional[int] = None) -> MjpegDevice:
+
+        if mac_to_vendor(mac) == VendorType.AXIS:
+            return AxisMjpegDevice(mac, ip, index=index, username=username, password=password)
+
+        if mac_to_vendor(mac) == VendorType.MOTEC:
+            return MotecMjpegDevice(mac, ip, username=username, password=password, control_port=control_port)
+
+        raise ValueError(f'Unknown vendor for mac="{mac}"')

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -15,7 +15,7 @@ class MotecMjpegDevice(MjpegDevice):
                          username=username, password=password)
 
         vendor = mac_to_vendor(mac)
-        if not vendor == VendorType.MOTEC:
+        if vendor != VendorType.MOTEC:
             raise ValueError(f'MotecMjpegDevice can only be used with MOTEC devices. Got {vendor} for mac="{mac}"')
 
         self.settings_interface = MotecSettingsInterface(ip, port=control_port or 8885)

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from .mjpeg_device import MjpegDevice
+from .motec_settings_interface import MotecSettingsInterface
+from .vendors import VendorType, mac_to_vendor
+
+
+class MotecMjpegDevice(MjpegDevice):
+    def __init__(self, mac: str, ip: str, *,
+                 username: Optional[str] = '',
+                 password: Optional[str] = '',
+                 control_port: Optional[int] = 8885) -> None:
+
+        super().__init__(mac, ip,
+                         username=username, password=password)
+
+        vendor = mac_to_vendor(mac)
+        if not vendor == VendorType.MOTEC:
+            raise ValueError(f'MotecMjpegDevice can only be used with MOTEC devices. Got {vendor} for mac="{mac}"')
+
+        self.settings_interface = MotecSettingsInterface(ip, port=control_port or 8885)
+
+    async def set_fps(self, fps: int) -> None:
+        await self.settings_interface.set_fps(fps)
+
+    async def set_resolution(self, width: int, height: int) -> None:
+        await self.settings_interface.set_stream_resolution(width, height)
+
+    async def set_stream_port(self, port: int) -> None:
+        await self.settings_interface.set_stream_port(port)
+
+    async def set_stream_compression(self, level: int) -> None:
+        await self.settings_interface.set_stream_compression(level)

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -23,11 +23,23 @@ class MotecMjpegDevice(MjpegDevice):
     async def set_fps(self, fps: int) -> None:
         await self.settings_interface.set_fps(fps)
 
+    async def get_fps(self) -> int:
+        return await self.settings_interface.get_fps()
+
     async def set_resolution(self, width: int, height: int) -> None:
         await self.settings_interface.set_stream_resolution(width, height)
 
+    async def get_resolution(self) -> tuple[int, int]:
+        return await self.settings_interface.get_stream_resolution()
+
     async def set_stream_port(self, port: int) -> None:
         await self.settings_interface.set_stream_port(port)
+
+    async def get_stream_port(self) -> int:
+        return await self.settings_interface.get_stream_port()
+
+    async def get_stream_compression(self) -> int:
+        return await self.settings_interface.get_stream_compression()
 
     async def set_stream_compression(self, level: int) -> None:
         await self.settings_interface.set_stream_compression(level)

--- a/rosys/vision/mjpeg_camera/vendors.py
+++ b/rosys/vision/mjpeg_camera/vendors.py
@@ -19,7 +19,7 @@ def mac_to_vendor(mac: str) -> VendorType:
 def mac_to_url(mac: str, ip: str, *, index: Optional[int] = None) -> Optional[str]:
     vendor = mac_to_vendor(mac)
     if vendor == VendorType.AXIS:
-        return f'http://{ip}/axis-cgi/mjpg/video.cgi' + (f'?camera={index}' if index is not None else '')
+        return f'http://{ip}/axis-cgi/mjpg/video.cgi' + '?' + (f'camera={index}' if index is not None else '')
     if vendor == VendorType.MOTEC:
         return f'http://{ip}:1001/stream.mjpg'
     return None

--- a/rosys/vision/mjpeg_camera/vendors.py
+++ b/rosys/vision/mjpeg_camera/vendors.py
@@ -19,7 +19,7 @@ def mac_to_vendor(mac: str) -> VendorType:
 def mac_to_url(mac: str, ip: str, *, index: Optional[int] = None) -> Optional[str]:
     vendor = mac_to_vendor(mac)
     if vendor == VendorType.AXIS:
-        return f'http://{ip}/axis-cgi/mjpg/video.cgi' + '?' + (f'camera={index}' if index is not None else '')
+        return f'http://{ip}/axis-cgi/mjpg/video.cgi?' + (f'camera={index}' if index is not None else '')
     if vendor == VendorType.MOTEC:
         return f'http://{ip}:1001/stream.mjpg'
     return None


### PR DESCRIPTION
The goal here is primarily to add the ability to change the settings on axis camera devices.

This works differently from all previous interfaces since it does not change anything on the camera device itself, but rather just edits the url that is used to request images.
As a result that functionality really needs to be implemented inside the MjpegDevice and I have thus separated devices with different interfaces into subclasses of MjpegDevice.

Some logging was also added to the providers `scan_for_cameras` method.

Considerations I have for the future of this:

- The configurable parameters of a camera should really be determined by the device. We now have a discrepancy of parameters between vendors:
Axis devices have a `mirrored` parameter and  Motec devices have options for the `stream_port` and `compression` level.
(really, this was already the case for usb cameras, too, but we do not actively differentiate there). 
Additionally, the base class now has to provide mock functions for all parameters.
- Parameters should probably be adjustable even if the camera is not connected so that they are applied once it is. The downside is that we might not get feedback that settings a value failed.