### PR TITLE
Earlier image timestamping

### DIFF
--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -40,9 +40,9 @@ class AxisMjpegDevice(MjpegDevice):
 
     async def set_fps(self, fps: int) -> None:
         self.axis_settings.fps = fps
-        self.url = re.sub(r'fps=\d+', f'fps={fps}', self.url)
-        if 'fps=' not in self.url:
-            self.url += f'&fps={fps}'
+        self._url = re.sub(r'fps=\d+', f'fps={fps}', self._url)
+        if 'fps=' not in self._url:
+            self._url += f'&fps={fps}'
         self.restart_capture()
 
     async def get_resolution(self) -> tuple[int, int]:
@@ -50,9 +50,9 @@ class AxisMjpegDevice(MjpegDevice):
 
     async def set_resolution(self, width: int, height: int) -> None:
         self.axis_settings.resolution = (width, height)
-        self.url = re.sub(r'resolution=\d+x\d+', f'resolution={width}x{height}', self.url)
-        if 'resolution=' not in self.url:
-            self.url += f'&resolution={width}x{height}'
+        self._url = re.sub(r'resolution=\d+x\d+', f'resolution={width}x{height}', self._url)
+        if 'resolution=' not in self._url:
+            self._url += f'&resolution={width}x{height}'
         self.restart_capture()
 
     async def get_mirrored(self) -> bool:
@@ -61,7 +61,7 @@ class AxisMjpegDevice(MjpegDevice):
     async def set_mirrored(self, mirrored: bool) -> None:
         self.axis_settings.mirrored = mirrored
         value = 1 if mirrored else 0
-        self.url = re.sub(r'mirror=\d', f'mirror={value}', self.url)
-        if 'mirror=' not in self.url:
-            self.url += f'&mirror={value}'
+        self._url = re.sub(r'mirror=\d', f'mirror={value}', self._url)
+        if 'mirror=' not in self._url:
+            self._url += f'&mirror={value}'
         self.restart_capture()

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -26,7 +26,7 @@ class AxisMjpegDevice(MjpegDevice):
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes], Awaitable | None]) -> None:
+                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
         super().__init__(mac, ip, index=index, username=username, password=password, on_new_image_data=on_new_image_data)
 
         self.axis_settings = AxisSettings(fps=6, resolution=(640, 480), mirrored=False)

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -89,7 +89,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         self.device.shutdown()
         self.device = None
 
-    async def _handle_new_image_data(self, image: bytes) -> None:
+    async def _handle_new_image_data(self, image: bytes, timestamp: float) -> None:
         if self.crop or self.rotation != ImageRotation.NONE:
             image = await rosys.run.cpu_bound(process_jpeg_image, image, self.rotation, self.crop)
         if image is None:
@@ -99,7 +99,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         except ValueError:
             return
 
-        self._add_image(Image(camera_id=self.id, data=image, time=rosys.time(), size=final_image_resolution))
+        self._add_image(Image(camera_id=self.id, data=image, time=timestamp, size=final_image_resolution))
 
     async def _set_fps(self, fps: int) -> None:
         assert self.device is not None

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -63,7 +63,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
 
     @property
     def is_connected(self) -> bool:
-        return (self.device is not None) and (self.device.capture_task is not None) and (not self.device.capture_task.done())
+        return (self.device is not None) and self.device.is_connected
 
     async def connect(self) -> None:
         if self.is_connected:

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 
 import httpx
 
+from ... import rosys
 from ...rosys import on_startup
 from ..image_processing import remove_exif
 from .vendors import mac_to_url
@@ -16,7 +17,7 @@ class MjpegDevice:
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes], Awaitable | None]) -> None:
+                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
         self.mac = mac
         self.ip = ip
         self.index = index
@@ -95,7 +96,8 @@ class MjpegDevice:
             if not image:
                 continue
             try:
-                result = self.on_new_image_data(remove_exif(image))
+                timestamp = rosys.time()
+                result = self.on_new_image_data(remove_exif(image), timestamp)
                 if isinstance(result, Awaitable):
                     await result
             except Exception as e:

--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -13,7 +13,7 @@ class MjpegDeviceFactory:
                username: str | None = None,
                password: str | None = None,
                control_port: int | None = None,
