### PR TITLE
Camera image callbacks

### DIFF
--- a/docs/src/example_camera_control.py
+++ b/docs/src/example_camera_control.py
@@ -18,8 +18,6 @@ def add_card(camera: rosys.vision.Camera, container: ui.element) -> None:
                     streams[uid] = ui.interactive_image()
                     ui.label(uid).classes('m-2')
                     with ui.row():
-                        ui.switch('stream').bind_value(camera, 'streaming')
-                        ui.button('capture', on_click=camera.capture_image)
                         ui.button('disconnect', on_click=camera.disconnect).bind_enabled_from(camera, 'is_connected')
                     if isinstance(camera, rosys.vision.ConfigurableCamera):
                         create_camera_settings_panel(camera)

--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -64,7 +64,7 @@ class Camera(abc.ABC):
         return True
 
     @streaming.setter
-    def streaming(self, value: bool) -> None:
+    def streaming(self, value: bool) -> None:  # pylint: disable=unused-argument
         logger.warning('The `streaming` parameter is deprecated. All cameras now stream images by default.')
 
     @property
@@ -73,7 +73,7 @@ class Camera(abc.ABC):
         return 0.0
 
     @polling_interval.setter
-    def polling_interval(self, value: float) -> None:
+    def polling_interval(self, value: float) -> None:  # pylint: disable=unused-argument
         logger.warning('The `polling_interval` parameter is deprecated. All cameras should now use callbacks')
 
     def get_image_url(self, image: Image) -> str:

--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -25,8 +25,6 @@ class Camera(abc.ABC):
                  id: str,  # pylint: disable=redefined-builtin
                  name: str | None = None,
                  connect_after_init: bool = True,
-                 streaming: bool | None = None,
-                 polling_interval: float | None = None,
                  base_path_overwrite: str | None = None,
                  image_history_length: int = 256,
                  **kwargs) -> None:
@@ -37,10 +35,10 @@ class Camera(abc.ABC):
         self.images: deque[Image] = deque(maxlen=image_history_length)
         self.base_path: str = f'images/{base_path_overwrite or id}'
 
-        if streaming is not None:
-            logger.warning('The `streaming` parameter is deprecated. All cameras now stream images by default.')
-        if polling_interval is not None:
-            logger.warning('The `polling_interval` parameter is deprecated. All cameras should now use callbacks')
+        if 'streaming' in kwargs:
+            logger.warning('The `streaming` parameter has been removed. All cameras now stream images by default.')
+        if 'polling_interval' in kwargs:
+            logger.warning('The `polling_interval` parameter has been removed. All cameras should now use callbacks.')
 
         self.NEW_IMAGE: Event = Event()
 
@@ -60,21 +58,21 @@ class Camera(abc.ABC):
 
     @property
     def streaming(self) -> bool:
-        logger.warning('The `streaming` parameter is deprecated. All cameras now stream images by default.')
+        logger.warning('The `streaming` parameter has been removed. All cameras now stream images by default.')
         return True
 
     @streaming.setter
     def streaming(self, value: bool) -> None:  # pylint: disable=unused-argument
-        logger.warning('The `streaming` parameter is deprecated. All cameras now stream images by default.')
+        logger.warning('The `streaming` parameter has been removed. All cameras now stream images by default.')
 
     @property
     def polling_interval(self) -> float:
-        logger.warning('The `polling_interval` parameter is deprecated. All cameras should now use callbacks')
+        logger.warning('The `polling_interval` parameter has been removed. All cameras should now use callbacks.')
         return 0.0
 
     @polling_interval.setter
     def polling_interval(self, value: float) -> None:  # pylint: disable=unused-argument
-        logger.warning('The `polling_interval` parameter is deprecated. All cameras should now use callbacks')
+        logger.warning('The `polling_interval` parameter has been removed. All cameras should now use callbacks.')
 
     def get_image_url(self, image: Image) -> str:
         return f'{self.base_path}/{image.time}'
@@ -151,4 +149,4 @@ class Camera(abc.ABC):
         self.NEW_IMAGE.emit(image)
 
     async def capture_image(self) -> None:
-        raise DeprecationWarning('The `capture_image()` method is deprecated. All cameras should now use callbacks')
+        raise DeprecationWarning('The `capture_image()` method has been removed. All cameras should now use callbacks.')

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Callable, Awaitable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from .mjpeg_device import MjpegDevice

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from .mjpeg_device import MjpegDevice
@@ -24,10 +25,11 @@ class AxisMjpegDevice(MjpegDevice):
     def __init__(self, mac: str, ip: str, *,
                  index: int | None = None,
                  username: str | None = None,
-                 password: str | None = None) -> None:
+                 password: str | None = None,
+                 on_new_image: Callable[[bytes], None]) -> None:
         super().__init__(mac, ip,
                          index=index,
-                         username=username, password=password)
+                         username=username, password=password, on_new_image=on_new_image)
 
         self.axis_settings = AxisSettings(fps=6, resolution=(640, 480), mirrored=False)
 

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -26,10 +26,8 @@ class AxisMjpegDevice(MjpegDevice):
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image: Callable[[bytes], Awaitable | None]) -> None:
-        super().__init__(mac, ip,
-                         index=index,
-                         username=username, password=password, on_new_image=on_new_image)
+                 on_new_image_data: Callable[[bytes], Awaitable | None]) -> None:
+        super().__init__(mac, ip, index=index, username=username, password=password, on_new_image_data=on_new_image_data)
 
         self.axis_settings = AxisSettings(fps=6, resolution=(640, 480), mirrored=False)
 

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Awaitable
 from dataclasses import dataclass
 
 from .mjpeg_device import MjpegDevice
