### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-buster
+FROM python:3.12-bookworm
 
 RUN apt update && apt install -y \
     sudo vim less ack-grep rsync wget curl cmake arp-scan iproute2 iw python3-pip python3-autopep8 libgeos-dev graphviz graphviz-dev v4l-utils psmisc sysstat \
@@ -22,7 +22,7 @@ COPY pyproject.toml ./
 
 # Allow installing dev dependencies to run tests
 ARG INSTALL_DEV=true
-RUN bash -c "if [ $INSTALL_DEV == 'true' ] ; then poetry install -vvv --no-root ; else poetry install -vvv --no-root --no-dev ; fi"
+RUN bash -c "if [ $INSTALL_DEV == 'true' ] ; then poetry install -vvv --no-root --with dev ; else poetry install -vvv --no-root ; fi"
 
 # Fetch Lizard firmware + scripts for hardware control
 WORKDIR /root/.lizard
@@ -39,6 +39,7 @@ RUN pip install --no-cache prompt-toolkit
 WORKDIR /rosys
 COPY LICENSE README.md rosys.code-workspace ./
 ADD ./rosys /rosys/rosys
+RUN poetry install -vvv
 
 ENV PYTHONPATH "/rosys"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   rosys:
     image: "zauberzeug/rosys:${TAG-latest}"


### PR DESCRIPTION
This PR uses 3.12-bookworm as the base image since 3.12-buster isn't available. It also installs the optional dev dependencies and RoSys itself.