### PR TITLE
fix: apply parameters after connecting too mjpg device

### DIFF
--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -82,6 +82,8 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
             self.log.error('Could not connect to device: %s', error)
             return
 
+        await self._apply_all_parameters()
+
     async def disconnect(self) -> None:
         if self.device is None:
             return


### PR DESCRIPTION
Fixes a bug where Settings of a camera were out of sync with the device.