### PR TITLE
Awaitable events

### DIFF
--- a/rosys/event.py
+++ b/rosys/event.py
@@ -81,6 +81,25 @@ class Event:
             except Exception:
                 log.exception('could not emit listener=%s', listener)
 
+    async def emitted(self, timeout: float | None = None) -> Any:
+        """Waits for an event to be emitted and returns its arguments."""
+        future: asyncio.Future[Any] = asyncio.Future()
+
+        def callback(*args):
+            if not future.done():
+                future.set_result(args[0] if len(args) == 1 else args if args else None)
+
+        self.register(callback)
+        try:
+            return await asyncio.wait_for(future, timeout)
+        except asyncio.TimeoutError as error:
+            raise TimeoutError(f'Timed out waiting for event after {timeout} seconds') from error
+        finally:
+            self.unregister(callback)
+
+    def __await__(self):
+        return self.emitted().__await__()
+
 
 def reset() -> None:
     for event in events:
@@ -88,20 +107,3 @@ def reset() -> None:
     for task in tasks:
         task.cancel()
     tasks.clear()
-
-
-async def wait_for(event: Event, timeout: float | None = None) -> Any:
-    """Waits for an event to be emitted and returns its arguments."""
-    future: asyncio.Future[Any] = asyncio.Future()
-
-    def callback(*args):
-        if not future.done():
-            future.set_result(args[0] if len(args) == 1 else args if args else None)
-
-    event.register(callback)
-    try:
-        return await asyncio.wait_for(future, timeout)
-    except asyncio.TimeoutError as error:
-        raise TimeoutError(f'Timed out waiting for event after {timeout} seconds') from error
-    finally:
-        event.unregister(callback)

--- a/rosys/event.py
+++ b/rosys/event.py
@@ -92,7 +92,7 @@ def reset() -> None:
 
 async def wait_for(event: Event, timeout: float | None = None) -> Any:
     """Waits for an event to be emitted and returns its arguments."""
-    future = asyncio.Future()
+    future: asyncio.Future[Any] = asyncio.Future()
 
     def callback(*args):
         if not future.done():

--- a/rosys/event.py
+++ b/rosys/event.py
@@ -91,6 +91,7 @@ def reset() -> None:
 
 
 async def wait_for(event: Event, timeout: float | None = None) -> Any:
+    """Waits for an event to be emitted and returns its arguments."""
     future = asyncio.Future()
 
     def callback(*args):
@@ -101,6 +102,6 @@ async def wait_for(event: Event, timeout: float | None = None) -> Any:
     try:
         return await asyncio.wait_for(future, timeout)
     except asyncio.TimeoutError as error:
-        raise TimeoutError(f"Timed out waiting for event after {timeout} seconds") from error
+        raise TimeoutError(f'Timed out waiting for event after {timeout} seconds') from error
     finally:
         event.unregister(callback)


### PR DESCRIPTION
On multiple occasions we needed to wait for the next call of an event. Instead of waiting in a loop or setting some internal variable this PR allows waiting for an event directly.

```python
from nicegui import ui

import rosys
from rosys.event import Event

event = Event()
event.register(lambda *args: print('Event fired!', *args))


async def wait_for_event_timeout(timeout: float | None = 10.0):
    print('Waiting for event with timeout', timeout)
    value = await event.emitted(timeout)
    print('Event received!', value, type(value))


async def wait_for_event():
    print('Waiting for event')
    value = await event
    print('Event received!', value, type(value))

ui.button('Wait for event with timeout', on_click=wait_for_event_timeout)
ui.button('Wait for event', on_click=wait_for_event)
ui.button('Emit', on_click=lambda: event.emit(42))
rosys.on_repeat(lambda: event.emit(123), interval=5.0)

ui.run(title='RoSys')
```