### PR TITLE
Add `SimulatedCalibratableCamera`

### DIFF
--- a/docs/src/example_coordinate_frames.py
+++ b/docs/src/example_coordinate_frames.py
@@ -5,12 +5,7 @@ from nicegui import ui
 
 import rosys
 from rosys.geometry import Pose3d, Rotation
-from rosys.vision import CalibratableCamera, CameraSceneObject, SimulatedCamera
-
-
-class SimulatedCalibratableCamera(SimulatedCamera, CalibratableCamera):
-    pass
-
+from rosys.vision import CameraSceneObject, SimulatedCalibratableCamera
 
 blue = Pose3d(z=0.5).as_frame('blue')
 pink = Pose3d(z=0.75).as_frame('pink').in_frame(blue)

--- a/rosys/vision/__init__.py
+++ b/rosys/vision/__init__.py
@@ -13,7 +13,7 @@ from .image import Image, ImageSize
 from .mjpeg_camera import MjpegCamera, MjpegCameraProvider
 from .multi_camera_provider import MultiCameraProvider
 from .rtsp_camera import RtspCamera, RtspCameraProvider
-from .simulated_camera import SimulatedCamera, SimulatedCameraProvider
+from .simulated_camera import SimulatedCalibratableCamera, SimulatedCamera, SimulatedCameraProvider
 from .usb_camera import UsbCamera, UsbCameraProvider
 
 __all__ = [
@@ -44,6 +44,7 @@ __all__ = [
     'RtspCamera',
     'RtspCameraProvider',
     'SimulatedCamera',
+    'SimulatedCalibratableCamera',
     'SimulatedCameraProvider',
     'UsbCamera',
     'UsbCameraProvider',

--- a/rosys/vision/simulated_camera/__init__.py
+++ b/rosys/vision/simulated_camera/__init__.py
@@ -1,7 +1,14 @@
+from ..camera import CalibratableCamera
 from .simulated_camera import SimulatedCamera
 from .simulated_camera_provider import SimulatedCameraProvider
+
+
+class SimulatedCalibratableCamera(SimulatedCamera, CalibratableCamera):
+    pass
+
 
 __all__ = [
     'SimulatedCamera',
     'SimulatedCameraProvider',
+    'SimulatedCalibratableCamera',
 ]

--- a/rosys/vision/simulated_camera/__init__.py
+++ b/rosys/vision/simulated_camera/__init__.py
@@ -1,11 +1,6 @@
-from ..camera import CalibratableCamera
+from .simulated_calibratable_camera import SimulatedCalibratableCamera
 from .simulated_camera import SimulatedCamera
 from .simulated_camera_provider import SimulatedCameraProvider
-
-
-class SimulatedCalibratableCamera(SimulatedCamera, CalibratableCamera):
-    pass
-
 
 __all__ = [
     'SimulatedCamera',

--- a/rosys/vision/simulated_camera/simulated_calibratable_camera.py
+++ b/rosys/vision/simulated_camera/simulated_calibratable_camera.py
@@ -1,0 +1,6 @@
+from ..camera import CalibratableCamera
+from .simulated_camera import SimulatedCamera
+
+
+class SimulatedCalibratableCamera(SimulatedCamera, CalibratableCamera):
+    pass


### PR DESCRIPTION
To avoid rewriting the very simple implementation of a `SimulatedCalibratableCamera` in every project, this PR adds it to `rosys.vision`.

~~NOTE: due to circular dependencies, the implementation was placed in the `__init__.py`.~~