### PR TITLE
Docker cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,10 +73,10 @@ jobs:
           fi
 
           # Set output parameters.
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "docker_image=${DOCKER_IMAGE}" >> $GITHUB_OUTPUT
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
       - name: Login to DockerHub
@@ -86,10 +86,14 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v3
         with:
-          install: true
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
       - name: Build
         uses: docker/build-push-action@v6
         with:
@@ -98,6 +102,15 @@ jobs:
           build-args: INSTALL_DEV=true
           push: true
           tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       # Uploading the README.md is not a core feature of docker/build-push-action yet
       - name: Update README

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.12"
           cache: "poetry"
       - name: get version
-        run: echo "VERSION=$(echo ${GITHUB_REF/refs\/tags\//})" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: set version
         run: |
           VERSION=${{ env.VERSION }}
@@ -45,7 +45,21 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - name: verify
         shell: bash
-        run: for i in {1..100}; do python -m pip install 'rosys==${{ env.VERSION }}' && break || sleep 2; done
+        run: |
+          for i in {1..100}; do
+            if python -m pip install "rosys==${{ env.VERSION }}"; then
+              echo "Successfully installed rosys version ${{ env.VERSION }}"
+              break
+            else
+              echo "Attempt $i failed. Retrying in 2 seconds..."
+              sleep 2
+            fi
+          done
+
+          if [ $i -eq 100 ]; then
+            echo "Failed to install rosys after 100 attempts"
+            exit 1
+          fi
 
   docker:
     needs: pypi

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,10 @@ name: Run Tests
 
 on: workflow_call
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
 jobs:
   checker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds cacheing for Docker to the Publish pipeline.

It also:

* refactors some variable assignments and the deprecated use of the `set-output` command
* refactors the verify step and adds some more logging
* adds a concurrency group to pytest runs on the same commit that cancels already running actions