### PR TITLE
More modular functions to use for export and import of persistence modules

### DIFF
--- a/rosys/persistence/__init__.py
+++ b/rosys/persistence/__init__.py
@@ -3,7 +3,7 @@ from dataclasses_json import Exclude, config
 from .backup_schedule import BackupSchedule
 from .converters import from_dict, replace_dataclass, replace_dict, replace_list, replace_set, to_dict
 from .persistent_module import PersistentModule
-from .registry import backup, restore, write_export
+from .registry import backup, get_export, restore, restore_from_export, write_export
 from .ui import export_button, import_button
 
 exclude: dict[str, dict] = config(exclude=Exclude.ALWAYS)
@@ -20,6 +20,8 @@ __all__ = [
     'exclude',
     'backup',
     'restore',
+    'get_export',
+    'restore_from_export',
     'write_export',
     'export_button',
     'import_button',

--- a/rosys/persistence/registry.py
+++ b/rosys/persistence/registry.py
@@ -63,7 +63,6 @@ def restore() -> None:
 
 
 async def restore_from_export(export_data: dict) -> None:
-    assert isinstance(export_data, dict)
     for name, data in export_data.items():
         modules[name].restore(data)
     await backup(force=True)

--- a/rosys/persistence/registry.py
+++ b/rosys/persistence/registry.py
@@ -62,6 +62,17 @@ def restore() -> None:
             log.exception('failed to restore %s', module)
 
 
+async def restore_from_export(export_data: dict) -> None:
+    assert isinstance(export_data, dict)
+    for name, data in export_data.items():
+        modules[name].restore(data)
+    await backup(force=True)
+
+
+def get_export() -> dict:
+    return {name: module.backup() for name, module in modules.items()}
+
+
 def write_export(to_filepath: Path) -> None:
-    data = {name: module.backup() for name, module in modules.items()}
+    data = get_export()
     to_filepath.write_text(json.dumps(data, indent=4))

--- a/rosys/persistence/ui.py
+++ b/rosys/persistence/ui.py
@@ -19,11 +19,7 @@ def export_button(title: str = 'Export', route: str = '/export', tmp_filepath: P
 
 def import_button(title: str = 'Import', after_import: Callable | None = None) -> ui.button:
     async def restore_from_file(e: events.UploadEventArguments) -> None:
-        all_data = json.load(e.content)
-        assert isinstance(all_data, dict)
-        for name, data in all_data.items():
-            registry.modules[name].restore(data)
-        await registry.backup(force=True)
+        await registry.restore_from_export(json.load(e.content))
         dialog.close()
         if after_import is not None:
             await invoke(after_import)


### PR DESCRIPTION
This PR splits the existing functions for exporting and importing the persistence modules to be used in different contexts. The ui buttons and functions remain the same and use the new `get_export` and `restore_from_export` functions now.