### PR TITLE
MultiCameraProvider camera scanning

### DIFF
--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -72,3 +72,7 @@ class CameraProvider(Generic[T], rosys.persistence.PersistentModule, metaclass=a
             else:
                 while camera.images and camera.images[0].time < rosys.time() - max_age_seconds:
                     del camera.images[0]
+
+    @abc.abstractmethod
+    async def update_device_list(self):
+        pass

--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -74,5 +74,5 @@ class CameraProvider(Generic[T], rosys.persistence.PersistentModule, metaclass=a
                     del camera.images[0]
 
     @abc.abstractmethod
-    async def update_device_list(self):
+    async def update_device_list(self) -> None:
         pass

--- a/rosys/vision/multi_camera_provider.py
+++ b/rosys/vision/multi_camera_provider.py
@@ -23,8 +23,8 @@ class MultiCameraProvider(CameraProvider):
         for provider in self.providers:
             try:
                 await provider.update_device_list()
-            except Exception as error:
-                self.log.error('Error while scanning for cameras in "%s": %s', provider.__class__.__name__, error)
+            except Exception as e:
+                self.log.error('Error while scanning for cameras in "%s": %s', provider.__class__.__name__, e)
 
     def request_backup(self) -> None:
         for provider in self.providers:


### PR DESCRIPTION
This adds the `scan_for_cameras` method to the `MultiCameraProvider` which in turn calls it on all its providers.
For this, all `CameraProvider`s need to support the `scan_for_cameras` method which is now an abstract method of the parent class.

Adding the method as an `abstractmethod` may require action on all derived `CameraProviders` outside of rosys.
Another option would be to add it as a default that does nothing.

The central question here would be if all providers can scan for new cameras somehow or if some need a fixed list provided by the application code.