### PR TITLE
Remove run.cpu_bound for rotation computation

### DIFF
--- a/rosys/vision/camera_objects_.py
+++ b/rosys/vision/camera_objects_.py
@@ -74,11 +74,7 @@ class CameraObjects(Group):
                             camera.calibration.intrinsics.matrix[0][0] / self.px_per_m,
                         )
             camera_groups[uid].move(*camera.calibration.extrinsics.translation)
-            camera_groups[uid].rotate_R(await run.cpu_bound(self.get_rotation, camera.calibration))
-
-    @staticmethod
-    def get_rotation(calibration: Calibration) -> list[list[float]]:
-        return calibration.extrinsics.resolve().rotation.R  # computing euler rotation is cpu expensive
+            camera_groups[uid].rotate_R(camera.calibration.extrinsics.resolve().rotation.R)
 
     async def update_images(self) -> None:
         newest_images = [camera.latest_captured_image

--- a/rosys/vision/camera_objects_.py
+++ b/rosys/vision/camera_objects_.py
@@ -5,7 +5,6 @@ from nicegui.elements.scene_objects import Cylinder, Group, Text, Texture
 
 from .. import run
 from .calibratable_camera_provider import CalibratableCameraProvider
-from .calibration import Calibration
 from .camera import CalibratableCamera
 from .camera_projector import CameraProjector
 


### PR DESCRIPTION
Caused by #153, resolving the frame on a different process fails:

```
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.11/3.11.7_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/concurrent/futures/process.py", line 261, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rodja/Projects/rosys/rosys/vision/camera_objects_.py", line 81, in get_rotation
    return calibration.extrinsics.resolve().rotation.R  # computing euler rotation is cpu expensive
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rodja/Projects/rosys/rosys/geometry/object3d.py", line 42, in resolve
    return self.relative_to(None)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rodja/Projects/rosys/rosys/geometry/object3d.py", line 36, in relative_to
    return self.transform_with(frame_registry[self._frame_id].resolve())
                               ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'odometer'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/rodja/Projects/nicegui/nicegui/elements/timer.py", line 96, in _invoke_callback
    await result
  File "/Users/rodja/Projects/rosys/rosys/vision/camera_objects_.py", line 51, in update
    await self.update_cameras()
  File "/Users/rodja/Projects/rosys/rosys/vision/camera_objects_.py", line 77, in update_cameras
    camera_groups[uid].rotate_R(await run.cpu_bound(self.get_rotation, camera.calibration))
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rodja/Projects/rosys/rosys/run.py", line 52, in cpu_bound
    return await loop.run_in_executor(process_pool, callback, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'odometer'
```

As far as I can see, accessing the properties is not cpu intensive. Hence the code could be simplified.