### PR TITLE
Do not pass camera kwargs to object base constructor

### DIFF
--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -28,7 +28,7 @@ class Camera(abc.ABC):
                  base_path_overwrite: str | None = None,
                  image_history_length: int = 256,
                  **kwargs) -> None:
-        super().__init__(**kwargs)
+        super().__init__()
         self.id: str = id
         self.name = name or self.id
         self.connect_after_init = connect_after_init


### PR DESCRIPTION
If you create a camera with an arbitrary kwargs property (eg. `rosys.vision.Camera(id='cam', some_property=True)`), we currently get:

```
    main_content = runpy.run_path(main_path,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 287, in run_path
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/rodja/Projects/rosys/main.py", line 27, in <module>
    camera = rosys.vision.Camera(id='cam', some_property=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/rodja/Projects/rosys/rosys/vision/camera/camera.py", line 31, in __init__
    super().__init__(**kwargs)
TypeError: object.__init__() takes exactly one argument (the instance to initialize)
```

This PR fixes this by not passing the kwargs to the obj base constructor in `Camera`.