### PR TITLE
add bitrate parameter to RTSP cameras

### DIFF
--- a/rosys/vision/rtsp_camera/jovision_rtsp_interface.py
+++ b/rosys/vision/rtsp_camera/jovision_rtsp_interface.py
@@ -150,7 +150,7 @@ class JovisionInterface:
             'cmd': json.dumps(cmd),
             '_': time.time() * 1000,
         }
-        response = requests.get(self.settings_url, params=params, headers=self.headers, timeout=1)
+        response = requests.get(self.settings_url, params=params, timeout=1)
 
         for stream_id, stream in enumerate(response.json()['result']['all']):
             print(f'stream {stream_id}')

--- a/rosys/vision/rtsp_camera/jovision_rtsp_interface.py
+++ b/rosys/vision/rtsp_camera/jovision_rtsp_interface.py
@@ -43,10 +43,6 @@ class JovisionInterface:
     def settings_url(self) -> str:
         return f'http://{self.ip}/cgi-bin/jvsweb.cgi'
 
-    @property
-    def headers(self) -> dict[str, str]:
-        return {'Cookie': 'passwdRule=1; username=admin; password=admin;'}
-
     def _send_settings(self, settings: list[JovisionCameraSettings]) -> None:
         """
         Set the settings for all streams
@@ -64,7 +60,6 @@ class JovisionInterface:
                 'digest': '479ead4555b49227dc8812d06970c652',
             },
             'param': {
-                'channelid': 0,
                 'streams': streams,
             },
         }
@@ -72,23 +67,39 @@ class JovisionInterface:
             'cmd': json.dumps(cmd),
             '_': int(time.time() * 1000),  # current time as a timestamp
         }
-        requests.get(self.settings_url, params=params, headers=self.headers, timeout=1)  # type: ignore
+        requests.get(self.settings_url, params=params, timeout=1)  # type: ignore
 
-    def set_fps(self, stream_id, fps) -> None:
+    def set_fps(self, stream_id: int, fps: int) -> None:
         current_settings = self.get_current_settings()
         for settings in current_settings:
             if settings.stream_id == stream_id:
-                settings.fps = fps
+                settings.fps = int(fps)
                 break
         self._send_settings(current_settings)
 
-    def get_fps(self, stream_id) -> int | None:
+    def get_fps(self, stream_id: int) -> int | None:
         current_settings = self.get_current_settings()
         for settings in current_settings:
             if settings.stream_id == stream_id:
                 return settings.fps
 
         return None
+
+    def get_bitrate(self, stream_id: int) -> int | None:
+        current_settings = self.get_current_settings()
+        for settings in current_settings:
+            if settings.stream_id == stream_id:
+                return settings.bitrate
+
+        return None
+
+    def set_bitrate(self, stream_id: int, bitrate: int) -> None:
+        current_settings = self.get_current_settings()
+        for settings in current_settings:
+            if settings.stream_id == stream_id:
+                settings.bitrate = int(bitrate)
+                break
+        self._send_settings(current_settings)
 
     def get_current_settings(self) -> list[JovisionCameraSettings]:
         cmd = {
@@ -105,7 +116,7 @@ class JovisionInterface:
             'cmd': json.dumps(cmd),
             '_': int(time.time() * 1000),
         }
-        response = requests.get(self.settings_url, params=params, headers=self.headers, timeout=1)  # type: ignore
+        response = requests.get(self.settings_url, params=params, timeout=1)  # type: ignore
 
         return [
             JovisionCameraSettings(

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -42,7 +42,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         self._register_parameter('fps', self.get_fps, self.set_fps,
                                  min_value=1, max_value=30, step=1, default_value=fps)
         self._register_parameter('bitrate', self.get_bitrate, self.set_bitrate,
-                                 min_value=256, max_value=8192, step=1, default_value=bitrate)
+                                 min_value=32, max_value=8192, step=1, default_value=bitrate)
 
     def to_dict(self) -> dict[str, Any]:
         return super().to_dict() | {

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -123,9 +123,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
     def set_jovision_profile(self, profile: int) -> None:
         assert self.device is not None
 
-        profile = max(self._parameters['jovision_profile'].info.min,
-                      min(profile, self._parameters['jovision_profile'].max_value))
-
         self.device.set_jovision_profile(profile)
 
     def get_jovision_profile(self) -> int | None:

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -38,7 +38,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         self.ip: str | None = ip
 
         self._register_parameter('jovision_profile', self.get_jovision_profile, self.set_jovision_profile,
-                                 min_value=1, max_value=2, step=1, default_value=jovision_profile)
+                                 min_value=0, max_value=1, step=1, default_value=jovision_profile)
         self._register_parameter('fps', self.get_fps, self.set_fps,
                                  min_value=1, max_value=30, step=1, default_value=fps)
         self._register_parameter('bitrate', self.get_bitrate, self.set_bitrate,
@@ -122,6 +122,9 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
     def set_jovision_profile(self, profile: int) -> None:
         assert self.device is not None
+
+        profile = max(self._parameters['jovision_profile'].info.min,
+                      min(profile, self._parameters['jovision_profile'].max_value))
 
         self.device.set_jovision_profile(profile)
 

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -21,6 +21,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
                  streaming: bool = True,
                  fps: int = 5,
                  jovision_profile: int = 1,
+                 bitrate: int = 4096,
                  ip: str | None = None,
                  **kwargs,
                  ) -> None:
@@ -40,6 +41,8 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
                                  min_value=1, max_value=2, step=1, default_value=jovision_profile)
         self._register_parameter('fps', self.get_fps, self.set_fps,
                                  min_value=1, max_value=30, step=1, default_value=fps)
+        self._register_parameter('bitrate', self.get_bitrate, self.set_bitrate,
+                                 min_value=256, max_value=8192, step=1, default_value=bitrate)
 
     def to_dict(self) -> dict[str, Any]:
         return super().to_dict() | {
@@ -126,6 +129,16 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         assert self.device is not None
 
         return self.device.get_jovision_profile()
+
+    def set_bitrate(self, bitrate: int) -> None:
+        assert self.device is not None
+
+        self.device.set_bitrate(bitrate)
+
+    def get_bitrate(self) -> int | None:
+        assert self.device is not None
+
+        return self.device.get_bitrate()
 
     async def _apply_parameters(self, new_values: dict[str, Any], force_set: bool = False) -> None:
         await super()._apply_parameters(new_values, force_set)

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -201,3 +201,12 @@ class RtspDevice:
 
     def get_jovision_profile(self) -> int:
         return self.jovision_profile
+
+    def set_bitrate(self, bitrate: int) -> None:
+        if self.settings_interface is not None:
+            self.settings_interface.set_bitrate(stream_id=self.jovision_profile, bitrate=bitrate)
+
+    def get_bitrate(self) -> int | None:
+        if self.settings_interface is not None:
+            return self.settings_interface.get_bitrate(stream_id=self.jovision_profile)
+        return None


### PR DESCRIPTION
Adds the bitrate as a parameter. The control was already supported through the jovision interface.

Aditionally, I have made some adjustments to the interface:

- username/ password in the header turned out not to be necessary
- some type hints were missing
- there was an extra channelid in the param dict
- the values to be set are easy to set as an incorrect type without noticing so I added a backup `int` cast