### PR TITLE
Fix wheels timing error

### DIFF
--- a/rosys/hardware/robot.py
+++ b/rosys/hardware/robot.py
@@ -82,8 +82,9 @@ class RobotSimulation(Robot):
         rosys.on_repeat(self.step, 0.01)
 
     async def step(self) -> None:
+        now = rosys.time()
         if self._last_step is not None:
-            dt = rosys.time() - self._last_step
+            dt = now - self._last_step
             for module in self.modules:
                 await cast(ModuleSimulation, module).step(dt)
-        self._last_step = rosys.time()
+        self._last_step = now

--- a/rosys/hardware/wheels.py
+++ b/rosys/hardware/wheels.py
@@ -118,16 +118,14 @@ class WheelsSimulation(Wheels, ModuleSimulation):
         self.angular_velocity = 0 if self.is_blocking else f * self.angular_velocity + (1 - f) * angular
 
     async def step(self, dt: float) -> None:
-        timestamp = rosys.time()
-        pose_dt = timestamp - self.pose.time
         self.linear_velocity *= 1 - self.friction_factor
         self.angular_velocity *= 1 - self.friction_factor
         left_speed = self.linear_velocity - self.angular_velocity * self.width / 2
         right_speed = self.linear_velocity + self.angular_velocity * self.width / 2
         left_speed *= 1 - self.slip_factor_left
         right_speed *= 1 - self.slip_factor_right
-        self.pose += PoseStep(linear=pose_dt * (left_speed + right_speed) / 2,
-                              angular=pose_dt * (right_speed - left_speed) / self.width,
-                              time=timestamp)
-        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=timestamp)
+        self.pose += PoseStep(linear=dt * (left_speed + right_speed) / 2,
+                              angular=dt * (right_speed - left_speed) / self.width,
+                              time=rosys.time())
+        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=self.pose.time)
         self.VELOCITY_MEASURED.emit([velocity])

--- a/rosys/hardware/wheels.py
+++ b/rosys/hardware/wheels.py
@@ -87,7 +87,7 @@ class WheelsSimulation(Wheels, ModuleSimulation):
         self.width: float = width
         """The distance between the wheels -- used to calculate actual drift when slip_factor_* is used."""
 
-        self.pose: Pose = Pose()
+        self.pose: Pose = Pose(time=rosys.time())
         """Provides the actual pose of the robot which can alter due to slippage."""
 
         self.linear_velocity: float = 0
@@ -118,14 +118,16 @@ class WheelsSimulation(Wheels, ModuleSimulation):
         self.angular_velocity = 0 if self.is_blocking else f * self.angular_velocity + (1 - f) * angular
 
     async def step(self, dt: float) -> None:
+        timestamp = rosys.time()
+        pose_dt = timestamp - self.pose.time
         self.linear_velocity *= 1 - self.friction_factor
         self.angular_velocity *= 1 - self.friction_factor
         left_speed = self.linear_velocity - self.angular_velocity * self.width / 2
         right_speed = self.linear_velocity + self.angular_velocity * self.width / 2
         left_speed *= 1 - self.slip_factor_left
         right_speed *= 1 - self.slip_factor_right
-        self.pose += PoseStep(linear=dt * (left_speed + right_speed) / 2,
-                              angular=dt * (right_speed - left_speed) / self.width,
-                              time=rosys.time())
-        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=rosys.time())
+        self.pose += PoseStep(linear=pose_dt * (left_speed + right_speed) / 2,
+                              angular=pose_dt * (right_speed - left_speed) / self.width,
+                              time=timestamp)
+        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=timestamp)
         self.VELOCITY_MEASURED.emit([velocity])


### PR DESCRIPTION
Upon investigating positioning errors of our [gnss simulation](https://github.com/zauberzeug/field_friend/blob/main/field_friend/localization/gnss_simulation.py), that is based on the wheels pose, I noticed that the timing in `wheels.step` is off by a little. The error per step is not high, but it adds up quite fast.

```python
import numpy as np
from nicegui import ui

from rosys import simulation_ui
from rosys.automation import Automator, automation_controls
from rosys.driving import Driver, Odometer, Steerer, keyboard_control, robot_object
from rosys.geometry import Pose, Prism, Spline
from rosys.hardware import RobotSimulation, WheelsSimulation

shape = Prism.default_robot_shape()
wheels = WheelsSimulation()
robot = RobotSimulation([wheels])
odometer = Odometer(wheels)
driver = Driver(wheels, odometer)
steerer = Steerer(wheels)


async def run_automation():
    target_pose = Pose(x=0.0, y=5.0, yaw=np.deg2rad(180))
    spline = Spline.from_poses(odometer.prediction, target_pose)
    await driver.drive_spline(spline)
automator = Automator(None, default_automation=run_automation, on_interrupt=wheels.stop)


automation_controls(automator)
ui.label('Odom').bind_text_from(odometer, 'prediction', lambda prediction: f'odom: {prediction}')
ui.label('Wheels').bind_text_from(driver.wheels, 'pose', lambda pose: f'wheels: {pose}')
ui.label('Difference').bind_text_from(odometer, 'prediction', lambda prediction:
                                      f'diff: {Pose(x=prediction.x-wheels.pose.x, y=prediction.y-wheels.pose.y, yaw=prediction.yaw-wheels.pose.yaw)}')
keyboard_control(steerer)
with ui.scene():
    robot_object(shape, odometer)
simulation_ui()

ui.run(title='RoSys')
```
