### PR TITLE
Add type annotation and kwargs to `run.io_bound` and `run.cpu_bound`

### DIFF
--- a/rosys/analysis/legacy/asyncio_page.py
+++ b/rosys/analysis/legacy/asyncio_page.py
@@ -31,9 +31,10 @@ class AsyncioPage(ui.element):
         super().__init__()
 
         async def update() -> None:
-            names, data = await run.cpu_bound(prepare_data, asyncio_monitor.timings)
-            chart.options['xAxis']['categories'][:] = names
-            chart.options['series']['data'][:] = data
+            result = await run.cpu_bound(prepare_data, asyncio_monitor.timings)
+            assert result is not None
+            chart.options['xAxis']['categories'][:] = result[0]
+            chart.options['series']['data'][:] = result[1]
             chart.update()
 
         with self:

--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -45,8 +45,11 @@ class LizardFirmware:
         await self.read_core_checksum()
 
     async def read_online_version(self) -> None:
-        response = (await rosys.run.io_bound(requests.get, self.GITHUB_URL)).json()
-        for i, item in enumerate(response):
+        response = await rosys.run.io_bound(requests.get, self.GITHUB_URL)
+        if response is None:
+            return
+        response_data = response.json()
+        for i, item in enumerate(response_data):
             try:
                 assert 'tag_name' in item
                 version_name = item['tag_name'].removeprefix('v')
@@ -58,7 +61,7 @@ class LizardFirmware:
                     continue
                 self.online_versions[version_name] = browser_download_url
             except KeyError:
-                rosys.notify(response.get('message', 'Could not access online version'), 'warning')
+                rosys.notify(response_data.get('message', 'Could not access online version'), 'warning')
                 break
 
     def read_local_version(self) -> None:

--- a/rosys/run.py
+++ b/rosys/run.py
@@ -23,9 +23,9 @@ running_sh_processes: list[subprocess.Popen] = []
 log = logging.getLogger('rosys.run')
 
 
-async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:
     if is_stopping():
-        return
+        return None
     try:
         return await run.io_bound(callback, *args, **kwargs)
     except RuntimeError as e:
@@ -33,6 +33,7 @@ async def io_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) 
             raise
     except asyncio.exceptions.CancelledError:
         pass
+    return None
 
 
 def awaitable(func: Callable) -> Callable:
@@ -43,9 +44,9 @@ def awaitable(func: Callable) -> Callable:
     return inner
 
 
-async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R:
+async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs) -> R | None:
     if is_stopping():
-        return
+        return None
     with cpu():
         try:
             return await run.cpu_bound(callback, *args, **kwargs)
@@ -54,6 +55,7 @@ async def cpu_bound(callback: Callable[P, R], *args: P.args, **kwargs: P.kwargs)
                 raise
         except asyncio.exceptions.CancelledError:
             pass
+    return None
 
 
 @contextmanager
