### PR TITLE
Fix slow SimulatedCamera tests

### DIFF
--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -28,7 +28,8 @@ class SimulatedDevice:
         self.repeater = rosys.on_repeat(self._create_image, interval=1.0 / fps)
 
     async def _create_image(self) -> None:
-        image_data = await rosys.run.cpu_bound(_create_image_data, self.id, self.size, self.color)
+        # image_data = await rosys.run.cpu_bound(_create_image_data, self.id, self.size, self.color)
+        image_data = self._create_image_data(self.id, self.size, self.color)
         if not image_data:
             return
         result = self.on_new_image_data(image_data)

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -29,7 +29,7 @@ class SimulatedDevice:
 
     async def _create_image(self) -> None:
         # image_data = await rosys.run.cpu_bound(_create_image_data, self.id, self.size, self.color)
-        image_data = self._create_image_data(self.id, self.size, self.color)
+        image_data = _create_image_data(self.id, self.size, self.color)
         if not image_data:
             return
         result = self.on_new_image_data(image_data)

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -28,8 +28,10 @@ class SimulatedDevice:
         self.repeater = rosys.on_repeat(self._create_image, interval=1.0 / fps)
 
     async def _create_image(self) -> None:
-        # image_data = await rosys.run.cpu_bound(_create_image_data, self.id, self.size, self.color)
-        image_data = _create_image_data(self.id, self.size, self.color)
+        if rosys.is_test:
+            image_data = b'test data'
+        else:
+            image_data = await rosys.run.cpu_bound(_create_image_data, self.id, self.size, self.color)
         if not image_data:
             return
         result = self.on_new_image_data(image_data)


### PR DESCRIPTION
We had issues with failing tests, because the camera simulation was too slow since https://github.com/zauberzeug/rosys/pull/197.
This PR brings back a check whether the image is created in a test or not, that was removed in https://github.com/zauberzeug/rosys/pull/197/commits/d9e612ad684a23213ca73ae49aac3f69f5e4f145#