-               on_new_image_data: Callable[[bytes], Awaitable | None]) -> MjpegDevice:
+               on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> MjpegDevice:
 
         if mac_to_vendor(mac) == VendorType.AXIS:
             return AxisMjpegDevice(mac, ip,

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -10,7 +10,7 @@ class MotecMjpegDevice(MjpegDevice):
                  username: str | None = '',
                  password: str | None = '',
                  control_port: int | None = 8885,
-                 on_new_image_data: Callable[[bytes], Awaitable | None]) -> None:
+                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
 
         super().__init__(mac, ip, username=username, password=password, on_new_image_data=on_new_image_data)
 

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -88,7 +88,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         await self.device.shutdown()
         self.device = None
 
-    async def _handle_new_image_data(self, image_bytes: bytes) -> None:
+    async def _handle_new_image_data(self, image_bytes: bytes, timestamp: float) -> None:
         if not image_bytes:
             return
         transformed_image_bytes = await rosys.run.cpu_bound(process_jpeg_image, image_bytes, self.rotation, self.crop)
@@ -100,7 +100,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         except ValueError:
             return
 
-        image = Image(time=rosys.time(), camera_id=self.id, size=final_image_resolution, data=transformed_image_bytes)
+        image = Image(time=timestamp, camera_id=self.id, size=final_image_resolution, data=transformed_image_bytes)
         self._add_image(image)
 
     async def set_fps(self, fps: int) -> None:

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -54,7 +54,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
     @property
     def is_connected(self) -> bool:
-        return self.device is not None and self.device.capture_task is not None
+        return self.device is not None and self.device.is_connected
 
     @property
     def url(self) -> str | None:

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -8,6 +8,7 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from io import BytesIO
 
 from nicegui import background_tasks
+import rosys
 
 from .jovision_rtsp_interface import JovisionInterface
 from .vendors import VendorType, mac_to_url, mac_to_vendor
@@ -16,7 +17,7 @@ from .vendors import VendorType, mac_to_url, mac_to_vendor
 class RtspDevice:
 
     def __init__(self, mac: str, ip: str, *,
-                 jovision_profile: int, fps: int, on_new_image_data: Callable[[bytes], Awaitable | None]) -> None:
+                 jovision_profile: int, fps: int, on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
         self.log = logging.getLogger('rosys.vision.rtsp_camera.rtsp_device')
 
         self.mac = mac
@@ -171,7 +172,8 @@ class RtspDevice:
                     self._authorized = False
 
         async for image in stream():
