### PR TITLE
Add relative_direction function to Pose

### DIFF
--- a/rosys/geometry/pose.py
+++ b/rosys/geometry/pose.py
@@ -8,6 +8,7 @@ import numpy as np
 from .line import Line
 from .point import Point
 from .point3d import Point3d
+from ..helpers import angle
 
 
 @dataclass(slots=True, kw_only=True)
@@ -78,6 +79,15 @@ class Pose:
 
     def direction(self, other: Point | Pose) -> float:
         return float(np.arctan2(other.y - self.y, other.x - self.x))
+
+    @overload
+    def relative_direction(self, other: Point) -> float: ...
+
+    @overload
+    def relative_direction(self, other: Pose) -> float: ...
+
+    def relative_direction(self, other: Point | Pose) -> float:
+        return angle(self.yaw, self.direction(other))
 
     def __iadd__(self, step: PoseStep) -> Pose:
         self.x += step.linear * np.cos(self.yaw)

--- a/rosys/geometry/pose.py
+++ b/rosys/geometry/pose.py
@@ -5,10 +5,10 @@ from typing import overload
 
 import numpy as np
 
+from .. import helpers
 from .line import Line
 from .point import Point
 from .point3d import Point3d
-from ..helpers import angle as helpers_angle
 
 
 @dataclass(slots=True, kw_only=True)
@@ -87,7 +87,7 @@ class Pose:
     def relative_direction(self, other: Pose) -> float: ...
 
     def relative_direction(self, other: Point | Pose) -> float:
-        return helpers_angle(self.yaw, self.direction(other))
+        return helpers.angle(self.yaw, self.direction(other))
 
     def __iadd__(self, step: PoseStep) -> Pose:
         self.x += step.linear * np.cos(self.yaw)

--- a/rosys/geometry/pose.py
+++ b/rosys/geometry/pose.py
@@ -8,7 +8,7 @@ import numpy as np
 from .line import Line
 from .point import Point
 from .point3d import Point3d
-from ..helpers import angle
+from ..helpers import angle as helpers_angle
 
 
 @dataclass(slots=True, kw_only=True)
@@ -87,7 +87,7 @@ class Pose:
     def relative_direction(self, other: Pose) -> float: ...
 
     def relative_direction(self, other: Point | Pose) -> float:
-        return angle(self.yaw, self.direction(other))
+        return helpers_angle(self.yaw, self.direction(other))
 
     def __iadd__(self, step: PoseStep) -> Pose:
         self.x += step.linear * np.cos(self.yaw)


### PR DESCRIPTION
I wanted to know how much the robot has to turn to face a target.
You first have to get the direction to the target and then calculate the difference between the direction and your robot's current yaw.
This PR combines this approach in the `Pose.relative_direction(Point | Pose)` function to make it more easily available.

@falkoschindler the angle parameter of `rotate(self, angle: float)` collides with `rosys.helpers.angle`. I imported it as `helpers_angle` for now, but I don't really like it.