### PR TITLE
Add Backup schedule

### DIFF
--- a/docs/examples/persistence.md
+++ b/docs/examples/persistence.md
@@ -29,8 +29,8 @@ Note that the persistence module contains a number of helper functions:
 - `replace_set`: replaces the content of a set using `from_dict` for each item
 - `replace_dataclass`: replaces the attributes of a dataclass with the values of a dictionary
 
-The persistence module also provides ui buttons for exporting the contents of your ~/.rosys directory to a single file and for importing such a file.
+The persistence module also provides UI buttons for exporting the contents of the ~/.rosys directory to a single file and for importing such a file.
 
-If you want to automatically keep daily backups can use the `BackupSchedule`.
-It will back up all the contents of your ~/.rosys directory at a configurable directory and at a given time each day.
+If you want to automatically keep daily backups, you can use the `BackupSchedule` module.
+It will backup all the contents of your ~/.rosys directory at a configurable directory and at a given time each day.
 When a maximum number of backup files is reached (specified with `backup_count`), it will delete the oldest file.

--- a/docs/examples/persistence.md
+++ b/docs/examples/persistence.md
@@ -28,3 +28,9 @@ Note that the persistence module contains a number of helper functions:
 - `replace_list`: replaces the content of a list using `from_dict` for each item
 - `replace_set`: replaces the content of a set using `from_dict` for each item
 - `replace_dataclass`: replaces the attributes of a dataclass with the values of a dictionary
+
+The persistence module also provides ui buttons for exporting the contents of your ~/.rosys directory to a single file and for importing such a file.
+
+If you want to automatically keep daily backups can use the `BackupSchedule`.
+It will back up all the contents of your ~/.rosys directory at a configurable directory and at a given time each day.
+When a maximum number of backup files is reached (specified with `backup_count`), it will delete the oldest file.

--- a/rosys/persistence/__init__.py
+++ b/rosys/persistence/__init__.py
@@ -1,5 +1,6 @@
 from dataclasses_json import Exclude, config
 
+from .backup_schedule import BackupSchedule
 from .converters import from_dict, replace_dataclass, replace_dict, replace_list, replace_set, to_dict
 from .persistent_module import PersistentModule
 from .registry import backup, restore, write_export
