### PR TITLE
Allow configuration of focal length when building a simulated camera

### DIFF
--- a/rosys/vision/camera/calibratable_camera.py
+++ b/rosys/vision/camera/calibratable_camera.py
@@ -32,7 +32,7 @@ class CalibratableCamera(Camera):
         return camera
 
     def set_perfect_calibration(self, *,
-                                width=800, height=600, focal_length=570,
+                                width: int = 800, height: int = 600, focal_length: float = 570,
                                 x: float = 0.0, y: float = 0.0, z: float = 1.0,
                                 roll: float = np.pi, pitch: float = 0.0, yaw: float = 0.0,
                                 ) -> None:

--- a/rosys/vision/camera/calibratable_camera.py
+++ b/rosys/vision/camera/calibratable_camera.py
@@ -25,10 +25,9 @@ class CalibratableCamera(Camera):
                           roll: float = np.pi, pitch: float = 0.0, yaw: float = 0.0,
                           **kwargs) -> Self:
         camera = cls(**kwargs)
-        camera.set_perfect_calibration(width=width, height=height,
+        camera.set_perfect_calibration(width=width, height=height, focal_length=focal_length,
                                        x=x, y=y, z=z,
-                                       roll=roll, pitch=pitch, yaw=yaw,
-                                       focal_length=focal_length)
+                                       roll=roll, pitch=pitch, yaw=yaw)
         return camera
 
     def set_perfect_calibration(self, *,

--- a/rosys/vision/camera/calibratable_camera.py
+++ b/rosys/vision/camera/calibratable_camera.py
@@ -23,16 +23,22 @@ class CalibratableCamera(Camera):
                           width: int = 800, height: int = 600,
                           x: float = 0.0, y: float = 0.0, z: float = 1.0,
                           roll: float = np.pi, pitch: float = 0.0, yaw: float = 0.0,
+                          focal_length: float = 570,
                           **kwargs) -> Self:
         camera = cls(**kwargs)
-        camera.set_perfect_calibration(width=width, height=height, x=x, y=y, z=z, roll=roll, pitch=pitch, yaw=yaw)
+        camera.set_perfect_calibration(width=width, height=height,
+                                       x=x, y=y, z=z,
+                                       roll=roll, pitch=pitch, yaw=yaw,
+                                       focal_length=focal_length)
         return camera
 
     def set_perfect_calibration(self, *,
                                 width=800, height=600,
                                 x: float = 0.0, y: float = 0.0, z: float = 1.0,
-                                roll: float = np.pi, pitch: float = 0.0, yaw: float = 0.0) -> None:
+                                roll: float = np.pi, pitch: float = 0.0, yaw: float = 0.0,
+                                focal_length: float = 570,
+                                ) -> None:
         self.calibration = Calibration(
-            intrinsics=Intrinsics.create_default(width, height),
+            intrinsics=Intrinsics.create_default(width, height, focal_length=focal_length),
             extrinsics=Extrinsics(rotation=Rotation.from_euler(roll, pitch, yaw), translation=[x, y, z]),
         )

--- a/rosys/vision/camera/calibratable_camera.py
+++ b/rosys/vision/camera/calibratable_camera.py
@@ -20,10 +20,9 @@ class CalibratableCamera(Camera):
 
     @classmethod
     def create_calibrated(cls, *,
-                          width: int = 800, height: int = 600,
+                          width: int = 800, height: int = 600, focal_length: float = 570,
                           x: float = 0.0, y: float = 0.0, z: float = 1.0,
                           roll: float = np.pi, pitch: float = 0.0, yaw: float = 0.0,
-                          focal_length: float = 570,
                           **kwargs) -> Self:
         camera = cls(**kwargs)
         camera.set_perfect_calibration(width=width, height=height,
@@ -33,10 +32,9 @@ class CalibratableCamera(Camera):
         return camera
 
     def set_perfect_calibration(self, *,
-                                width=800, height=600,
+                                width=800, height=600, focal_length=570,
                                 x: float = 0.0, y: float = 0.0, z: float = 1.0,
                                 roll: float = np.pi, pitch: float = 0.0, yaw: float = 0.0,
-                                focal_length: float = 570,
                                 ) -> None:
         self.calibration = Calibration(
             intrinsics=Intrinsics.create_default(width, height, focal_length=focal_length),


### PR DESCRIPTION
This pull requests adds the `focal_length` parameter to the creator methods of `CalibratableCamera`. 