@@ -111,7 +113,9 @@ async def sh(command: list[str] | str, *,
     if is_stopping():
         return ''
     try:
-        return await asyncio.wait_for(io_bound(popen), timeout) or ''
+        async def popen_coro() -> str:
+            return await io_bound(popen) or ''
+        return await asyncio.wait_for(popen_coro(), timeout)
     except asyncio.TimeoutError:
         log.warning('Command "%s" timed out after %s seconds.', command, timeout)
         return ''

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -91,9 +91,10 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
 
     async def _handle_new_image_data(self, image: bytes, timestamp: float) -> None:
         if self.crop or self.rotation != ImageRotation.NONE:
-            image = cast(bytes, await rosys.run.cpu_bound(process_jpeg_image, image, self.rotation, self.crop))
-        if image is None:
-            return
+            image_ = await rosys.run.cpu_bound(process_jpeg_image, image, self.rotation, self.crop)
+            if image_ is None:
+                return
+            image = image_
         try:
             final_image_resolution = get_image_size_from_bytes(image)
         except ValueError:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, cast
 
 from typing_extensions import Self
 
@@ -91,7 +91,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
 
     async def _handle_new_image_data(self, image: bytes, timestamp: float) -> None:
         if self.crop or self.rotation != ImageRotation.NONE:
-            image = await rosys.run.cpu_bound(process_jpeg_image, image, self.rotation, self.crop)
+            image = cast(bytes, await rosys.run.cpu_bound(process_jpeg_image, image, self.rotation, self.crop))
         if image is None:
             return
         try:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, cast
+from typing import Any
 
 from typing_extensions import Self
 

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -32,6 +32,7 @@ class SimulatedDevice:
 
     async def _create_image(self) -> None:
         timestamp = rosys.time()
+        image_data: bytes | None
         if rosys.is_test:
             image_data = b'test data'
         else:

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -88,8 +88,11 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         def to_bytes(image: list[np.ndarray]) -> bytes:
             return image[0].tobytes()
 
+        bytes_: bytes | None
         if image_is_MJPG:
             bytes_ = await rosys.run.io_bound(to_bytes, image_array)
+            if bytes_ is None:
+                return
             if self.crop or self.rotation != ImageRotation.NONE:
                 bytes_ = await rosys.run.cpu_bound(process_jpeg_image, bytes_, self.rotation, self.crop)
         else:

--- a/rosys/vision/usb_camera/usb_device.py
+++ b/rosys/vision/usb_camera/usb_device.py
@@ -76,10 +76,10 @@ class UsbDevice:
     async def _capture_image(self) -> None:
         if not self._capture.isOpened():
             return
-        result = await rosys.run.io_bound(self._capture.read)
-        if result is None:
+        read_result = await rosys.run.io_bound(self._capture.read)
+        if read_result is None:
             return
-        capture_success, frame = result
+        capture_success, frame = read_result
         if capture_success:
             timestamp = rosys.time()
             result = self._on_new_image_data(frame, timestamp)

--- a/rosys/vision/usb_camera/usb_device.py
+++ b/rosys/vision/usb_camera/usb_device.py
@@ -30,7 +30,7 @@ def to_bytes(image: np.ndarray) -> bytes:
 class UsbDevice:
 
     def __init__(self, video_id: int, capture: cv2.VideoCapture, *,
-                 on_new_image_data: Callable[[np.ndarray, float], Awaitable | None]) -> None:
+                 on_new_image_data: Callable[[np.ndarray | bytes, float], Awaitable | None]) -> None:
         self._video_id: int = video_id
         self._capture: cv2.VideoCapture = capture
         self._on_new_image_data = on_new_image_data


### PR DESCRIPTION
As noticed by @denniswittich, IO- and CPU-bound functions in RoSys are missing type annotations for parameters and return values. Apart from that `run.cpu_bound` is missing `kwargs`.

While this PR adds both, it unveils several type errors in connection with `run.cpu_bound` and `run.io_bound`:
```
rosys/run.py:26: error: Missing return statement  [return]
rosys/run.py:28: error: Return value expected  [return-value]
rosys/run.py:46: error: Missing return statement  [return]
rosys/run.py:48: error: Return value expected  [return-value]
rosys/vision/usb_camera/usb_device.py:85: error: Incompatible types in assignment (expression has type "Awaitable[Any] | None", variable has type "tuple[bool, Mat | ndarray[Any, dtype[integer[Any] | floating[Any]]]]")  [assignment]
rosys/vision/usb_camera/usb_camera.py:92: error: Argument 2 to "io_bound" has incompatible type "ndarray[Any, Any]"; expected "list[ndarray[Any, Any]]"  [arg-type]
rosys/vision/usb_camera/usb_camera.py:94: error: Argument 1 to "cpu_bound" has incompatible type "Callable[[bytes, ImageRotation, Rectangle | None], bytes | None]"; expected "Callable[[bytes, ImageRotation, Rectangle | None], bytes]"  [arg-type]
rosys/vision/mjpeg_camera/mjpeg_camera.py:94: error: Argument 1 to "cpu_bound" has incompatible type "Callable[[bytes, ImageRotation, Rectangle | None], bytes | None]"; expected "Callable[[bytes, ImageRotation, Rectangle | None], bytes]"  [arg-type]
```

We should fix them before merging into main.