### PR TITLE
detectors: image creation date

### DIFF
--- a/rosys/vision/detector.py
+++ b/rosys/vision/detector.py
@@ -43,7 +43,7 @@ class Detector(abc.ABC):
                      autoupload: Autoupload = Autoupload.FILTERED,
                      tags: list[str] | None = None,
                      source: str | None = None,
-                     creation_date: datetime | str | None = None
+                     creation_date: datetime | str | None = None,
                      ) -> Detections | None:
         """Runs detections on the image. Afterwards the `image.detections` property is filled.
 
@@ -51,10 +51,12 @@ class Detector(abc.ABC):
         """
 
     @abc.abstractmethod
-    async def upload(self, image: Image, *,
+    async def upload(self,
+                     image: Image,
+                     *,
                      tags: list[str] | None = None,
                      source: str | None = None,
-                     creation_date: datetime | str | None = None
+                     creation_date: datetime | str | None = None,
                      ) -> None:
         """Uploads the image to the Learning Loop.
 

--- a/rosys/vision/detector_hardware.py
+++ b/rosys/vision/detector_hardware.py
@@ -122,7 +122,7 @@ class DetectorHardware(Detector):
                      autoupload: Autoupload = Autoupload.FILTERED,
                      tags: list[str] | None = None,
                      source: str | None = None,
-                     creation_date: datetime | str | None = None
+                     creation_date: datetime | str | None = None,
                      ) -> Detections | None:
         assert len(image.data or []) < self.MAX_IMAGE_SIZE, f'image too large: {len(image.data or [])}'
         tags = tags or []
@@ -133,7 +133,7 @@ class DetectorHardware(Detector):
                       autoupload: Autoupload,
                       tags: list[str],
                       source: str | None = None,
-                      creation_date: datetime | str | None = None
+                      creation_date: datetime | str | None = None,
                       ) -> Detections | None:
         if image.is_broken:
             return None
@@ -146,7 +146,7 @@ class DetectorHardware(Detector):
                 'source': source,
                 'creation_date': _creation_date_to_isoformat(creation_date),
             }, timeout=3)
-            assert isinstance(result, dict), 'Error: Result returned by detect call was not a dictionary'
+            assert isinstance(result, dict)
             if image.is_broken:  # NOTE: image can be marked broken while detection is underway
                 return None
             detections = Detections(

--- a/rosys/vision/detector_simulation.py
+++ b/rosys/vision/detector_simulation.py
@@ -62,7 +62,7 @@ class DetectorSimulation(Detector):
                      autoupload: Autoupload = Autoupload.FILTERED,
                      tags: list[str] | None = None,
                      source: str | None = None,
-                     creation_date: datetime | str | None = None
+                     creation_date: datetime | str | None = None,
                      ) -> Detections | None:
         is_blocked = image.camera_id in self.blocked_cameras
         await rosys.sleep(self.detection_delay)
@@ -73,7 +73,9 @@ class DetectorSimulation(Detector):
         self.NEW_DETECTIONS.emit(image)
         return image.get_detections(self.name)
 
-    async def upload(self, image: Image, *,
+    async def upload(self,
+                     image: Image,
+                     *,
                      tags: list[str] | None = None,
                      source: str | None = None,
                      creation_date: datetime | str | None = None,


### PR DESCRIPTION
enable to set custom creation date when uploading an image or when running inference using a detector. This requires detectors that use learning loop node library 0.11.1 or higher.