### PR TITLE
Allow parallelizing coroutines with different sleep intervals

### DIFF
--- a/rosys/automation/parallelize.py
+++ b/rosys/automation/parallelize.py
@@ -24,37 +24,53 @@ class parallelize:
         waiting = [False for _ in sends]
         futures = [None for _ in sends]
 
-        while not all(completed):
-            active_coros = [i for i, is_completed in enumerate(completed) if not is_completed]
+        try:
+            while not all(completed):
+                active_coros = [i for i, is_completed in enumerate(completed) if not is_completed]
 
-            for i in active_coros:
-                if waiting[i]:
-                    if futures[i].done():
-                        waiting[i] = False
-                        futures[i] = None
-                    else:
-                        continue
+                for i in active_coros:
+                    if waiting[i]:
+                        if futures[i].done():
+                            waiting[i] = False
+                            futures[i] = None
+                        else:
+                            continue
 
-                try:
-                    signal = sends[i](messages[i])
-                except StopIteration:
-                    if self.return_when_first_completed:
-                        return
-                    completed[i] = True
-                    continue
-                else:
-                    sends[i] = iter_sends[i]
-
-                if isinstance(signal, asyncio.Future | asyncio.Task):
-                    waiting[i] = True
-                    futures[i] = signal
-                else:
                     try:
-                        messages[i] = yield signal
-                    except GeneratorExit:
-                        raise
-                    except BaseException as e:
-                        sends[i], messages[i] = iter_throws[i], e
+                        signal = sends[i](messages[i])
+                    except StopIteration:
+                        completed[i] = True
+                        if self.return_when_first_completed:
+                            return
+                        continue
+                    else:
+                        sends[i] = iter_sends[i]
 
-            if all(waiting[i] or completed[i] for i in active_coros):
-                yield
+                    if isinstance(signal, asyncio.Future | asyncio.Task):
+                        waiting[i] = True
+                        futures[i] = signal
+                    else:
+                        try:
+                            messages[i] = yield signal
+                        except GeneratorExit:
+                            raise
+                        except BaseException as e:
+                            sends[i], messages[i] = iter_throws[i], e
+
+                if all(waiting[i] or completed[i] for i in active_coros):
+                    yield  # Allow event loop to process other tasks
+        finally:
+            # Ensure all coroutines are properly closed
+            close_exceptions = []
+            for i, is_completed in enumerate(completed):
+                if not is_completed:
+                    try:
+                        coro_iters[i].close()
+                    except Exception as e:
+                        close_exceptions.append((i, e))
+
+            # If any exceptions occurred during closing, raise a RuntimeError with details
+            if close_exceptions:
+                error_msg = 'Exceptions occurred while closing coroutines:\n'
+                error_msg += '\n'.join(f'Coroutine {i}: {e}' for i, e in close_exceptions)
+                raise RuntimeError(error_msg)

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -118,7 +118,7 @@ async def test_parallelize(automator: Automator):
 
     events.clear()
     automator.start(rosys.automation.parallelize(slow(), fast(), return_when_first_completed=True))
-    await forward(seconds=15)
+    await forward(seconds=10)
     assert events == [
         'slow 0',
         'fast 0',

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -95,3 +95,49 @@ async def test_finally_block(automator: Automator):
     automator.stop(because='test')
     await forward(seconds=1)
     assert events == ['tick', 'tick', 'tick', 'tick', 'tock']
+
+
+async def test_parallelize(automator: Automator):
+    events: list[str] = []
+
+    async def slow():
+        for i in range(5):
+            events.append(f'slow {i}')
+            await rosys.sleep(0.5)
+
+    async def fast():
+        for i in range(5):
+            events.append(f'fast {i}')
+            await rosys.sleep(0.2)
+
+    events.clear()
+    automator.start(rosys.automation.parallelize(slow(), fast(), return_when_first_completed=True))
+    await forward(seconds=10)
+    assert events == [
+        'slow 0',
+        'fast 0',
+        'fast 1',
+        'fast 2',
+        'slow 1',
+        'fast 3',
+        'fast 4',
+        'slow 2',
+    ]
+    assert automator.is_stopped
+
+    events.clear()
+    automator.start(rosys.automation.parallelize(slow(), fast(), return_when_first_completed=False))
+    await forward(seconds=10)
+    assert events == [
+        'slow 0',
+        'fast 0',
+        'fast 1',
+        'fast 2',
+        'slow 1',
+        'fast 3',
+        'fast 4',
+        'slow 2',
+        'slow 3',
+        'slow 4',
+    ]
+    assert automator.is_stopped


### PR DESCRIPTION
We noticed that `rosys.automation.parallelize()` called both coroutines by turns, independent if one of them is sleeping longer than the other, slowing down the faster one. Here is an example:

```py
import rosys
from nicegui import ui

async def slow():
    for i in range(10):
        print(f'slow {i}')
        await rosys.sleep(0.5)

async def fast():
    for i in range(50):
        print(f'fast {i}')
        await rosys.sleep(0.1)

async def parallel():
    await rosys.automation.parallelize(slow(), fast(), return_when_first_completed=True)

automator = rosys.automation.Automator(None)
ui.button('Run', on_click=lambda: automator.start(parallel()))

ui.run()
```

This PR fixes this issue with the help of Claude AI by keeping track of waiting and completed futures.

It also adds a pytest. But even though it tests the general behavior of the `parallelize` class, it isn't able to reproduce the original problem, probably due to the way RoSys speeds up sleeping tasks within pytests. So it's best to verify this PR with the above-mentioned code snippet.