### PR TITLE
Add focal length property to Intrinsics

### DIFF
--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -55,6 +55,11 @@ class Intrinsics:
         D: list[float] = [0] * 5
         return Intrinsics(matrix=K, distortion=D, size=size)
 
+    @property
+    def focal_length(self) -> float:
+        """The calculated focal length of the camera."""
+        return (self.matrix[0][0] + self.matrix[1][1]) / 2.0
+
 
 log = logging.getLogger('rosys.world.calibration')
 


### PR DESCRIPTION
This PR adds a property to the camera calibration intrinsics to get the focal length which is calculated from the camera matrix