### PR TITLE
Deprecate camera polling

### DIFF
--- a/docs/src/example_camera_control.py
+++ b/docs/src/example_camera_control.py
@@ -18,8 +18,6 @@ def add_card(camera: rosys.vision.Camera, container: ui.element) -> None:
                     streams[uid] = ui.interactive_image()
                     ui.label(uid).classes('m-2')
                     with ui.row():
-                        ui.switch('stream').bind_value(camera, 'streaming')
-                        ui.button('capture', on_click=camera.capture_image)
                         ui.button('disconnect', on_click=camera.disconnect).bind_enabled_from(camera, 'is_connected')
                     if isinstance(camera, rosys.vision.ConfigurableCamera):
                         create_camera_settings_panel(camera)


### PR DESCRIPTION
Since it is not used anymore, I would remove the whole camera polling feature. Some persistence dicts might still contain the polling parameter though, so this keeps it around but does not save it anymore, so that all persistence dicts will be corrected.