### PR TITLE
Fix backup during shutdown

### DIFF
--- a/rosys/persistence/__init__.py
+++ b/rosys/persistence/__init__.py
@@ -3,7 +3,7 @@ from dataclasses_json import Exclude, config
 from .backup_schedule import BackupSchedule
 from .converters import from_dict, replace_dataclass, replace_dict, replace_list, replace_set, to_dict
 from .persistent_module import PersistentModule
-from .registry import backup, get_export, restore, restore_from_export, write_export
+from .registry import backup, get_export, restore, restore_from_export, sync_backup, write_export
 from .ui import export_button, import_button
 
 exclude: dict[str, dict] = config(exclude=Exclude.ALWAYS)
@@ -19,6 +19,7 @@ __all__ = [
     'PersistentModule',
     'exclude',
     'backup',
+    'sync_backup',
     'restore',
     'get_export',
     'restore_from_export',

--- a/rosys/persistence/registry.py
+++ b/rosys/persistence/registry.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from ..helpers import is_test
-from ..run import awaitable
+from ..run import io_bound
 
 if TYPE_CHECKING:
     from .persistent_module import PersistentModule
@@ -31,8 +31,11 @@ class Encoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-@awaitable
-def backup(force: bool = False) -> None:
+async def backup(force: bool = False) -> None:
+    return await io_bound(sync_backup, force)
+
+
+def sync_backup(force: bool = False) -> None:
     for name, module in modules.items():
         if not module.needs_backup and not force:
             continue

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -19,7 +19,7 @@ from .config import Config
 from .geometry.frame3d_registry import frame_registry
 from .helpers import invoke, is_stopping
 from .helpers import is_test as is_test_
-from .persistence.registry import backup, restore
+from .persistence.registry import backup, restore, sync_backup
 
 log = logging.getLogger('rosys.core')
 
@@ -254,7 +254,7 @@ async def shutdown() -> None:
         log.debug('invoking shutdown handler "%s"', handler.__qualname__)
         await invoke(handler)
     log.debug('creating data backup')
-    await backup(force=True)
+    sync_backup(force=True)
     log.debug('tear down "run" tasks')
     run.tear_down()
     log.debug('stopping all repeaters')


### PR DESCRIPTION
We noticed that persistent modules are not backed up during RoSys shutdown or restart. This problem can be reproduced with this simple example:

```py
from nicegui import ui
from rosys import persistence

class Model(persistence.PersistentModule):

    def __init__(self) -> None:
        super().__init__()
        self.checked = False

    def restore(self, data: dict) -> None:
        self.checked = data.get('checked', False)

    def backup(self) -> dict:
        print('Backup called')
        return {'checked': self.checked}

model = Model()
ui.checkbox('Checked').bind_value(model, 'checked')

ui.run()
```

When causing a reload by touching the Python file, the print statement doesn't appear. The reason is that `backup()`, which is called during shutdown, is decorated with `@awaitable`, wrapping it with an `io_bound` call. But `io_bound` is silently skipped when RoSys `is_stopping()`.

This PR creates an explicit `sync_backup()` which calls (the now undecorated) async `backup()` via `io_bound`. This way everything works like before, but the `shutdown()` handler can call `sync_backup()` and guarantee the backup file being written.