### PR TITLE
image route max_size parameter

### DIFF
--- a/rosys/vision/image_route.py
+++ b/rosys/vision/image_route.py
@@ -13,7 +13,6 @@ from .. import run
 from .calibration import Calibration
 from .image import Image
 
-
 if TYPE_CHECKING:
     from .camera import Camera
 


### PR DESCRIPTION
adds a `max_size` parameter to determine the necessary shrink based on the image size

resulting shrink is always the maximum between (`shrink`, `shrink_from_max_size`)
meaning you can still apply a base shrink AND set a maximum

Here, "size"  (in `max_size`) refers to the maximum dimension of the image. I would like some feedback on that name. 

I was also considering a maximum pixel area instead (e.g. 1.5 MP), but felt like that would be more confusing.