### PR TITLE
Fix Point3d.transform_with

### DIFF
--- a/rosys/geometry/point3d.py
+++ b/rosys/geometry/point3d.py
@@ -59,4 +59,4 @@ class Point3d(Object3d):
 
     def transform_with(self, pose: Pose3d) -> Point3d:
         """Transform this pose with another pose."""
-        return Point3d.from_tuple(np.dot(pose.rotation.R, self.array) + pose.translation_vector)
+        return Point3d.from_tuple((np.dot(pose.rotation.R, self.array) + pose.translation_vector).flatten())


### PR DESCRIPTION
Both the dot product and the translation vector in `Point3d.transform_with` are 2D but need to be 1D for `Point3d.from_tuple`, which causes the coordinates to be np.arrays and not floats. https://github.com/zauberzeug/rosys/blob/e3ef8cf8ecfe092789699410cd659ecb471e6a2e/rosys/geometry/point3d.py#L62 

```python
import numpy as np
from rosys.geometry import Point3d, Pose3d, Rotation

point = Point3d(x=0.015, y=0.135, z=0.357)
pose = Pose3d(x=0.2965439264325891, y=-0.004233199581623145, z=0.3609662018089546,
              rotation=Rotation.from_euler(-138.1, -1.3, 89.9))

# works
new_point = Point3d.from_tuple((np.dot(pose.rotation.R, point.array) + pose.translation_vector).flatten())
print(new_point)
# Point3d(0.341, -0.366, 0.475)

# does not work
new_point = Point3d.from_tuple((np.dot(pose.rotation.R, point.array) + pose.translation_vector))
print(new_point)
# TypeError: unsupported format string passed to numpy.ndarray.__format__
```