@@ -8,6 +9,7 @@ from .ui import export_button, import_button
 exclude: dict[str, dict] = config(exclude=Exclude.ALWAYS)
 
 __all__ = [
+    'BackupSchedule',
     'from_dict',
     'replace_dataclass',
     'replace_dict',

--- a/rosys/persistence/__init__.py
+++ b/rosys/persistence/__init__.py
@@ -2,7 +2,7 @@ from dataclasses_json import Exclude, config
 
 from .converters import from_dict, replace_dataclass, replace_dict, replace_list, replace_set, to_dict
 from .persistent_module import PersistentModule
-from .registry import backup, restore
+from .registry import backup, restore, write_export
 from .ui import export_button, import_button
 
 exclude: dict[str, dict] = config(exclude=Exclude.ALWAYS)
@@ -18,6 +18,7 @@ __all__ = [
     'exclude',
     'backup',
     'restore',
+    'write_export',
     'export_button',
     'import_button',
 ]

--- a/rosys/persistence/backup_schedule.py
+++ b/rosys/persistence/backup_schedule.py
@@ -1,0 +1,33 @@
+import datetime
+import logging
+from pathlib import Path
+
+import rosys
+
+from . import registry
+
+
+class BackupSchedule:
+
+    def __init__(self, path: Path = Path('~/.rosysbackup'),
+                 time: datetime.time = datetime.time(3, 0),
+                 backup_count: int = 100) -> None:
+        self.path = path.expanduser()
+        self.time = time
+        self.backup_count = backup_count
+        self.log = logging.getLogger('rosys.persistence')
+
+        if not self.path.exists():
+            self.path.mkdir(parents=True)
+
+        rosys.on_repeat(self.need_to_backup, 60)
+
+    def need_to_backup(self) -> None:
+        now = datetime.datetime.now()
+        if now.time() < self.time or now.time() > self.time.replace(second=59):
+            return
+        backups = sorted(self.path.glob('*.json'))
+        if len(backups) == self.backup_count:
+            backups[0].unlink()
+        self.log.info('Backing up persistence files to %s', self.path)
+        registry.write_export(self.path / f'{now:%Y-%m-%d}.json')

--- a/rosys/persistence/backup_schedule.py
+++ b/rosys/persistence/backup_schedule.py
@@ -8,26 +8,31 @@ from . import registry
 
 
 class BackupSchedule:
+    """The BackupSchedule module is responsible for backing up the persistence files every day at the specified time."""
 
-    def __init__(self, path: Path = Path('~/.rosysbackup'),
+    def __init__(self,
+                 path: Path = Path('~/.rosys_backup'),
                  time: datetime.time = datetime.time(3, 0),
                  backup_count: int = 100) -> None:
         self.path = path.expanduser()
+        self.path.mkdir(parents=True, exist_ok=True)
         self.time = time
         self.backup_count = backup_count
         self.log = logging.getLogger('rosys.persistence')
 
-        if not self.path.exists():
-            self.path.mkdir(parents=True)
+        rosys.on_repeat(self.backup, 60)
 
-        rosys.on_repeat(self.need_to_backup, 60)
-
-    def need_to_backup(self) -> None:
+    def backup(self) -> None:
+        """Backup the persistence files every day at the specified time."""
         now = datetime.datetime.now()
-        if now.time() < self.time or now.time() > self.time.replace(second=59):
+        filepath = self.path / f'{now:%Y-%m-%d}.json'
+        if now.time() < self.time or filepath.exists():
             return
-        backups = sorted(self.path.glob('*.json'))
-        if len(backups) == self.backup_count:
+        self.log.info('Backing up persistence files to %s', filepath)
+        registry.write_export(filepath)
+        self.prune()
+
+    def prune(self) -> None:
+        """Delete old backups if there are more than the specified number."""
+        while len(backups := sorted(self.path.glob('*.json'))) > self.backup_count:
             backups[0].unlink()
-        self.log.info('Backing up persistence files to %s', self.path)
-        registry.write_export(self.path / f'{now:%Y-%m-%d}.json')

--- a/rosys/persistence/registry.py
+++ b/rosys/persistence/registry.py
@@ -56,3 +56,8 @@ def restore() -> None:
             module.restore(json.loads(filepath.read_text()))
         except Exception:
             log.exception('failed to restore %s', module)
+
+
+def write_export(to_filepath: Path) -> None:
+    data = {name: module.backup() for name, module in modules.items()}
+    to_filepath.write_text(json.dumps(data, indent=4))

--- a/rosys/persistence/ui.py
+++ b/rosys/persistence/ui.py
@@ -12,8 +12,7 @@ from . import registry
 def export_button(title: str = 'Export', route: str = '/export', tmp_filepath: Path = Path('/tmp/export.json')) -> ui.button:
     @app.get(route)
     def get_export() -> FileResponse:
-        data = {name: module.backup() for name, module in registry.modules.items()}
-        tmp_filepath.write_text(json.dumps(data, indent=4))
+        registry.write_export(tmp_filepath)
         return FileResponse(tmp_filepath, filename='export.json')
     return ui.button(title, on_click=lambda: ui.download(route[1:]))
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -34,7 +34,6 @@ def test_conversion_to_and_from_dict() -> None:
         'x': 42,
         'y': 3.14,
         'a': {'s': 'foo', 'b': True},
-        'l': [1, 2, 3],
         'l': [{'s': 'foo', 'b': True}, {'s': 'bar', 'b': True}],
         'd': {'a': {'s': 'foo', 'b': True}, 'b': {'s': 'bar', 'b': True}},
     }


### PR DESCRIPTION
This PR adds a backup schedule to backup all files in the persistence folder (`~/.rosys`) once a day as suggested here #108.

The location of the backup, the time it's performed and the number of backup files that are kept is configurable.

Changes:
* move writing of an export file to `persistence.registry`
* add BackupSchedule itself
* add documentation 