### PR TITLE
Fix camera removal

### DIFF
--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 from typing import Generic, TypeVar
 
 from .. import persistence, rosys
@@ -57,7 +58,7 @@ class CameraProvider(Generic[T], persistence.PersistentModule, metaclass=abc.ABC
         self.request_backup()
 
     def remove_camera(self, camera_id: str) -> None:
-        del self.cameras[camera_id]
+        del self._cameras[camera_id]
         self.CAMERA_REMOVED.emit(camera_id)
         self.request_backup()
 
@@ -66,6 +67,7 @@ class CameraProvider(Generic[T], persistence.PersistentModule, metaclass=abc.ABC
             self.remove_camera(camera_id)
 
     def prune_images(self, max_age_seconds: float | None = None):
+        warnings.warn('Pruning images is not required anymore because images is now a deque')
         for camera in self.cameras.values():
             if max_age_seconds is None:
                 camera.images.clear()

--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -67,7 +67,8 @@ class CameraProvider(Generic[T], persistence.PersistentModule, metaclass=abc.ABC
             self.remove_camera(camera_id)
 
     def prune_images(self, max_age_seconds: float | None = None):
-        warnings.warn('Pruning images is not required anymore because images is now a deque', stacklevel=2)
+        warnings.warn('Pruning images is not required anymore because images is now a deque',
+                      DeprecationWarning, stacklevel=2)
         for camera in self.cameras.values():
             if max_age_seconds is None:
                 camera.images.clear()

--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -67,7 +67,7 @@ class CameraProvider(Generic[T], persistence.PersistentModule, metaclass=abc.ABC
             self.remove_camera(camera_id)
 
     def prune_images(self, max_age_seconds: float | None = None):
-        warnings.warn('Pruning images is not required anymore because images is now a deque')
+        warnings.warn('Pruning images is not required anymore because images is now a deque', stacklevel=2)
         for camera in self.cameras.values():
             if max_age_seconds is None:
                 camera.images.clear()

--- a/rosys/vision/multi_camera_provider.py
+++ b/rosys/vision/multi_camera_provider.py
@@ -33,3 +33,11 @@ class MultiCameraProvider(CameraProvider):
     @property
     def cameras(self) -> dict[str, Camera]:
         return {id: camera for provider in self.providers for id, camera in provider.cameras.items()}
+
+    def remove_camera(self, camera_id: str) -> None:
+        for provider in self.providers:
+            if camera_id in provider.cameras:
+                provider.remove_camera(camera_id)
+
+    def add_camera(self, camera) -> None:
+        raise NotImplementedError('Adding cameras to a MultiCameraProvider is not supported')


### PR DESCRIPTION
This PR fixes the removal of cameras in the `multi_camera_provider`. 

The problem was that the camera removal works by modifying the dict returned by `self.cameras`. However, the `multi_camera_provider` overwrites this method to return a joined dict of all sub-providers. Consequently, the deletion had no effect. 
 
This PR also adds a deprecation warning for the `prune_images` function which is outdated because images is a dequeue now.