### PR TITLE
Fix camera and projector extrinsics in 3dScene

### DIFF
--- a/rosys/vision/camera_objects_.py
+++ b/rosys/vision/camera_objects_.py
@@ -23,6 +23,7 @@ class CameraObjects(Group):
                  *,
                  px_per_m: float = 10000,
                  debug: bool = False,
+                 interval: float = 1.0
                  ) -> None:
         super().__init__()
 
@@ -33,7 +34,7 @@ class CameraObjects(Group):
         self.textures: dict[str, Texture] = {}
         self.image_shrink_factor = 2
 
-        ui.timer(1.0, self.update)
+        ui.timer(interval, self.update)
 
     @property
     def calibrated_cameras(self) -> dict[str, CalibratableCamera]:
@@ -72,8 +73,9 @@ class CameraObjects(Group):
                             camera.calibration.intrinsics.size.height / self.px_per_m,
                             camera.calibration.intrinsics.matrix[0][0] / self.px_per_m,
                         )
-            camera_groups[uid].move(*camera.calibration.extrinsics.translation)
-            camera_groups[uid].rotate_R(camera.calibration.extrinsics.resolve().rotation.R)
+            world_extrinsics = camera.calibration.extrinsics.resolve()
+            camera_groups[uid].move(*world_extrinsics.translation)
+            camera_groups[uid].rotate_R(world_extrinsics.rotation.R)
 
     async def update_images(self) -> None:
         newest_images = [camera.latest_captured_image

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -24,12 +24,12 @@ class CameraProjector:
     It is mainly used for visualization purposes.
     """
 
-    def __init__(self, camera_provider: CalibratableCameraProvider) -> None:
+    def __init__(self, camera_provider: CalibratableCameraProvider, interval: float = 1.0) -> None:
         self.camera_provider = camera_provider
 
         self.projections: dict[str, Projection] = {}
 
-        rosys.on_repeat(self.step, 1.0)
+        rosys.on_repeat(self.step, interval)
 
     async def step(self) -> None:
         for id_ in list(self.projections):
@@ -38,8 +38,6 @@ class CameraProjector:
 
         for id_, camera in self.camera_provider.cameras.items():
             if not camera.calibration:
-                continue
-            if id_ in self.projections and self.projections[id_].camera_calibration == camera.calibration:
                 continue
             self.projections[id_] = Projection(
                 camera_id=id_,


### PR DESCRIPTION
Cameras in a 3dScene weren't moving correctly with the new transformation changes. This PR fixes both the camera and the camera projection movement.

Here is an example to test both:
```python
import math

import rosys
from nicegui import ui
from rosys.driving import Odometer, Steerer, joystick, keyboard_control, robot_object
from rosys.geometry import Prism
from rosys.hardware import RobotSimulation, WheelsSimulation
from rosys.vision import CameraProjector, SimulatedCalibratableCamera, camera_objects

shape = Prism.default_robot_shape()
wheels = WheelsSimulation()
robot = RobotSimulation([wheels])
odometer = Odometer(wheels)
steerer = Steerer(wheels)
camera_provider = rosys.vision.SimulatedCameraProvider()
camera_provider.remove_all_cameras()
camera = SimulatedCalibratableCamera.create_calibrated(id='Camera', roll=math.pi / 2, frame=odometer.prediction_frame)
camera_provider.add_camera(camera)
camera_projector = CameraProjector(camera_provider)
keyboard_control(steerer)
joystick(steerer, size=50, color='blue')
with ui.scene():
    robot_object(shape, odometer)
    camera_objects(camera_provider, camera_projector)

ui.run(title='RoSys')

```