### PR TITLE
Add request_backup to MultiCameraProvider

### DIFF
--- a/rosys/vision/multi_camera_provider.py
+++ b/rosys/vision/multi_camera_provider.py
@@ -16,6 +16,10 @@ class MultiCameraProvider(CameraProvider):
             camera_provider.CAMERA_ADDED.register(self.CAMERA_ADDED.emit)
             camera_provider.CAMERA_REMOVED.register(self.CAMERA_REMOVED.emit)
 
+    def request_backup(self) -> None:
+        for provider in self.providers:
+            provider.request_backup()
+
     @property
     def cameras(self) -> dict[str, Camera]:
         return {id: camera for provider in self.providers for id, camera in provider.cameras.items()}


### PR DESCRIPTION
`CameraProvider` derives from `rosys.persistent_module`, so each provider will have a `request_backup` function.

Here we overwrite that functions, since we really want all cameras to be backed up by their respective providers.

Alternatively, we could iterate over `cameras` and back them up into `rosys.vision.multi_camera_provider.MultiCameraProvider.json`. 

I think this is less fitting though since the MultiCameraProvider is meant to be a proxy rather than a provider by itself.