-            result = self.on_new_image_data(image)
+            timestamp = rosys.time()
+            result = self.on_new_image_data(image, timestamp)
             if isinstance(result, Awaitable):
                 await result
 

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -18,10 +18,9 @@ class RtspDevice:
 
     def __init__(self, mac: str, ip: str, *,
                  jovision_profile: int, fps: int, on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
-        self.log = logging.getLogger('rosys.vision.rtsp_camera.rtsp_device')
-
         self._mac = mac
         self._ip = ip
+        self.log = logging.getLogger('rosys.vision.rtsp_camera.rtsp_device.' + self._mac)
 
         self._fps = fps
         self._jovision_profile = jovision_profile
@@ -40,10 +39,7 @@ class RtspDevice:
             self.log.warning('[%s] No settings interface for vendor type %s', self._mac, vendor_type)
             self.log.warning('[%s] Using default fps of 10', self._mac)
 
-        url = mac_to_url(mac, ip, jovision_profile)
-        if url is None:
-            raise ValueError(f'could not determine RTSP URL for {mac}')
-        self.log.info('[%s] Starting VideoStream for %s', self._mac, url)
+        self.log.info('[%s] Starting VideoStream for %s', self._mac, self.url)
         self._start_gstreamer_task()
 
     @property

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -8,8 +8,8 @@ from collections.abc import AsyncGenerator, Awaitable, Callable
 from io import BytesIO
 
 from nicegui import background_tasks
-import rosys
 
+from ... import rosys
 from .jovision_rtsp_interface import JovisionInterface
 from .vendors import VendorType, mac_to_url, mac_to_vendor
 

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -20,31 +20,35 @@ class RtspDevice:
                  jovision_profile: int, fps: int, on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
         self.log = logging.getLogger('rosys.vision.rtsp_camera.rtsp_device')
 
-        self.mac = mac
-        self.ip = ip
+        self._mac = mac
+        self._ip = ip
 
-        self.fps = fps
-        self.jovision_profile = jovision_profile
-        self.on_new_image_data = on_new_image_data
+        self._fps = fps
+        self._jovision_profile = jovision_profile
+        self._on_new_image_data = on_new_image_data
 
-        self.capture_task: asyncio.Task | None = None
-        self.capture_process: Process | None = None
+        self._capture_task: asyncio.Task | None = None
+        self._capture_process: Process | None = None
         self._authorized: bool = True
 
         vendor_type = mac_to_vendor(mac)
 
-        self.settings_interface: JovisionInterface | None = None
+        self._settings_interface: JovisionInterface | None = None
         if vendor_type == VendorType.JOVISION:
-            self.settings_interface = JovisionInterface(ip)
+            self._settings_interface = JovisionInterface(ip)
         else:
-            self.log.warning('[%s] No settings interface for vendor type %s', self.mac, vendor_type)
-            self.log.warning('[%s] Using default fps of 10', self.mac)
+            self.log.warning('[%s] No settings interface for vendor type %s', self._mac, vendor_type)
+            self.log.warning('[%s] Using default fps of 10', self._mac)
 
         url = mac_to_url(mac, ip, jovision_profile)
         if url is None:
             raise ValueError(f'could not determine RTSP URL for {mac}')
-        self.log.info('[%s] Starting VideoStream for %s', self.mac, url)
+        self.log.info('[%s] Starting VideoStream for %s', self._mac, url)
         self._start_gstreamer_task()
+
+    @property
+    def is_connected(self) -> bool:
+        return self._capture_task is not None
 
     @property
     def authorized(self) -> bool:
@@ -52,51 +56,51 @@ class RtspDevice:
 
     @property
     def url(self) -> str:
-        url = mac_to_url(self.mac, self.ip, self.jovision_profile)
+        url = mac_to_url(self._mac, self._ip, self._jovision_profile)
         if url is None:
-            raise ValueError(f'could not determine RTSP URL for {self.mac}')
+            raise ValueError(f'could not determine RTSP URL for {self._mac}')
         return url
 
     async def shutdown(self) -> None:
-        if self.capture_process is not None:
-            self.log.debug('[%s] Terminating gstreamer process', self.mac)
-            self.capture_process.terminate()
+        if self._capture_process is not None:
+            self.log.debug('[%s] Terminating gstreamer process', self._mac)
+            self._capture_process.terminate()
             try:
-                await asyncio.wait_for(self.capture_process.wait(), timeout=5)
+                await asyncio.wait_for(self._capture_process.wait(), timeout=5)
             except asyncio.TimeoutError:
-                self.log.warning('[%s] Timeout while waiting for gstreamer process to terminate', self.mac)
+                self.log.warning('[%s] Timeout while waiting for gstreamer process to terminate', self._mac)
             else:
                 self.log.debug('[%s] Successfully shut down process (code %s)',
-                               self.mac, self.capture_process.returncode if self.capture_process.returncode is not None else 'None')
-                self.capture_process = None
-        if self.capture_task is not None and not self.capture_task.done():
-            self.log.debug('[%s] Cancelling gstreamer task', self.mac)
-            self.capture_task.cancel()
+                               self._mac, self._capture_process.returncode if self._capture_process.returncode is not None else 'None')
+                self._capture_process = None
+        if self._capture_task is not None and not self._capture_task.done():
+            self.log.debug('[%s] Cancelling gstreamer task', self._mac)
+            self._capture_task.cancel()
             try:
-                await asyncio.wait_for(self.capture_task, timeout=5)
+                await asyncio.wait_for(self._capture_task, timeout=5)
             except asyncio.TimeoutError:
-                self.log.warning('[%s] Timeout while waiting for capture task to cancel', self.mac)
+                self.log.warning('[%s] Timeout while waiting for capture task to cancel', self._mac)
                 return
             except asyncio.CancelledError:
-                self.log.debug('[%s] Task was successfully cancelled', self.mac)
+                self.log.debug('[%s] Task was successfully cancelled', self._mac)
             else:
-                self.log.debug('[%s] Task finished', self.mac)
-            self.capture_task = None
+                self.log.debug('[%s] Task finished', self._mac)
+            self._capture_task = None
 
     def _start_gstreamer_task(self) -> None:
-        self.log.debug('[%s] Starting gstreamer task', self.mac)
-        if self.capture_task is not None and not self.capture_task.done():
-            self.log.warning('[%s] capture task already running', self.mac)
+        self.log.debug('[%s] Starting gstreamer task', self._mac)
+        if self._capture_task is not None and not self._capture_task.done():
+            self.log.warning('[%s] capture task already running', self._mac)
             return
-        self.capture_task = background_tasks.create(self._run_gstreamer(), name=f'capture {self.mac}')
+        self._capture_task = background_tasks.create(self._run_gstreamer(), name=f'capture {self._mac}')
 
     async def restart_gstreamer(self) -> None:
         await self.shutdown()
         self._start_gstreamer_task()
 
     async def _run_gstreamer(self) -> None:
-        if self.capture_process is not None and self.capture_process.returncode is None:
-            self.log.warning('[%s] capture process already running', self.mac)
+        if self._capture_process is not None and self._capture_process.returncode is None:
+            self.log.warning('[%s] capture process already running', self._mac)
             return
 
         async def stream() -> AsyncGenerator[bytes, None]:
@@ -104,10 +108,10 @@ class RtspDevice:
             if 'subtype=0' in url:
                 url = url.replace('subtype=0', 'subtype=1')
 
-            self.log.debug('[%s] Starting gstreamer pipeline for %s', self.mac, url)
+            self.log.debug('[%s] Starting gstreamer pipeline for %s', self._mac, url)
             # to try: replace avdec_h264 with nvh264dec ! nvvidconv (!videoconvert)
             command = f'gst-launch-1.0 rtspsrc location="{url}" latency=0 protocols=tcp ! rtph264depay ! avdec_h264 ! videoconvert ! jpegenc ! fdsink'
-            self.log.debug('[%s] Running command: %s', self.mac, command)
+            self.log.debug('[%s] Running command: %s', self._mac, command)
             process = await asyncio.create_subprocess_exec(
                 *shlex.split(command),
                 stdout=subprocess.PIPE,
@@ -116,7 +120,7 @@ class RtspDevice:
             )
             assert process.stdout is not None
             assert process.stderr is not None
-            self.capture_process = process
+            self._capture_process = process
 
             buffer = BytesIO()
             chunk_size = 1024*1024
@@ -156,7 +160,7 @@ class RtspDevice:
                 await asyncio.wait_for(process.wait(), timeout=5)
             except asyncio.TimeoutError:
                 self.log.warning(
-                    '[%s] Stream ended. Timeout while waiting for gstreamer process to terminate', self.mac)
+                    '[%s] Stream ended. Timeout while waiting for gstreamer process to terminate', self._mac)
                 return
 
             return_code = process.returncode
@@ -173,36 +177,36 @@ class RtspDevice:
 
         async for image in stream():
             timestamp = rosys.time()
-            result = self.on_new_image_data(image, timestamp)
+            result = self._on_new_image_data(image, timestamp)
             if isinstance(result, Awaitable):
                 await result
 
-        self.log.info('[%s] stream ended', self.mac)
+        self.log.info('[%s] stream ended', self._mac)
 
-        self.capture_task = None
+        self._capture_task = None
 
     async def set_fps(self, fps: int) -> None:
-        self.fps = fps
+        self._fps = fps
 
-        if self.settings_interface is not None:
-            await self.settings_interface.set_fps(stream_id=self.jovision_profile, fps=self.fps)
+        if self._settings_interface is not None:
+            await self._settings_interface.set_fps(stream_id=self._jovision_profile, fps=self._fps)
 
     async def get_fps(self) -> int | None:
-        if self.settings_interface is not None:
-            return await self.settings_interface.get_fps(stream_id=self.jovision_profile)
-        return self.fps
+        if self._settings_interface is not None:
+            return await self._settings_interface.get_fps(stream_id=self._jovision_profile)
+        return self._fps
 
     def set_jovision_profile(self, profile: int) -> None:
-        self.jovision_profile = profile
+        self._jovision_profile = profile
 
     def get_jovision_profile(self) -> int:
-        return self.jovision_profile
+        return self._jovision_profile
 
     async def set_bitrate(self, bitrate: int) -> None:
-        if self.settings_interface is not None:
-            await self.settings_interface.set_bitrate(stream_id=self.jovision_profile, bitrate=bitrate)
+        if self._settings_interface is not None:
+            await self._settings_interface.set_bitrate(stream_id=self._jovision_profile, bitrate=bitrate)
 
     async def get_bitrate(self) -> int | None:
-        if self.settings_interface is not None:
-            return await self.settings_interface.get_bitrate(stream_id=self.jovision_profile)
+        if self._settings_interface is not None:
+            return await self._settings_interface.get_bitrate(stream_id=self._jovision_profile)
         return None

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -1,6 +1,5 @@
 import random
 
-from ... import rosys
 from ..camera.configurable_camera import ConfigurableCamera
 from ..camera.transformable_camera import TransformableCamera
 from ..image import Image, ImageSize

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -52,8 +52,8 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
     async def disconnect(self) -> None:
         self.device = None
 
-    def _handle_new_image_data(self, image_data: bytes) -> None:
-        image = Image(time=rosys.time(), camera_id=self.id, size=self.resolution, data=image_data)
+    async def _handle_new_image_data(self, image_data: bytes, timestamp: float) -> None:
+        image = Image(time=timestamp, camera_id=self.id, size=self.resolution, data=image_data)
         self._add_image(image)
 
     def _set_color(self, value: str) -> None:

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -16,7 +16,7 @@ class SimulatedDevice:
                  id: str,  # pylint: disable=redefined-builtin
                  *,
                  size: ImageSize,
-                 on_new_image_data: Callable[[bytes], Awaitable | None],
+                 on_new_image_data: Callable[[bytes, float], Awaitable | None],
                  color: str = '#ffffff',
                  fps: float = 30.0) -> None:
         self.id = id
@@ -28,13 +28,14 @@ class SimulatedDevice:
         self.repeater = rosys.on_repeat(self._create_image, interval=1.0 / fps)
 
     async def _create_image(self) -> None:
+        timestamp = rosys.time()
         if rosys.is_test:
             image_data = b'test data'
         else:
             image_data = await rosys.run.cpu_bound(_create_image_data, self.id, self.size, self.color)
         if not image_data:
             return
-        result = self.on_new_image_data(image_data)
+        result = self.on_new_image_data(image_data, timestamp)
         if isinstance(result, Awaitable):
             await result
 

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -78,7 +78,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         self.device = None
         logging.info('camera %s: disconnected', self.id)
 
-    async def _handle_new_image_data(self, image_array: np.ndarray) -> None:
+    async def _handle_new_image_data(self, image_array: np.ndarray, timestamp: float) -> None:
         if not self.is_connected:
             return None
 
@@ -101,7 +101,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         image_size = ImageSize(width=image_array.shape[1], height=image_array.shape[0])
         final_image_resolution = self._resolution_after_transform(image_size)
 
-        image = Image(time=rosys.time(), camera_id=self.id, size=final_image_resolution, data=bytes_)
+        image = Image(time=timestamp, camera_id=self.id, size=final_image_resolution, data=bytes_)
         self._add_image(image)
 
     def set_auto_exposure(self, auto: bool) -> None:

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -74,7 +74,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
             return
 
         assert self.device is not None
-        await rosys.run.io_bound(self.device.capture.release)
+        await self.device.release_capture()
         self.device = None
         logging.info('camera %s: disconnected', self.id)
 

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -105,8 +105,11 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
 
     def set_auto_exposure(self, auto: bool) -> None:
         assert self.device is not None
-        fallback_exposure = self._parameters['exposure'].value
-        self.device.set_auto_exposure(auto, fallback_exposure)
+        self.device.set_auto_exposure(auto)
+        if not auto:
+            manual_exposure = self._parameters['exposure'].value
+            assert manual_exposure is not None
+            self.device.set_exposure(manual_exposure)
 
     def set_exposure(self, value: float) -> None:
         assert self.device is not None

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -106,70 +106,41 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
 
     def set_auto_exposure(self, auto: bool) -> None:
         assert self.device is not None