@@ -26,7 +26,7 @@ class AxisMjpegDevice(MjpegDevice):
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image: Callable[[bytes], None]) -> None:
+                 on_new_image: Callable[[bytes], Awaitable | None]) -> None:
         super().__init__(mac, ip,
                          index=index,
                          username=username, password=password, on_new_image=on_new_image)

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -75,7 +75,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
 
         try:
             self.device = MjpegDeviceFactory.create(self.mac, self.ip, index=self.index, username=self.username,
-                                                    password=self.password, on_new_image=self._image_data_callback)
+                                                    password=self.password, on_new_image_data=self._handle_new_image_data)
         except ValueError as error:
             self.log.error('Could not connect to device: %s', error)
             return
@@ -89,9 +89,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         self.device.shutdown()
         self.device = None
 
-    async def _image_data_callback(self, image_bytes: bytes) -> None:
-        image = image_bytes
-
+    async def _handle_new_image_data(self, image: bytes) -> None:
         if self.crop or self.rotation != ImageRotation.NONE:
             image = await rosys.run.cpu_bound(process_jpeg_image, image, self.rotation, self.crop)
         if image is None:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -28,7 +28,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
                  mirrored: bool = False,
                  **kwargs: Any,
                  ) -> None:
-        super().__init__(id=id, name=name, connect_after_init=connect_after_init, streaming=False,
+        super().__init__(id=id, name=name, connect_after_init=connect_after_init,
                          base_path_overwrite=base_path_overwrite, **kwargs)
         self.log = logging.getLogger(f'rosys.vision.mjpeg_camera.{self.id}')
         self.username = username
@@ -88,13 +88,10 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         self.device = None
 
     async def _image_data_callback(self, image_bytes: bytes) -> None:
-        if not self.is_connected:
-            return
-
-        assert self.device is not None
+        image = image_bytes
 
         if self.crop or self.rotation != ImageRotation.NONE:
-            image = await rosys.run.cpu_bound(process_jpeg_image, image_bytes, self.rotation, self.crop)
+            image = await rosys.run.cpu_bound(process_jpeg_image, image, self.rotation, self.crop)
         if image is None:
             return
         try:

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -71,17 +71,16 @@ class MjpegDevice:
                                 buffer_view[buffer_end:buffer_end + chunk_len] = chunk
                                 buffer_end += chunk_len
 
-                                data = buffer_view[:buffer_end]
-                                end = data.rfind(b'\xff\xd9')
+                                end = buffer.rfind(b'\xff\xd9', 0, buffer_end)
                                 if end == -1:
                                     continue
 
-                                start = data.rfind(b'\xff\xd8', 0, end)
+                                start = buffer.rfind(b'\xff\xd8', 0, end)
                                 if start == -1:
                                     continue
 
                                 end += 2
-                                yield data[start:end]
+                                yield buffer_view[start:end]
                                 buffer_view[:buffer_end - end] = buffer_view[end:buffer_end]
                                 buffer_end -= end
 

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -16,11 +16,11 @@ class MjpegDevice:
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image: Callable[[bytes], Awaitable | None]) -> None:
+                 on_new_image_data: Callable[[bytes], Awaitable | None]) -> None:
         self.mac = mac
         self.ip = ip
         self.index = index
-        self.on_new_image = on_new_image
+        self.on_new_image_data = on_new_image_data
         self.capture_task: Task | None = None
         self.authentication = None if username is None or password is None else httpx.DigestAuth(username, password)
         self.log = logging.getLogger('rosys.mjpeg_device ' + self.mac)
@@ -95,7 +95,7 @@ class MjpegDevice:
             if not image:
                 continue
             try:
-                result = self.on_new_image(remove_exif(image))
+                result = self.on_new_image_data(remove_exif(image))
                 if isinstance(result, Awaitable):
                     await result
             except Exception as e:

--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from .axis_mjpeg_device import AxisMjpegDevice
 from .mjpeg_device import MjpegDevice
 from .motec_mjpeg_device import MotecMjpegDevice
@@ -10,12 +12,13 @@ class MjpegDeviceFactory:
                index: int | None = None,
                username: str | None = None,
                password: str | None = None,
-               control_port: int | None = None) -> MjpegDevice:
+               control_port: int | None = None,
+               on_new_image: Callable[[bytes], None]) -> MjpegDevice:
 
         if mac_to_vendor(mac) == VendorType.AXIS:
-            return AxisMjpegDevice(mac, ip, index=index, username=username, password=password)
+            return AxisMjpegDevice(mac, ip, index=index, username=username, password=password, on_new_image=on_new_image)
 
         if mac_to_vendor(mac) == VendorType.MOTEC:
-            return MotecMjpegDevice(mac, ip, username=username, password=password, control_port=control_port)
+            return MotecMjpegDevice(mac, ip, username=username, password=password, control_port=control_port, on_new_image=on_new_image)
 
         raise ValueError(f'Unknown vendor for mac="{mac}"')

--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Awaitable
 
 from .axis_mjpeg_device import AxisMjpegDevice
 from .mjpeg_device import MjpegDevice
@@ -13,7 +13,7 @@ class MjpegDeviceFactory:
                username: str | None = None,
                password: str | None = None,
                control_port: int | None = None,
-               on_new_image: Callable[[bytes], None]) -> MjpegDevice:
+               on_new_image: Callable[[bytes], Awaitable | None]) -> MjpegDevice:
 
         if mac_to_vendor(mac) == VendorType.AXIS:
             return AxisMjpegDevice(mac, ip, index=index, username=username, password=password, on_new_image=on_new_image)

--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -13,12 +13,16 @@ class MjpegDeviceFactory:
                username: str | None = None,
                password: str | None = None,
                control_port: int | None = None,
-               on_new_image: Callable[[bytes], Awaitable | None]) -> MjpegDevice:
+               on_new_image_data: Callable[[bytes], Awaitable | None]) -> MjpegDevice:
 
         if mac_to_vendor(mac) == VendorType.AXIS:
-            return AxisMjpegDevice(mac, ip, index=index, username=username, password=password, on_new_image=on_new_image)
+            return AxisMjpegDevice(mac, ip,
+                                   index=index, username=username,
+                                   password=password, on_new_image_data=on_new_image_data)
 
         if mac_to_vendor(mac) == VendorType.MOTEC:
-            return MotecMjpegDevice(mac, ip, username=username, password=password, control_port=control_port, on_new_image=on_new_image)
+            return MotecMjpegDevice(mac, ip,
+                                    username=username, password=password,
+                                    control_port=control_port, on_new_image_data=on_new_image_data)
 
         raise ValueError(f'Unknown vendor for mac="{mac}"')

--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Awaitable
+from collections.abc import Awaitable, Callable
 
 from .axis_mjpeg_device import AxisMjpegDevice
 from .mjpeg_device import MjpegDevice

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable
+from collections.abc import Callable, Awaitable
 
 from .mjpeg_device import MjpegDevice
 from .motec_settings_interface import MotecSettingsInterface
@@ -10,7 +10,7 @@ class MotecMjpegDevice(MjpegDevice):
                  username: str | None = '',
                  password: str | None = '',
                  control_port: int | None = 8885,
-                 on_new_image: Callable[[bytes], None]) -> None:
+                 on_new_image: Callable[[bytes], Awaitable | None]) -> None:
 
         super().__init__(mac, ip,
                          username=username, password=password, on_new_image=on_new_image)

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from .mjpeg_device import MjpegDevice
 from .motec_settings_interface import MotecSettingsInterface
 from .vendors import VendorType, mac_to_vendor
@@ -7,10 +9,11 @@ class MotecMjpegDevice(MjpegDevice):
     def __init__(self, mac: str, ip: str, *,
                  username: str | None = '',
                  password: str | None = '',
-                 control_port: int | None = 8885) -> None:
+                 control_port: int | None = 8885,
+                 on_new_image: Callable[[bytes], None]) -> None:
 
         super().__init__(mac, ip,
-                         username=username, password=password)
+                         username=username, password=password, on_new_image=on_new_image)
 
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.MOTEC:

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -10,10 +10,9 @@ class MotecMjpegDevice(MjpegDevice):
                  username: str | None = '',
                  password: str | None = '',
                  control_port: int | None = 8885,
-                 on_new_image: Callable[[bytes], Awaitable | None]) -> None:
+                 on_new_image_data: Callable[[bytes], Awaitable | None]) -> None:
 
-        super().__init__(mac, ip,
-                         username=username, password=password, on_new_image=on_new_image)
+        super().__init__(mac, ip, username=username, password=password, on_new_image_data=on_new_image_data)
 
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.MOTEC:

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Awaitable
+from collections.abc import Awaitable, Callable
 
 from .mjpeg_device import MjpegDevice
 from .motec_settings_interface import MotecSettingsInterface

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -27,7 +27,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         super().__init__(id=id,
                          name=name,
                          connect_after_init=connect_after_init,
-                         streaming=False,
                          **kwargs)
 
         self.log = logging.getLogger(f'rosys.vision.rtsp_camera.{self.id}')

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -18,7 +18,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
                  id: str,  # pylint: disable=redefined-builtin
                  name: str | None = None,
                  connect_after_init: bool = True,
-                 streaming: bool = True,
                  fps: int = 5,
                  jovision_profile: int = 1,
                  bitrate: int = 4096,
