### PR TITLE
Fix @track decorator when used with parallelize()

### DIFF
--- a/rosys/analysis/tracking.py
+++ b/rosys/analysis/tracking.py
@@ -1,3 +1,4 @@
+import uuid
 from functools import wraps
 from typing import Callable, ParamSpec, TypeVar
 
@@ -10,26 +11,23 @@ _P = ParamSpec('_P')
 class Track:
 
     def __init__(self) -> None:
-        self.stack: list[str] = []
+        self.stack: dict[int, str] = {}
 
     def __call__(self, f: Callable[_P, _T]) -> Callable[_P, _T]:
         @wraps(f)
         async def wrap(*args, **kwargs):
+            uid = uuid.uuid4().int
+            self.stack[uid] = f.__name__
             try:
-                self.stack.append(f.__name__)
                 return await f(*args, **kwargs)
             finally:
-                if self.stack and self.stack[-1] == f.__name__:
-                    self.stack.pop()
+                del self.stack[uid]
         return wrap
 
     def ui(self) -> ui.label:
         label = ui.label()
-        ui.timer(0.5, lambda: label.set_text(' → '.join(self.stack)))
+        ui.timer(0.5, lambda: label.set_text(' → '.join(self.stack.values())))
         return label
-
-    def reset(self) -> None:
-        self.stack.clear()
 
 
 track = Track()

--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -2,7 +2,6 @@ import logging
 from typing import Callable, Coroutine, Optional, cast
 
 from .. import rosys
-from ..analysis import track
 from ..driving import Steerer
 from ..event import Event
 from .automation import Automation
@@ -124,7 +123,6 @@ class Automator:
             self.automation.stop()
             self.automation = None
             self.AUTOMATION_STOPPED.emit(because)
-            track.reset()
             rosys.notify(f'automation stopped because {because}')
 
     def enable(self) -> None:


### PR DESCRIPTION
This PR replaces the `stack` list with a dictionary, mapping a unique ID to function names. After running the function, we don't _pop_ the last function name, but delete the item with the respective ID from the dictionary. Since Python dictionaries preserve their item's order, we can simply display the current state by joining all dictionary values.

Has been successfully tested with the code snippet from https://github.com/zauberzeug/rosys/issues/147#issue-2408992831.