### PR TITLE
Fix calibration.project_to_image

### DIFF
--- a/rosys/geometry/rotation.py
+++ b/rosys/geometry/rotation.py
@@ -13,7 +13,7 @@ class Rotation:
 
     @staticmethod
     def zero() -> Rotation:
-        return Rotation(R=[[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+        return Rotation(R=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
     @staticmethod
     def from_euler(roll: float, pitch: float, yaw: float) -> Rotation:

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -186,7 +186,7 @@ class Calibration:
     def project_to_image(self, *args, **kwargs) -> Point | np.ndarray | None:
         if isinstance(args[0], Point3d):
             point: Point3d = args[0]
-            world_array = np.array([point.resolve().tuple], dtype=np.float32)
+            world_array = np.array([point.resolve().tuple], dtype=np.float64)
             image_array = self.project_to_image(world_array)
             if np.isnan(image_array).any():
                 return None
@@ -195,7 +195,7 @@ class Calibration:
         coordinates: np.ndarray = args[0]
         frame: Frame3d | None = kwargs.get('frame')
         world_extrinsics = self.extrinsics.relative_to(frame)
-        R = world_extrinsics.rotation.matrix.astype(np.float32)
+        R = world_extrinsics.rotation.matrix.astype(np.float64)
         Rod = cv2.Rodrigues(R.T)[0]
         t = -R.T @ world_extrinsics.translation
         K = np.array(self.intrinsics.matrix)

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -195,7 +195,7 @@ class Calibration:
         coordinates: np.ndarray = args[0]
         frame: Frame3d | None = kwargs.get('frame')
         world_extrinsics = self.extrinsics.relative_to(frame)
-        R = world_extrinsics.rotation.matrix
+        R = world_extrinsics.rotation.matrix.astype(np.float32)
         Rod = cv2.Rodrigues(R.T)[0]
         t = -R.T @ world_extrinsics.translation
         K = np.array(self.intrinsics.matrix)


### PR DESCRIPTION
While creating a calibration, I found that the zero-function of rosys.geometry.Rotation uses integers, which causes `cv2.Rodrigues` to fail, because it expects floats.
While using `.astype(np.float32)` helps, using floats directly makes it easier to use in the future.


```python
import cv2
import numpy as np
from rosys.geometry import Pose3d, Rotation

# works
extrinsics = Pose3d(x=0, y=0, z=0, rotation=Rotation(R=[[0, 0, 0], [0, 1, 0], [0, 0, 1]]))
R = extrinsics.rotation.matrix.astype(np.float32)
Rod = cv2.Rodrigues(R.T)[0]

# works
extrinsics = Pose3d(x=0.0, y=0.0, z=0.0, rotation=Rotation(R=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]))
R = extrinsics.rotation.matrix
Rod = cv2.Rodrigues(R.T)[0]

# doesn't work without the changes
extrinsics = Pose3d(x=0, y=0, z=0, rotation=Rotation(R=[[0, 0, 0], [0, 1, 0], [0, 0, 1]]))
R = extrinsics.rotation.matrix
Rod = cv2.Rodrigues(R.T)[0]
```

edit: float64 is needed for our tests