### PR TITLE
Rename integration fixture to "rosys_integration"

### DIFF
--- a/rosys/testing/fixtures.py
+++ b/rosys/testing/fixtures.py
@@ -17,7 +17,7 @@ from rosys.testing import helpers, log_configuration
 
 
 @pytest.fixture
-async def integration() -> AsyncGenerator:
+async def rosys_integration() -> AsyncGenerator:
     log_configuration.setup()
     core.loop = asyncio.get_event_loop()
     rosys.reset_before_test()
@@ -28,29 +28,29 @@ async def integration() -> AsyncGenerator:
 
 
 @pytest.fixture
-async def odometer(wheels: Wheels, integration: None) -> Odometer:
+async def odometer(wheels: Wheels, rosys_integration: None) -> Odometer:
     helpers.odometer = Odometer(wheels)
     return helpers.odometer
 
 
 @pytest.fixture
-async def wheels(integration: None) -> Wheels:
+async def wheels(rosys_integration: None) -> Wheels:
     return WheelsSimulation()
 
 
 @pytest.fixture
-async def robot(wheels: Wheels, integration: None) -> Robot:
+async def robot(wheels: Wheels, rosys_integration: None) -> Robot:
     return RobotSimulation([wheels])
 
 
 @pytest.fixture
-async def driver(wheels: Wheels, odometer: Odometer, integration: None) -> Driver:
+async def driver(wheels: Wheels, odometer: Odometer, rosys_integration: None) -> Driver:
     helpers.driver = Driver(wheels, odometer)
     return helpers.driver
 
 
 @pytest.fixture
-async def automator(wheels: Wheels, integration: None) -> Automator:
+async def automator(wheels: Wheels, rosys_integration: None) -> Automator:
     helpers.automator = Automator(None, on_interrupt=wheels.stop)
     return helpers.automator
 
@@ -61,12 +61,12 @@ def shape() -> Prism:
 
 
 @pytest.fixture
-async def path_planner(shape: Prism, integration: None) -> PathPlanner:
+async def path_planner(shape: Prism, rosys_integration: None) -> PathPlanner:
     return PathPlanner(shape)
 
 
 @pytest.fixture
-async def kpi_logger(integration: None) -> KpiLogger:
+async def kpi_logger(rosys_integration: None) -> KpiLogger:
     return KpiLogger()
 
 

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -6,7 +6,7 @@ import pytest
 from rosys.vision import RtspCamera, RtspCameraProvider, SimulatedCamera, UsbCamera, UsbCameraProvider
 
 
-async def test_simulated_camera(integration):
+async def test_simulated_camera(rosys_integration):
     camera = SimulatedCamera(id='test_cam', width=800, height=600, streaming=False)
     await camera.connect()
     assert camera.is_connected
@@ -16,7 +16,7 @@ async def test_simulated_camera(integration):
     assert camera.images[0].size.height == 600
 
 
-async def test_usb_camera(integration):
+async def test_usb_camera(rosys_integration):
     if platform.system() != 'Linux':
         pytest.skip('UsbCamera is only supported on Linux.')
     connected_uids = list(await UsbCameraProvider.scan_for_cameras())
@@ -29,7 +29,7 @@ async def test_usb_camera(integration):
     assert len(camera.images) == 1
 
 
-async def test_rtsp_camera(integration):
+async def test_rtsp_camera(rosys_integration):
     try:
         connected_uids = await RtspCameraProvider.scan_for_cameras()
     except Exception as e:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -48,7 +48,7 @@ async def test_registering_lambdas():
     assert numbers == [42]
 
 
-@pytest.mark.usefixtures('integration')
+@pytest.mark.usefixtures('rosys_integration')
 async def test_fire_and_forget_with_emit():
 
     async def handle_event(number: int) -> None:

--- a/tests/test_mjpeg_camera.py
+++ b/tests/test_mjpeg_camera.py
@@ -7,7 +7,7 @@ from rosys.vision import MjpegCamera, MjpegCameraProvider
 from rosys.vision.mjpeg_camera.vendors import VendorType, mac_to_vendor
 
 
-async def test_mjpeg_camera(integration):
+async def test_mjpeg_camera(rosys_integration):
     try:
         connected_uids = await MjpegCameraProvider().scan_for_cameras()
     except Exception as e:
@@ -26,7 +26,7 @@ async def test_mjpeg_camera(integration):
 
 
 @pytest_asyncio.fixture()
-async def motec_settings_interface(integration):
+async def motec_settings_interface(rosys_integration):
     try:
         connected_uids = await MjpegCameraProvider().scan_for_cameras()
     except Exception as e:

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -4,7 +4,7 @@ import rosys
 from rosys.testing import forward
 
 
-@pytest.mark.usefixtures('integration')
+@pytest.mark.usefixtures('rosys_integration')
 async def test_time():
     assert rosys.time() == 0.0
 
@@ -21,7 +21,7 @@ async def test_time():
     assert rosys.uptime() == pytest.approx(5.0, abs=0.1)
 
 
-@pytest.mark.usefixtures('integration')
+@pytest.mark.usefixtures('rosys_integration')
 async def test_sleep():
     assert rosys.time() == 0.0
     sleep = rosys.background_tasks.create(rosys.sleep(1.0))


### PR DESCRIPTION
Since we provide an entry point for the RoSys pytest plugin, we decided to use a more discriminative name.