@@ -28,7 +27,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         super().__init__(id=id,
                          name=name,
                          connect_after_init=connect_after_init,
-                         polling_interval=1.0 / fps,
                          streaming=False,
                          **kwargs)
 
@@ -108,7 +106,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         assert self.device is not None
 
         self.device.set_fps(fps)
-        self.polling_interval = 1.0 / fps
 
     def get_fps(self) -> int | None:
         assert self.device is not None

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -72,9 +72,10 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
             self.log.error('no IP address provided for camera %s', self.id)
             return
 
-        self.device = RtspDevice(
-            mac=self.id, ip=self.ip,
-            jovision_profile=self.parameters['jovision_profile'], fps=self.parameters['fps'], on_new_image=self._image_data_callback)
+        self.device = RtspDevice(mac=self.id, ip=self.ip,
+                                 jovision_profile=self.parameters['jovision_profile'],
+                                 fps=self.parameters['fps'],
+                                 on_new_image_data=self._handle_new_image_data)
 
         await self._apply_all_parameters()
 
@@ -87,7 +88,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         await self.device.shutdown()
         self.device = None
 
-    async def _image_data_callback(self, image_bytes: bytes) -> None:
+    async def _handle_new_image_data(self, image_bytes: bytes) -> None:
         if not image_bytes:
             return
         transformed_image_bytes = await rosys.run.cpu_bound(process_jpeg_image, image_bytes, self.rotation, self.crop)

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -4,9 +4,8 @@ import shlex
 import signal
 import subprocess
 from asyncio.subprocess import Process
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from io import BytesIO
-from typing import Callable
 
 from nicegui import background_tasks
 

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -107,7 +107,7 @@ class RtspDevice:
 
             self.log.debug('[%s] Starting gstreamer pipeline for %s', self.mac, url)
             # to try: replace avdec_h264 with nvh264dec ! nvvidconv (!videoconvert)
-            command = f'gst-launch-1.0 rtspsrc location="{url}" latency=0 protocols=tcp ! rtph264depay ! avdec_h264 ! videoconvert ! videorate ! "video/x-raw,framerate={self.fps}/1" ! jpegenc ! fdsink'
+            command = f'gst-launch-1.0 rtspsrc location="{url}" latency=0 protocols=tcp ! rtph264depay ! avdec_h264 ! videoconvert ! jpegenc ! fdsink'
             self.log.debug('[%s] Running command: %s', self.mac, command)
             process = await asyncio.create_subprocess_exec(*shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             assert process.stdout is not None

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -16,7 +16,7 @@ from .vendors import VendorType, mac_to_url, mac_to_vendor
 
 class RtspDevice:
 
-    def __init__(self, mac: str, ip: str, jovision_profile: int, fps: int = 10, on_new_image: Callable) -> None:
+    def __init__(self, mac: str, ip: str, jovision_profile: int, fps: int, on_new_image: Callable) -> None:
         self.log = logging.getLogger('rosys.vision.rtsp_camera.rtsp_device')
 
         self.mac = mac

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -54,7 +54,6 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
     async def _image_data_callback(self, image_data: bytes) -> None:
         image = Image(time=rosys.time(), camera_id=self.id, size=self.resolution, data=image_data)
-        print(f'{rosys.time()}: adding image')
         self._add_image(image)
 
     def _set_color(self, value: str) -> None:

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -14,7 +14,6 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
                  id: str,  # pylint: disable=redefined-builtin
                  name: str | None = None,
                  connect_after_init: bool = True,
-                 streaming: bool = True,
                  width: int = 800,
                  height: int = 600,
                  color: str | None = None,
@@ -24,8 +23,7 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
         super().__init__(id=id,
                          name=name,
                          connect_after_init=connect_after_init,
-                         streaming=streaming,
-                         polling_interval=1.0 / fps,
+                         streaming=False,
                          **kwargs)
         self.device: SimulatedDevice | None = None
         self.resolution = ImageSize(width=width, height=height)
@@ -48,21 +46,16 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
     async def connect(self) -> None:
         if not self.is_connected:
-            self.device = SimulatedDevice(id=self.id, size=self.resolution)
+            self.device = SimulatedDevice(id=self.id, size=self.resolution,
+                                          image_data_callback=self._image_data_callback)
             await self._apply_all_parameters()
 
     async def disconnect(self) -> None:
         self.device = None
 
-    async def capture_image(self) -> None:
-        if not self.is_connected:
-            return None
-        image = Image(time=rosys.time(), camera_id=self.id, size=self.resolution)
-        if rosys.is_test:
-            image.data = b'test data'
-        else:
-            assert self.device is not None
-            image.data = await rosys.run.cpu_bound(self.device.create_image_data)
+    async def _image_data_callback(self, image_data: bytes) -> None:
+        image = Image(time=rosys.time(), camera_id=self.id, size=self.resolution, data=image_data)
+        print(f'{rosys.time()}: adding image')
         self._add_image(image)
 
     def _set_color(self, value: str) -> None:
@@ -75,8 +68,8 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
     def _set_fps(self, value: int) -> None:
         assert self.device is not None
-        self.polling_interval = 1.0 / value
+        self.device.set_fps(value)
 
     def _get_fps(self) -> int:
         assert self.device is not None
-        return int(1.0 / self.polling_interval)
+        return int(self.device.get_fps())

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -46,13 +46,13 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
     async def connect(self) -> None:
         if not self.is_connected:
             self.device = SimulatedDevice(id=self.id, size=self.resolution, fps=self.parameters['fps'],
-                                          image_data_callback=self._image_data_callback)
+                                          on_new_image_data=self._handle_new_image_data)
             await self._apply_all_parameters()
 
     async def disconnect(self) -> None:
         self.device = None
 
