### PR TITLE
Do not stop after driving a spline

### DIFF
--- a/examples/hello_bot/main.py
+++ b/examples/hello_bot/main.py
@@ -20,11 +20,11 @@ from rosys.hardware import (
 
 
 async def drive_square():
-    corner_0: Point = Point(x=0.0, y=0.0)
-    corner_1: Point = Point(x=4.0, y=0.0)
-    corner_2: Point = Point(x=4.0, y=4.0)
-    corner_3: Point = Point(x=0.0, y=4.0)
-    path: list[PathSegment] = [
+    corner_0 = Point(x=0.0, y=0.0)
+    corner_1 = Point(x=4.0, y=0.0)
+    corner_2 = Point(x=4.0, y=4.0)
+    corner_3 = Point(x=0.0, y=4.0)
+    path = [
         PathSegment(spline=Spline.from_points(start=corner_0, end=corner_1)),
         PathSegment(spline=Spline.from_points(start=corner_1, end=corner_2)),
         PathSegment(spline=Spline.from_points(start=corner_2, end=corner_3)),

--- a/examples/hello_bot/main.py
+++ b/examples/hello_bot/main.py
@@ -6,8 +6,8 @@ from nicegui import ui
 
 import rosys
 from rosys.automation import Automator, automation_controls
-from rosys.driving import Driver, Odometer, Steerer, joystick, keyboard_control, robot_object, PathSegment
-from rosys.geometry import Prism, Spline, Point
+from rosys.driving import Driver, Odometer, PathSegment, Steerer, joystick, keyboard_control, robot_object
+from rosys.geometry import Point, Prism, Spline
 from rosys.hardware import (
     CanHardware,
     RobotBrain,
@@ -19,18 +19,13 @@ from rosys.hardware import (
 )
 
 
-async def drive_square():
-    corner_0 = Point(x=0.0, y=0.0)
-    corner_1 = Point(x=4.0, y=0.0)
-    corner_2 = Point(x=4.0, y=4.0)
-    corner_3 = Point(x=0.0, y=4.0)
-    path = [
-        PathSegment(spline=Spline.from_points(start=corner_0, end=corner_1)),
-        PathSegment(spline=Spline.from_points(start=corner_1, end=corner_2)),
-        PathSegment(spline=Spline.from_points(start=corner_2, end=corner_3)),
-        PathSegment(spline=Spline.from_points(start=corner_3, end=corner_0)),
-    ]
-    await driver.drive_path(path, stop_at_end=True)
+async def drive_square() -> None:
+    await driver.drive_path([
+        PathSegment(spline=Spline.from_points(Point(x=0, y=0), Point(x=4, y=0))),
+        PathSegment(spline=Spline.from_points(Point(x=4, y=0), Point(x=4, y=4))),
+        PathSegment(spline=Spline.from_points(Point(x=4, y=4), Point(x=0, y=4))),
+        PathSegment(spline=Spline.from_points(Point(x=0, y=4), Point(x=0, y=0))),
+    ], stop_at_end=True)
 
 log_configuration.setup()
 

--- a/examples/hello_bot/main.py
+++ b/examples/hello_bot/main.py
@@ -6,8 +6,8 @@ from nicegui import ui
 
 import rosys
 from rosys.automation import Automator, automation_controls
-from rosys.driving import Driver, Odometer, Steerer, joystick, keyboard_control, robot_object
-from rosys.geometry import Prism
+from rosys.driving import Driver, Odometer, Steerer, joystick, keyboard_control, robot_object, PathSegment
+from rosys.geometry import Prism, Spline, Point
 from rosys.hardware import (
     CanHardware,
     RobotBrain,
@@ -17,6 +17,16 @@ from rosys.hardware import (
     WheelsHardware,
     WheelsSimulation,
 )
+
+
+async def drive_square():
+    path: list[PathSegment] = [
+        PathSegment(spline=Spline.from_points(start=Point(x=0.0, y=0.0), end=Point(x=4.0, y=0.0))),
+        PathSegment(spline=Spline.from_points(start=Point(x=4.0, y=0.0), end=Point(x=4.0, y=4.0))),
+        PathSegment(spline=Spline.from_points(start=Point(x=4.0, y=4.0), end=Point(x=0.0, y=4.0))),
+        PathSegment(spline=Spline.from_points(start=Point(x=0.0, y=4.0), end=Point(x=0.0, y=0.0))),
+    ]
+    await driver.drive_path(path, stop_at_end=True)
 
 log_configuration.setup()
 
@@ -34,7 +44,7 @@ else:
 steerer = Steerer(wheels)
 odometer = Odometer(wheels)
 driver = Driver(wheels, odometer)
-automator = Automator(steerer, default_automation=driver.drive_square, on_interrupt=wheels.stop)
+automator = Automator(steerer, default_automation=drive_square, on_interrupt=wheels.stop)
 
 # ui
 with ui.card():

--- a/examples/hello_bot/main.py
+++ b/examples/hello_bot/main.py
@@ -20,11 +20,15 @@ from rosys.hardware import (
 
 
 async def drive_square():
+    corner_0: Point = Point(x=0.0, y=0.0)
+    corner_1: Point = Point(x=4.0, y=0.0)
+    corner_2: Point = Point(x=4.0, y=4.0)
+    corner_3: Point = Point(x=0.0, y=4.0)
     path: list[PathSegment] = [
-        PathSegment(spline=Spline.from_points(start=Point(x=0.0, y=0.0), end=Point(x=4.0, y=0.0))),
-        PathSegment(spline=Spline.from_points(start=Point(x=4.0, y=0.0), end=Point(x=4.0, y=4.0))),
-        PathSegment(spline=Spline.from_points(start=Point(x=4.0, y=4.0), end=Point(x=0.0, y=4.0))),
-        PathSegment(spline=Spline.from_points(start=Point(x=0.0, y=4.0), end=Point(x=0.0, y=0.0))),
+        PathSegment(spline=Spline.from_points(start=corner_0, end=corner_1)),
+        PathSegment(spline=Spline.from_points(start=corner_1, end=corner_2)),
+        PathSegment(spline=Spline.from_points(start=corner_2, end=corner_3)),
+        PathSegment(spline=Spline.from_points(start=corner_3, end=corner_0)),
     ]
     await driver.drive_path(path, stop_at_end=True)
 

--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -83,9 +83,9 @@ class Driver:
         """Drives the robot to the specified target point.
 
         :param target: The target point to drive to.
-        :param backward: If True, drives the robot in the opposite direction. Defaults to False.
-        :param throttle_at_end: Whether to throttle down when approaching the target. Defaults to True.
-        :param stop_at_end: Whether to stop at the end of the drive. Defaults to True.
+        :param backward: If True, drives the robot in the opposite direction.
+        :param throttle_at_end: Whether to throttle down when approaching the target.
+        :param stop_at_end: Whether to stop at the end of the drive.
         """
         if self.parameters.minimum_turning_radius:
             await self.drive_circle(target, backward)
@@ -104,7 +104,7 @@ class Driver:
         """Drives the robot in a circular path until the angle between the robot's current direction and the target direction is less than 5 degrees.
 
         :param target: The target point to drive towards.
-        :param backward: If True, drives the robot in the opposite direction. Defaults to False.
+        :param backward: If True, drives the robot in the opposite direction.
         :param stop_at_end: If True, stops the robot at the end of the circular path. Important: in contrast to the other functions, this defaults to False.
         :raises: DrivingAbortedException: If the driving process is aborted.
         """
@@ -133,9 +133,9 @@ class Driver:
         """Drives the robot along a given spline.
 
         :param spline: The spline to drive along.
-        :param flip_hook: Whether to flip the hook offset. Defaults to False.
-        :param throttle_at_end: Whether to throttle down when approaching the target. Defaults to True.
-        :param stop_at_end: Whether to stop at the end of the drive. Defaults to True.
+        :param flip_hook: Whether to flip the hook offset.
+        :param throttle_at_end: Whether to throttle down when approaching the target.
+        :param stop_at_end: Whether to stop at the end of the drive.
         :raises DrivingAbortedException: If the driving process is aborted.
         """
         if spline.start.distance(spline.end) < 0.01:

--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Protocol
 

--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -70,26 +70,22 @@ class Driver:
 
     @track
     async def drive_path(self, path: list[PathSegment], stop_at_end: bool = False) -> None:
-        """
-        Drives along the given path composed of PathSegments.
-        Args:
-            path (list[PathSegment]): The path to drive along, composed of PathSegments.
-            stop_at_end (bool, optional): Whether to stop after each segment. Defaults to False, but does stop at the end of the path.
-        Returns:
-            None
+        """Drives along the given path composed of PathSegments.
+
+        :param path: The path to drive along, composed of PathSegments.
+        :param stop_at_end: Whether to stop after each segment. Defaults to False, but does stop at the end of the path.
         """
         for segment in path:
             await self.drive_spline(segment.spline, throttle_at_end=segment == path[-1], flip_hook=segment.backward, stop_at_end=stop_at_end or segment == path[-1])
 
     @track
     async def drive_to(self, target: Point, backward: bool = False, throttle_at_end: bool = True, stop_at_end: bool = True) -> None:
-        """
-        Drives the robot to the specified target point.
-        Args:
-            target (Point): The target point to drive to.
-            backward (bool, optional): If True, drives the robot in the opposite direction. Defaults to False.
-            throttle_at_end (bool, optional): Whether to throttle down when approaching the target. Defaults to True.
-            stop_at_end (bool, optional): Whether to stop at the end of the drive. Defaults to True.
+        """Drives the robot to the specified target point.
+
+        :param target: The target point to drive to.
+        :param backward: If True, drives the robot in the opposite direction. Defaults to False.
+        :param throttle_at_end: Whether to throttle down when approaching the target. Defaults to True.
+        :param stop_at_end: Whether to stop at the end of the drive. Defaults to True.
         """
         if self.parameters.minimum_turning_radius:
             await self.drive_circle(target, backward)
@@ -105,17 +101,12 @@ class Driver:
 
     @track
     async def drive_circle(self, target: Point, backward: bool = False, stop_at_end: bool = False) -> None:
-        """
-        Drives the robot in a circular path until the angle between the robot's current direction and the target direction
-        is less than 5 degrees.
-        Args:
-            target (Point): The target point to drive towards.
-            backward (bool, optional): If True, drives the robot in the opposite direction. Defaults to False.
-            stop_at_end (bool, optional): If True, stops the robot at the end of the circular path. Important: in contrast to the other functions, this defaults to False.
-        Raises:
-            DrivingAbortedException: If the driving process is aborted.
-        Returns:
-            None
+        """Drives the robot in a circular path until the angle between the robot's current direction and the target direction is less than 5 degrees.
+
+        :param target: The target point to drive towards.
+        :param backward: If True, drives the robot in the opposite direction. Defaults to False.
+        :param stop_at_end: If True, stops the robot at the end of the circular path. Important: in contrast to the other functions, this defaults to False.
+        :raises: DrivingAbortedException: If the driving process is aborted.
         """
         while True:
             if self._abort:
@@ -139,17 +130,13 @@ class Driver:
 
     @track
     async def drive_spline(self, spline: Spline, *, flip_hook: bool = False, throttle_at_end: bool = True, stop_at_end: bool = True) -> None:
-        """
-        Drives the robot along a given spline.
-        Args:
-            spline (Spline): The spline to drive along.
-            flip_hook (bool, optional): Whether to flip the hook offset. Defaults to False.
-            throttle_at_end (bool, optional): Whether to throttle down when approaching the target. Defaults to True.
-            stop_at_end (bool, optional): Whether to stop at the end of the drive. Defaults to True.
-        Raises:
-            DrivingAbortedException: If the driving process is aborted.
-        Returns:
-            None
+        """Drives the robot along a given spline.
+
+        :param spline: The spline to drive along.
+        :param flip_hook: Whether to flip the hook offset. Defaults to False.
+        :param throttle_at_end: Whether to throttle down when approaching the target. Defaults to True.
+        :param stop_at_end: Whether to stop at the end of the drive. Defaults to True.
+        :raises DrivingAbortedException: If the driving process is aborted.
         """
         if spline.start.distance(spline.end) < 0.01:
             return  # NOTE: skip tiny splines

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -8,26 +8,6 @@ from rosys.hardware import Robot
 from rosys.testing import assert_pose, forward
 
 
-async def test_driving_an_arc(driver: Driver, automator: Automator, robot: Robot):
-    assert_pose(0, 0, deg=0)
-    automator.start(driver.drive_arc())
-    await forward(x=2)
-    assert_pose(2, 1, deg=56)
-
-
-async def test_driving_a_square(driver: Driver, automator: Automator, robot: Robot):
-    assert_pose(0, 0, deg=0)
-    automator.start(driver.drive_square())
-    await forward(x=1)
-    assert_pose(1, 0, deg=0)
-    await forward(y=1)
-    assert_pose(1, 1, deg=90, deg_tolerance=3)
-    await forward(x=0)
-    assert_pose(0, 1, deg=180, deg_tolerance=3)
-    await forward(y=0)
-    assert_pose(0, 0, deg=270, deg_tolerance=3)
-
-
 async def test_pause_and_resume_spline(driver: Driver, automator: Automator, robot: Robot):
     spline = Spline.from_poses(Pose(x=0, y=0, yaw=0), Pose(x=2, y=0, yaw=0))
     automator.start(driver.drive_spline(spline))
@@ -41,20 +21,6 @@ async def test_pause_and_resume_spline(driver: Driver, automator: Automator, rob
     automator.resume()
     await forward(x=2)
     assert_pose(2, 0, deg=0)
-
-
-async def test_pause_and_resume_square(driver: Driver, automator: Automator, robot: Robot):
-    automator.start(driver.drive_square())
-    await forward(x=1)
-    assert_pose(1, 0, deg=0)
-
-    automator.pause(because='test')
-    await forward(seconds=1)
-    assert_pose(1, 0, deg=0)
-
-    automator.resume()
-    await forward(y=1)
-    assert_pose(1, 1, deg=90, deg_tolerance=3)
 
 
 @pytest.mark.parametrize('dx', [2, 10])


### PR DESCRIPTION
Our robot needs to drive continuously between two GNSS coordinates while adjusting its heading. For each segment we use `drive_spline`, but it stops after completing the spline drive.
This PR adds a parameter for not stopping at the end `stop_at_end` and does some refactoring in the `Driver` class