### PR TITLE
Prevent log config from loading for other pytest projects

### DIFF
--- a/rosys/testing/fixtures.py
+++ b/rosys/testing/fixtures.py
@@ -14,11 +14,10 @@ from rosys.hardware import Robot, RobotSimulation, Wheels, WheelsSimulation
 from rosys.pathplanning import PathPlanner
 from rosys.testing import helpers, log_configuration
 
-log_configuration.setup()
-
 
 @pytest.fixture
 async def integration() -> AsyncGenerator:
+    log_configuration.setup()
     core.loop = asyncio.get_event_loop()
     rosys.reset_before_test()
     await rosys.startup()


### PR DESCRIPTION
This pull request moves the log setup into the integration test fixture to prevent it from loading when pytest loads all fixtures.  Before the log formatting was applied to all pytests as long as rosys is installed via pip.