-    async def _image_data_callback(self, image_data: bytes) -> None:
+    def _handle_new_image_data(self, image_data: bytes) -> None:
         image = Image(time=rosys.time(), camera_id=self.id, size=self.resolution, data=image_data)
         self._add_image(image)
 

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -23,7 +23,6 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
         super().__init__(id=id,
                          name=name,
                          connect_after_init=connect_after_init,
-                         streaming=False,
                          **kwargs)
         self.device: SimulatedDevice | None = None
         self.resolution = ImageSize(width=width, height=height)

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -45,7 +45,7 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
     async def connect(self) -> None:
         if not self.is_connected:
-            self.device = SimulatedDevice(id=self.id, size=self.resolution,
+            self.device = SimulatedDevice(id=self.id, size=self.resolution, fps=self.parameters['fps'],
                                           image_data_callback=self._image_data_callback)
             await self._apply_all_parameters()
 

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Awaitable, Callable
 
 import cv2
 import numpy as np
@@ -14,23 +15,43 @@ class SimulatedDevice:
     def __init__(self,
                  id: str,  # pylint: disable=redefined-builtin
                  size: ImageSize,
+                 image_data_callback: Callable[[bytes], Awaitable | None],
                  color: str = '#ffffff') -> None:
         self.id = id
         self.size = size
         self.color = color
+        self.image_data_callback = image_data_callback
         self.creation_time: float = rosys.time()
 
-    def create_image_data(self) -> bytes:
-        img = PIL.Image.new('RGB', size=(self.size.width, self.size.height), color=self.color)
+        self.repeater = rosys.on_repeat(self.capture_image, interval=1.0 / 30)
+
+    @staticmethod
+    def create_image_data(id: str, size: ImageSize, color: str) -> bytes:
+        img = PIL.Image.new('RGB', size=(size.width, size.height), color=color)
         d = PIL.ImageDraw.Draw(img)
-        text = f'{self.id}: {time.time():.2f}'
-        position = floating_text_position(self.size.width, self.size.height)
+        text = f'{id}: {time.time():.2f}'
+        position = floating_text_position(size.width, size.height)
 
         d.text((position.x, position.y), text, fill=(0, 0, 0))
         d.text((position.x + 1, position.y + 1), text, fill=(255, 255, 255))
 
         _, encoded_image = cv2.imencode('.jpg', np.array(img)[:, :, ::-1])  # NOTE: cv2 expects BGR
         return encoded_image.tobytes()
+
+    async def capture_image(self) -> None:
+        print(f'{rosys.time()}: capturing image')
+        image_data = await rosys.run.cpu_bound(SimulatedDevice.create_image_data, self.id, self.size, self.color)
+        if not image_data:
+            return
+        result = self.image_data_callback(image_data)
+        if isinstance(result, Awaitable):
+            await result
+
+    def set_fps(self, fps: float) -> None:
+        self.repeater.interval = 1.0 / fps
+
+    def get_fps(self) -> float:
+        return 1.0 / self.repeater.interval
 
 
 def floating_text_position(box_width: int, box_height: int, speed: float = 100, angle: float = np.deg2rad(45)) -> Point:

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -14,37 +14,24 @@ class SimulatedDevice:
 
     def __init__(self,
                  id: str,  # pylint: disable=redefined-builtin
+                 *,
                  size: ImageSize,
-                 image_data_callback: Callable[[bytes], Awaitable | None],
+                 on_new_image_data: Callable[[bytes], Awaitable | None],
                  color: str = '#ffffff',
                  fps: float = 30.0) -> None:
         self.id = id
         self.size = size
         self.color = color
-        self.image_data_callback = image_data_callback
+        self.on_new_image_data = on_new_image_data
         self.creation_time: float = rosys.time()
 
-        self.repeater = rosys.on_repeat(self.capture_image, interval=1.0 / fps)
+        self.repeater = rosys.on_repeat(self._create_image, interval=1.0 / fps)
 
-    @staticmethod
-    def create_image_data(id: str, size: ImageSize, color: str) -> bytes:  # pylint: disable=redefined-builtin
-        img = PIL.Image.new('RGB', size=(size.width, size.height), color=color)
-        d = PIL.ImageDraw.Draw(img)
-        text = f'{id}: {time.time():.2f}'
-        position = floating_text_position(size.width, size.height)
-
-        d.text((position.x, position.y), text, fill=(0, 0, 0))
-        d.text((position.x + 1, position.y + 1), text, fill=(255, 255, 255))
-
-        _, encoded_image = cv2.imencode('.jpg', np.array(img)[:, :, ::-1])  # NOTE: cv2 expects BGR
-        return encoded_image.tobytes()
-
-    async def capture_image(self) -> None:
-        print(f'{rosys.time()}: capturing image')
-        image_data = await rosys.run.cpu_bound(SimulatedDevice.create_image_data, self.id, self.size, self.color)
+    async def _create_image(self) -> None:
+        image_data = await rosys.run.cpu_bound(_create_image_data, self.id, self.size, self.color)
         if not image_data:
             return
-        result = self.image_data_callback(image_data)
+        result = self.on_new_image_data(image_data)
         if isinstance(result, Awaitable):
             await result
 
@@ -55,7 +42,20 @@ class SimulatedDevice:
         return 1.0 / self.repeater.interval
 
 
-def floating_text_position(box_width: int, box_height: int, speed: float = 100, angle: float = np.deg2rad(45)) -> Point:
+def _create_image_data(id: str, size: ImageSize, color: str) -> bytes:  # pylint: disable=redefined-builtin
+    img = PIL.Image.new('RGB', size=(size.width, size.height), color=color)
+    d = PIL.ImageDraw.Draw(img)
+    text = f'{id}: {time.time():.2f}'
+    position = _floating_text_position(size.width, size.height)
+
+    d.text((position.x, position.y), text, fill=(0, 0, 0))
+    d.text((position.x + 1, position.y + 1), text, fill=(255, 255, 255))
+
+    _, encoded_image = cv2.imencode('.jpg', np.array(img)[:, :, ::-1])  # NOTE: cv2 expects BGR
+    return encoded_image.tobytes()
+
+
+def _floating_text_position(box_width: int, box_height: int, speed: float = 100, angle: float = np.deg2rad(45)) -> Point:
     """Calculate the position of the text that floats around the image."""
     t = time.time()
     return Point(x=(speed * t * np.cos(angle)) % box_width,

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -16,14 +16,15 @@ class SimulatedDevice:
                  id: str,  # pylint: disable=redefined-builtin
                  size: ImageSize,
                  image_data_callback: Callable[[bytes], Awaitable | None],
-                 color: str = '#ffffff') -> None:
+                 color: str = '#ffffff',
+                 fps: float = 30.0) -> None:
         self.id = id
         self.size = size
         self.color = color
         self.image_data_callback = image_data_callback
         self.creation_time: float = rosys.time()
 
