### PR TITLE
Allow setting parameters on disconnected cameras

### DIFF
--- a/rosys/vision/camera/configurable_camera.py
+++ b/rosys/vision/camera/configurable_camera.py
@@ -49,6 +49,7 @@ class ConfigurableCamera(Camera):
 
     async def _apply_parameters(self, new_values: dict[str, Any], force_set: bool = False) -> None:
         if not self.is_connected:
+            self._write_values_to_cache(new_values)
             return
         for name, value in new_values.items():
             if name not in self._parameters:
@@ -64,10 +65,16 @@ class ConfigurableCamera(Camera):
                     await result
             except Exception as e:
                 if not self.is_connected:
+                    self._write_values_to_cache(new_values)
                     return
                 raise e
 
         await self._update_parameter_cache()
+
+    def _write_values_to_cache(self, new_values: dict[str, Any]) -> None:
+        for name, value in new_values.items():
+            if name in self._parameters:
+                self._parameters[name].value = value
 
     async def _apply_all_parameters(self) -> None:
         await self._apply_parameters(self.parameters, force_set=True)

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -106,38 +106,32 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         self._add_image(Image(camera_id=self.id, data=image, time=rosys.time(), size=final_image_resolution))
 
     async def _set_fps(self, fps: int) -> None:
-        if self.device is None:
-            raise ValueError('Device is not connected')
+        assert self.device is not None
 
         await self.device.set_fps(fps)
         self.polling_interval = 1.0 / fps
 
     async def _get_fps(self) -> int:
-        if self.device is None:
-            raise ValueError('Device is not connected')
+        assert self.device is not None
 
         return await self.device.get_fps()
 
     async def _set_resolution(self, resolution: tuple[int, int]) -> None:
-        if self.device is None:
-            raise ValueError('Device is not connected')
+        assert self.device is not None
 
         await self.device.set_resolution(*resolution)
 
     async def _get_resolution(self) -> tuple[int, int]:
-        if self.device is None:
-            raise ValueError('Device is not connected')
+        assert self.device is not None
 
         return await self.device.get_resolution()
 
     async def _set_mirrored(self, mirrored: bool) -> None:
-        if self.device is None:
-            raise ValueError('Device is not connected')
+        assert self.device is not None
 
         await self.device.set_mirrored(mirrored)
 
     async def _get_mirrored(self) -> bool:
-        if self.device is None:
-            raise ValueError('Device is not connected')
+        assert self.device is not None
 
         return await self.device.get_mirrored()

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -109,11 +109,13 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
     def set_fps(self, fps: int) -> None:
         assert self.device is not None
+        assert self.device.settings_interface is not None
         self.device.settings_interface.set_fps(stream_id=self.jovision_profile, fps=fps)
         self.polling_interval = 1.0 / fps
 
     def get_fps(self) -> int | None:
         assert self.device is not None
+        assert self.device.settings_interface is not None
         fps = self.device.settings_interface.get_fps(stream_id=self.jovision_profile)
         return fps
 

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -108,25 +108,21 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         self._add_image(image)
 
     def set_fps(self, fps: int) -> None:
-        if self.device is None or self.device.settings_interface is None:
-            raise ValueError('Camera is not connected')
+        assert self.device is not None
         self.device.settings_interface.set_fps(stream_id=self.jovision_profile, fps=fps)
         self.polling_interval = 1.0 / fps
 
     def get_fps(self) -> int | None:
-        if self.device is None or self.device.settings_interface is None:
-            raise ValueError('Camera is not connected')
+        assert self.device is not None
         fps = self.device.settings_interface.get_fps(stream_id=self.jovision_profile)
         return fps
 
     def set_jovision_profile(self, profile: int) -> None:
-        if self.device is None:
-            raise ValueError('Camera is not connected')
+        assert self.device is not None
         self.jovision_profile = profile
 
     def get_jovision_profile(self) -> int | None:
-        if self.device is None:
-            raise ValueError('Camera is not connected')
+        assert self.device is not None
         return self.jovision_profile
 
     async def _apply_parameters(self, new_values: dict[str, Any], force_set: bool = False) -> None:

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -109,24 +109,24 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
     def set_fps(self, fps: int) -> None:
         if self.device is None or self.device.settings_interface is None:
-            return
+            raise ValueError('Camera is not connected')
         self.device.settings_interface.set_fps(stream_id=self.jovision_profile, fps=fps)
         self.polling_interval = 1.0 / fps
 
     def get_fps(self) -> int | None:
         if self.device is None or self.device.settings_interface is None:
-            return None
+            raise ValueError('Camera is not connected')
         fps = self.device.settings_interface.get_fps(stream_id=self.jovision_profile)
         return fps
 
     def set_jovision_profile(self, profile: int) -> None:
         if self.device is None:
-            return
+            raise ValueError('Camera is not connected')
         self.jovision_profile = profile
 
     def get_jovision_profile(self) -> int | None:
         if self.device is None:
-            return None
+            raise ValueError('Camera is not connected')
         return self.jovision_profile
 
     async def _apply_parameters(self, new_values: dict[str, Any], force_set: bool = False) -> None:

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -81,7 +81,9 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
         return self.device.color
 
     def _set_fps(self, value: int) -> None:
+        assert self.device is not None
         self.polling_interval = 1.0 / value
 
     def _get_fps(self) -> int:
+        assert self.device is not None
         return int(1.0 / self.polling_interval)


### PR DESCRIPTION
Currently, when setting parameters the camera checks if it is connected and simply drops the values if it is not (with the idea that if we cannot set the values on the camera then we cannot do anything).

This PR now saves the values to cache if the camera is disconnected so that upon a reconnect, the values will be applied.