### PR TITLE
Add optional parameter for enabling startup ESP in RobotBrain

### DIFF
--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -1,5 +1,6 @@
 import logging
 from collections import deque
+from typing import Optional
 
 from nicegui import ui
 
@@ -22,7 +23,7 @@ class RobotBrain:
     If the offset changes significantly, a notification is sent and the offset history is cleared.
     """
 
-    def __init__(self, communication: Communication) -> None:
+    def __init__(self, communication: Communication, enable_startup_esp: Optional[bool] = True) -> None:
         self.LINE_RECEIVED = Event()
         """a line has been received from the microcontroller (argument: line as string)"""
         self.FLASH_P0_COMPLETE = Event()
@@ -38,8 +39,8 @@ class RobotBrain:
         self._clock_offset: float | None = None
         self._clock_offsets: deque[float] = deque(maxlen=CLOCK_OFFSET_HISTORY_LENGTH)
         self.hardware_time: float | None = None
-
-        rosys.on_startup(self.enable_esp)
+        if enable_startup_esp:
+            rosys.on_startup(self.enable_esp)
 
     @property
     def clock_offset(self) -> float | None:


### PR DESCRIPTION
The new Robot brains enable the esp on their own. When rosys sends the enable script it disables the esp.