-        self.repeater = rosys.on_repeat(self.capture_image, interval=1.0 / 30)
+        self.repeater = rosys.on_repeat(self.capture_image, interval=1.0 / fps)
 
     @staticmethod
     def create_image_data(id: str, size: ImageSize, color: str) -> bytes:

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -27,7 +27,7 @@ class SimulatedDevice:
         self.repeater = rosys.on_repeat(self.capture_image, interval=1.0 / fps)
 
     @staticmethod
-    def create_image_data(id: str, size: ImageSize, color: str) -> bytes:
+    def create_image_data(id: str, size: ImageSize, color: str) -> bytes:  # pylint: disable=redefined-builtin
         img = PIL.Image.new('RGB', size=(size.width, size.height), color=color)
         d = PIL.ImageDraw.Draw(img)
         text = f'{id}: {time.time():.2f}'

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -59,7 +59,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         if self.is_connected:
             return
 
-        device = UsbDevice.from_uid(self.id, self._image_data_callback)
+        device = UsbDevice.from_uid(self.id, self._handle_new_image_data)
         if device is None:
             logging.warning('Connecting camera %s: failed', self.id)
             return
@@ -78,7 +78,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         self.device = None
         logging.info('camera %s: disconnected', self.id)
 
-    async def _image_data_callback(self, image_array: np.ndarray) -> None:
+    async def _handle_new_image_data(self, image_array: np.ndarray) -> None:
         if not self.is_connected:
             return None
 

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -30,7 +30,6 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         super().__init__(id=id,
                          name=name,
                          connect_after_init=connect_after_init,
-                         streaming=False,
                          **kwargs)
         self._pending_operations = 0
         self.device: UsbDevice | None = None

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -21,7 +21,6 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
                  id: str,  # pylint: disable=redefined-builtin
                  name: str | None = None,
                  connect_after_init: bool = True,
-                 streaming: bool = True,
                  auto_exposure: bool = True,
                  exposure: bool = False,
                  width: int = 800,
@@ -31,8 +30,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         super().__init__(id=id,
                          name=name,
                          connect_after_init=connect_after_init,
-                         streaming=streaming,
-                         polling_interval=1.0 / fps,
+                         streaming=False,
                          **kwargs)
         self._pending_operations = 0
         self.device: UsbDevice | None = None
@@ -62,7 +60,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         if self.is_connected:
             return
 
