### PR TITLE
Allow images up to 10 mb for the detector

### DIFF
--- a/rosys/vision/detector_hardware.py
+++ b/rosys/vision/detector_hardware.py
@@ -16,7 +16,8 @@ class DetectorHardware(Detector):
     """This detector communicates with a [YOLO detector](https://hub.docker.com/r/zauberzeug/yolov5-detector) via Socket.IO.
 
     It automatically connects and reconnects, submits and receives detections and sends images that should be uploaded to the [Zauberzeug Learning Loop](https://zauberzeug.com/products/learning-loop).
-    NOTE: images must be smaller than MAX_IMAGE_SIZE (default: 10 MB).
+
+    Note: Images must be smaller than ``MAX_IMAGE_SIZE`` bytes (default: 10 MB).
     """
     MAX_IMAGE_SIZE = 10 * 1024 * 1024
 
@@ -89,7 +90,7 @@ class DetectorHardware(Detector):
             self.uploads.priority_queue.clear()
 
     async def upload(self, image: Image, *, tags: list[str] | None = None) -> None:
-        assert len(image.data) < self.MAX_IMAGE_SIZE, f'image too large: {len(image.data)}'
+        assert len(image.data or []) < self.MAX_IMAGE_SIZE, f'image too large: {len(image.data or [])}'
         tags = tags or []
         try:
             self.log.info('Upload detections to port %s', self.port)
@@ -112,7 +113,7 @@ class DetectorHardware(Detector):
                      autoupload: Autoupload = Autoupload.FILTERED,
                      tags: list[str] | None = None,
                      ) -> Detections | None:
-        assert len(image.data) < self.MAX_IMAGE_SIZE, f'image too large: {len(image.data)}'
+        assert len(image.data or []) < self.MAX_IMAGE_SIZE, f'image too large: {len(image.data or [])}'
         tags = tags or []
         return await self.lazy_worker.run(self._detect(image, autoupload, tags))
 


### PR DESCRIPTION
The detector disconnects/reconnects and does not provide proper detections if the image is too big. This is caused by the default message size of 1 MB in the Detector container. This PR increases the default for RoSys to 10 MB.