### PR TITLE
Fix selectable lizard version

### DIFF
--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -49,7 +49,7 @@ class LizardFirmware:
         if response is None:
             return
         response_data = response.json()
-        for i, item in enumerate(response_data):
+        for item in response_data:
             try:
                 assert 'tag_name' in item
                 version_name = item['tag_name'].removeprefix('v')

--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -53,8 +53,6 @@ class LizardFirmware:
             try:
                 assert 'tag_name' in item
                 version_name = item['tag_name'].removeprefix('v')
-                if i == 0:
-                    self.selected_online_version = version_name
                 assert 'assets' in item
                 browser_download_url = item['assets'][0]['browser_download_url']
                 if not browser_download_url.endswith('.zip'):

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -67,7 +67,7 @@ class RobotBrain:
 
         with ui.row().classes('items-center'):
             version_select = ui.select([], label='Lizard Version').style('min-width: 140px;') \
-                .bind_value(self.lizard_firmware, 'selected_online_version')
+                .bind_value_to(self.lizard_firmware, 'selected_online_version')
             ui.button(on_click=read_online_versions).props('icon=refresh flat round dense') \
                 .tooltip('Read all available versions from GitHub')
             online_update_button = ui.button(on_click=online_update).props('icon=file_download flat round dense') \

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -51,7 +51,8 @@ class RobotBrain:
         async def read_online_versions() -> None:
             await self.lizard_firmware.read_online_version()
             version_select.set_options(list(self.lizard_firmware.online_versions.keys()))
-            version_select.value = version_select.options[0]
+            if len(version_select.options) > 0:
+                version_select.value = version_select.options[0]
 
         async def online_update() -> None:
             await self.lizard_firmware.download()

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -51,6 +51,7 @@ class RobotBrain:
         async def read_online_versions() -> None:
             await self.lizard_firmware.read_online_version()
             version_select.set_options(list(self.lizard_firmware.online_versions.keys()))
+            version_select.value = version_select.options[0]
 
         async def online_update() -> None:
             await self.lizard_firmware.download()

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -50,8 +50,8 @@ class RobotBrain:
 
         async def read_online_versions() -> None:
             await self.lizard_firmware.read_online_version()
-            version_select.set_options(list(self.lizard_firmware.online_versions.keys()))
-            if len(version_select.options) > 0:
+            version_select.set_options(list(self.lizard_firmware.online_versions))
+            if version_select.options:
                 version_select.value = version_select.options[0]
 
         async def online_update() -> None:

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -53,7 +53,6 @@ class RobotBrain:
             version_select.set_options(list(self.lizard_firmware.online_versions.keys()))
             if len(version_select.options) > 0:
                 version_select.value = version_select.options[0]
-                self.lizard_firmware.selected_online_version = version_select.value
 
         async def online_update() -> None:
             await self.lizard_firmware.download()

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -53,6 +53,7 @@ class RobotBrain:
             version_select.set_options(list(self.lizard_firmware.online_versions.keys()))
             if len(version_select.options) > 0:
                 version_select.value = version_select.options[0]
+                self.lizard_firmware.selected_online_version = version_select.value
 
         async def online_update() -> None:
             await self.lizard_firmware.download()


### PR DESCRIPTION
Using `bind_value` on `version_select` leads to a recursion error.
I'm not quite sure yet what causes this, but using `bind_value_to` helps.

Additionally, 329ad6dfb3a1d5507ab1c1ec0af70675d302c7a2 sets the selection to the latest version when the list is updated.

```
rosys_1  | 2024-11-04 23:18:34.374 [ERROR] nicegui/app/app.py:122: maximum recursion depth exceeded
rosys_1  | Traceback (most recent call last):
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/events.py", line 430, in handle_event
rosys_1  |     result = cast(Callable[[EventT], Any], handler)(arguments)
rosys_1  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/mixins/value_element.py", line 40, in handle_change
rosys_1  |     self.set_value(self._event_args_to_value(e))
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/mixins/value_element.py", line 108, in set_value
rosys_1  |     self.value = value
rosys_1  |     ^^^^^^^^^^
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 153, in __set__
rosys_1  |     _propagate(owner, self.name)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 77, in _propagate
rosys_1  |     _propagate(target_obj, target_name, visited)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 76, in _propagate
rosys_1  |     _set_attribute(target_obj, target_name, target_value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 33, in _set_attribute
rosys_1  |     setattr(obj, name, value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 153, in __set__
rosys_1  |     _propagate(owner, self.name)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 77, in _propagate
rosys_1  |     _propagate(target_obj, target_name, visited)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 76, in _propagate
rosys_1  |     _set_attribute(target_obj, target_name, target_value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 33, in _set_attribute
rosys_1  |     setattr(obj, name, value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 153, in __set__
rosys_1  |     _propagate(owner, self.name)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 77, in _propagate
rosys_1  |     _propagate(target_obj, target_name, visited)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 76, in _propagate
rosys_1  |     _set_attribute(target_obj, target_name, target_value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 33, in _set_attribute
rosys_1  |     setattr(obj, name, value)
...
...
...
...
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 153, in __set__
rosys_1  |     _propagate(owner, self.name)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 77, in _propagate
rosys_1  |     _propagate(target_obj, target_name, visited)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 76, in _propagate
rosys_1  |     _set_attribute(target_obj, target_name, target_value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 33, in _set_attribute
rosys_1  |     setattr(obj, name, value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 155, in __set__
rosys_1  |     self._change_handler(owner, value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/mixins/value_element.py", line 23, in <lambda>
rosys_1  |     on_change=lambda sender, value: cast(Self, sender)._handle_value_change(value))  # pylint: disable=protected-access
rosys_1  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/mixins/validation_element.py", line 74, in _handle_value_change
rosys_1  |     super()._handle_value_change(value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/mixins/value_element.py", line 113, in _handle_value_change
rosys_1  |     self.update()
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/choice_element.py", line 37, in update
rosys_1  |     self._update_options()
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/choice_element.py", line 33, in _update_options
rosys_1  |     self.value = before_value if before_value in self._values else None
rosys_1  |     ^^^^^^^^^^
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 153, in __set__
rosys_1  |     _propagate(owner, self.name)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 77, in _propagate
rosys_1  |     _propagate(target_obj, target_name, visited)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 76, in _propagate
rosys_1  |     _set_attribute(target_obj, target_name, target_value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 33, in _set_attribute
rosys_1  |     setattr(obj, name, value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/binding.py", line 155, in __set__
rosys_1  |     self._change_handler(owner, value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/mixins/value_element.py", line 23, in <lambda>
rosys_1  |     on_change=lambda sender, value: cast(Self, sender)._handle_value_change(value))  # pylint: disable=protected-access
rosys_1  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/mixins/validation_element.py", line 74, in _handle_value_change
rosys_1  |     super()._handle_value_change(value)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/mixins/value_element.py", line 113, in _handle_value_change
rosys_1  |     self.update()
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/elements/choice_element.py", line 38, in update
rosys_1  |     super().update()
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/element.py", line 388, in update
rosys_1  |     self.client.outbox.enqueue_update(self)
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/outbox.py", line 41, in enqueue_update
rosys_1  |     self._set_enqueue_event()
rosys_1  |   File "/usr/local/lib/python3.12/site-packages/nicegui/outbox.py", line 35, in _set_enqueue_event
rosys_1  |     self._enqueue_event.set()
rosys_1  | RecursionError: maximum recursion depth exceeded
```