-        device = UsbDevice.from_uid(self.id)
+        device = UsbDevice.from_uid(self.id, self._image_data_callback)
         if device is None:
             logging.warning('Connecting camera %s: failed', self.id)
             return
@@ -81,37 +79,27 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         self.device = None
         logging.info('camera %s: disconnected', self.id)
 
-    async def capture_image(self) -> None:
+    async def _image_data_callback(self, image_array: np.ndarray) -> None:
         if not self.is_connected:
             return None
 
         assert self.device is not None
-        result = await rosys.run.io_bound(self.device.capture.read)
-        if result is None:  # NOTE this can happen when shutting down and the thread is aborted before opencv has returned
-            return
-        capture_success, captured_image = result
+
         image_is_MJPG = 'MJPG' in self.device.video_formats
-
-        if not capture_success:
-            await self.disconnect()
-            return
-
-        if captured_image is None:
-            return
 
         def to_bytes(image: list[np.ndarray]) -> bytes:
             return image[0].tobytes()
 
         if image_is_MJPG:
-            bytes_ = await rosys.run.io_bound(to_bytes, captured_image)
+            bytes_ = await rosys.run.io_bound(to_bytes, image_array)
             if self.crop or self.rotation != ImageRotation.NONE:
                 bytes_ = await rosys.run.cpu_bound(process_jpeg_image, bytes_, self.rotation, self.crop)
         else:
-            bytes_ = await rosys.run.cpu_bound(process_ndarray_image, captured_image, self.rotation, self.crop)
+            bytes_ = await rosys.run.cpu_bound(process_ndarray_image, image_array, self.rotation, self.crop)
         if bytes_ is None:
             return
 
-        image_size = ImageSize(width=captured_image.shape[1], height=captured_image.shape[0])
+        image_size = ImageSize(width=image_array.shape[1], height=image_array.shape[0])
         final_image_resolution = self._resolution_after_transform(image_size)
 
         image = Image(time=rosys.time(), camera_id=self.id, size=final_image_resolution, data=bytes_)

--- a/rosys/vision/usb_camera/usb_device.py
+++ b/rosys/vision/usb_camera/usb_device.py
@@ -7,9 +7,7 @@ from collections.abc import Awaitable, Callable
 import cv2
 import numpy as np
 
-import rosys
-
-from ... import run
+from ... import rosys
 from .usb_camera_scanner import device_nodes_from_uid
 
 MJPG = cv2.VideoWriter.fourcc(*'MJPG')
@@ -102,7 +100,7 @@ class UsbDevice:
     async def run_v4l(self, *args) -> str:
         cmd = ['v4l2-ctl', '-d', str(self.video_id)]
         cmd.extend(args)
-        return await run.sh(cmd)
+        return await rosys.run.sh(cmd)
 
     def set_video_format(self) -> None:
         if 'MJPG' in self.video_formats:

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -3,7 +3,7 @@ import platform
 
 import pytest
 
-import rosys
+from rosys.testing import forward
 from rosys.vision import RtspCamera, RtspCameraProvider, SimulatedCamera, UsbCamera, UsbCameraProvider
 
 
@@ -11,9 +11,7 @@ async def test_simulated_camera(rosys_integration):
     camera = SimulatedCamera(id='test_cam', width=800, height=600, fps=1)
     await camera.connect()
     assert camera.is_connected
-    await asyncio.sleep(0.)
-    rosys.set_time(1.1)
-    await asyncio.sleep(0.5)  # wait for SimulatedDevice to generate images
+    await forward(1.1)
     assert len(camera.images) >= 1
     assert camera.images[0].size.width == 800
     assert camera.images[0].size.height == 600

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -10,7 +10,7 @@ async def test_simulated_camera(rosys_integration):
     camera = SimulatedCamera(id='test_cam', width=800, height=600)
     await camera.connect()
     assert camera.is_connected
-    await camera.capture_image()
+    await asyncio.sleep(0.5)
     assert len(camera.images) >= 1
     assert camera.images[0].size.width == 800
     assert camera.images[0].size.height == 600
@@ -24,8 +24,8 @@ async def test_usb_camera(rosys_integration):
         pytest.skip('No USB camera detected. This test requires a physical USB camera to be connected.')
     camera = UsbCamera(id=connected_uids[0])
     await camera.connect()
+    await asyncio.sleep(0.5)
     assert camera.is_connected
-    await camera.capture_image()
     assert len(camera.images) >= 1
 
 
@@ -41,7 +41,7 @@ async def test_rtsp_camera(rosys_integration):
     mac, ip = connected_uids[0]
     camera = RtspCamera(id=mac, ip=ip)
     await camera.connect()
+    await asyncio.sleep(0.5)
     assert camera.is_connected
     await asyncio.sleep(1)
-    await camera.capture_image()
     assert len(camera.images) >= 1

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -7,11 +7,11 @@ from rosys.vision import RtspCamera, RtspCameraProvider, SimulatedCamera, UsbCam
 
 
 async def test_simulated_camera(rosys_integration):