-
-        device = self.device
-
-        if device.has_manual_exposure:
-            is_auto_exposure = self.get_auto_exposure()
-            if auto and not is_auto_exposure:
-                # self.log.info(f'activating auto-exposure for {self.id}')
-                device.capture.set(cv2.CAP_PROP_AUTO_EXPOSURE, 3)
-            else:
-                device.capture.set(cv2.CAP_PROP_AUTO_EXPOSURE, 1)
-                self.set_exposure(self._parameters['exposure'].value)
+        fallback_exposure = self._parameters['exposure'].value
+        self.device.set_auto_exposure(auto, fallback_exposure)
 
     def set_exposure(self, value: float) -> None:
         assert self.device is not None
-
-        device = self.device
-        assert device.capture is not None
-
-        if device.has_manual_exposure:
-            is_auto_exposure = self.get_auto_exposure()
-            if not is_auto_exposure:
-                exposure = device.capture.get(cv2.CAP_PROP_EXPOSURE) / device.exposure_max
-                if value != exposure:
-                    device.capture.set(cv2.CAP_PROP_EXPOSURE, int(value * device.exposure_max))
+        self.device.set_exposure(value)
 
     def get_auto_exposure(self) -> bool | None:
         assert self.device is not None
-        device = self.device
-        return device.capture.get(cv2.CAP_PROP_AUTO_EXPOSURE) == 3
+        return self.device.get_auto_exposure()
 
     def get_exposure(self) -> float | None:
         assert self.device is not None
-
-        device = self.device
-        if not device.has_manual_exposure:
-            return None
-        return device.capture.get(cv2.CAP_PROP_EXPOSURE) / device.exposure_max
+        return self.device.get_exposure()
 
     def set_width(self, width: int) -> None:
         assert self.device is not None
-        device = self.device
-        device.capture.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+        self.device.set_width(width)
 
     def get_width(self) -> int:
         assert self.device is not None
-        device = self.device
-        return int(device.capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+        return self.device.get_width()
 
     def set_height(self, height: int) -> None:
         assert self.device is not None
-        device = self.device
-        device.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+        self.device.set_height(height)
 
     def get_height(self) -> int:
         assert self.device is not None
-        device = self.device
-        return int(device.capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        return self.device.get_height()
 
     def set_fps(self, fps: int) -> None:
         assert self.device is not None
-        device = self.device
-        device.capture.set(cv2.CAP_PROP_FPS, fps)
+        self.device.set_fps(fps)
 
     def get_fps(self) -> int:
         assert self.device is not None
-        device = self.device
-        return int(device.capture.get(cv2.CAP_PROP_FPS))
+        return self.device.get_fps()

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any
 
-import cv2
 import numpy as np
 from typing_extensions import Self
 

--- a/rosys/vision/usb_camera/usb_device.py
+++ b/rosys/vision/usb_camera/usb_device.py
@@ -123,15 +123,12 @@ class UsbDevice:
             if self._capture.get(cv2.CAP_PROP_BUFFERSIZE) != 1:
                 self._capture.set(cv2.CAP_PROP_BUFFERSIZE, 1)
 
-    def set_auto_exposure(self, auto: bool, fallback_exposure: float) -> None:
+    def set_auto_exposure(self, auto: bool) -> None:
         if self._has_manual_exposure:
-            is_auto_exposure = self.get_auto_exposure()
-            if auto and not is_auto_exposure:
-                # self.log.info(f'activating auto-exposure for {self.id}')
+            if auto:
                 self._capture.set(cv2.CAP_PROP_AUTO_EXPOSURE, 3)
             else:
                 self._capture.set(cv2.CAP_PROP_AUTO_EXPOSURE, 1)
-                self.set_exposure(fallback_exposure)
 
     def set_exposure(self, value: float) -> None:
         if self._has_manual_exposure:


### PR DESCRIPTION
Gets the timestamp for images in each camera earlier (mainly before any further image procession).
This is not critical but should make the timestamps a little more accurate. 