-    camera = SimulatedCamera(id='test_cam', width=800, height=600, streaming=False)
+    camera = SimulatedCamera(id='test_cam', width=800, height=600)
     await camera.connect()
     assert camera.is_connected
     await camera.capture_image()
-    assert len(camera.images) == 1
+    assert len(camera.images) >= 1
     assert camera.images[0].size.width == 800
     assert camera.images[0].size.height == 600
 
@@ -22,11 +22,11 @@ async def test_usb_camera(rosys_integration):
     connected_uids = list(await UsbCameraProvider.scan_for_cameras())
     if len(connected_uids) == 0:
         pytest.skip('No USB camera detected. This test requires a physical USB camera to be connected.')
-    camera = UsbCamera(id=connected_uids[0], streaming=False)
+    camera = UsbCamera(id=connected_uids[0])
     await camera.connect()
     assert camera.is_connected
     await camera.capture_image()
-    assert len(camera.images) == 1
+    assert len(camera.images) >= 1
 
 
 async def test_rtsp_camera(rosys_integration):
@@ -39,9 +39,9 @@ async def test_rtsp_camera(rosys_integration):
     if len(connected_uids) == 0:
         pytest.skip('No RTSP camera detected. This test requires a physical RTSP camera on the local network.')
     mac, ip = connected_uids[0]
-    camera = RtspCamera(id=mac, ip=ip, streaming=False)
+    camera = RtspCamera(id=mac, ip=ip)
     await camera.connect()
     assert camera.is_connected
     await asyncio.sleep(1)
     await camera.capture_image()
-    assert len(camera.images) == 1
+    assert len(camera.images) >= 1

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -3,14 +3,17 @@ import platform
 
 import pytest
 
+import rosys
 from rosys.vision import RtspCamera, RtspCameraProvider, SimulatedCamera, UsbCamera, UsbCameraProvider
 
 
 async def test_simulated_camera(rosys_integration):
-    camera = SimulatedCamera(id='test_cam', width=800, height=600)
+    camera = SimulatedCamera(id='test_cam', width=800, height=600, fps=1)
     await camera.connect()
     assert camera.is_connected
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(0.)
+    rosys.set_time(1.1)
+    await asyncio.sleep(0.5)  # wait for SimulatedDevice to generate images
     assert len(camera.images) >= 1
     assert camera.images[0].size.width == 800
     assert camera.images[0].size.height == 600

--- a/tests/test_mjpeg_camera.py
+++ b/tests/test_mjpeg_camera.py
@@ -17,11 +17,10 @@ async def test_mjpeg_camera(rosys_integration):
     if len(connected_uids) == 0:
         pytest.skip('No MJPEG camera detected. This test requires a physical MJPEG camera on the local network.')
     uid, ip = connected_uids[0]
-    camera = MjpegCamera(id=uid, ip=ip, connect_after_init=False, streaming=False)
+    camera = MjpegCamera(id=uid, ip=ip, connect_after_init=False)
     await camera.connect()
     await asyncio.sleep(0.5)
     assert camera.is_connected
-    await camera.capture_image()
     assert len(camera.images) == 1
 
 

--- a/tests/test_mjpeg_camera.py
+++ b/tests/test_mjpeg_camera.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_asyncio
 
 from rosys.vision import MjpegCamera, MjpegCameraProvider
+from rosys.vision.mjpeg_camera.motec_mjpeg_device import MotecMjpegDevice
 from rosys.vision.mjpeg_camera.vendors import VendorType, mac_to_vendor
 
 
@@ -21,7 +22,7 @@ async def test_mjpeg_camera(rosys_integration):
     await camera.connect()
     await asyncio.sleep(0.5)
     assert camera.is_connected
-    assert len(camera.images) == 1
+    assert len(camera.images) >= 1
 
 
 @pytest_asyncio.fixture()
@@ -37,14 +38,16 @@ async def motec_settings_interface(rosys_integration):
 
     for mac, ip in connected_uids:
         if mac_to_vendor(mac) == VendorType.MOTEC:
-            camera = MjpegCamera(id=mac, connect_after_init=False, ip=ip, streaming=False)
+            camera = MjpegCamera(id=mac, connect_after_init=False, ip=ip)
             await camera.connect()
             break
     else:
         pytest.skip('No MOTEC camera detected. This test requires a physical MOTEC camera on the local network.')
 
-    assert camera.device is not None and camera.device.settings_interface is not None
-    yield camera.device.settings_interface
+    assert camera.device is not None
+    assert isinstance(camera.device, MotecMjpegDevice)
+    assert camera.device.settings_interface is not None
+    yield camera.device
 
 
 async def test_fps(motec_settings_interface):


### PR DESCRIPTION
This PR sends camera images directly from the `Device` to the `Camera` without the camera having to poll on its own.
That causes a much more stable frame-rate and more accurate image timing.

It also improves the processing the `RtspDevice`s Pipe stream. On loop iteration we now read as much data as possible from the pipe and only process the last image. This enables the system to catch up to the real camera stream much faster.