### PR TITLE
update GitHub action to support multiple platforms

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,14 @@ jobs:
   docker:
     needs: pypi
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          [
+            { platform: linux/amd64, cache: buildcache-amd64 },
+            { platform: linux/arm64, cache: buildcache-arm64 },
+          ]
     steps:
       - uses: actions/checkout@v4
       - name: Prepare
@@ -103,13 +111,18 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.build.platform }}
           build-args: INSTALL_DEV=true
           push: true
           tags: ${{ steps.prep.outputs.tags }}
-          cache-from: type=registry,ref=${{ steps.prep.outputs.docker_image }}:buildcache
-          cache-to: type=registry,ref=${{ steps.prep.outputs.docker_image }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ steps.prep.outputs.docker_image }}:${{ matrix.build.cache }}
+          cache-to: type=registry,ref=${{ steps.prep.outputs.docker_image }}:${{ matrix.build.cache }},mode=max
 
+  readme:
+    runs-on: ubuntu-latest
+    needs: docker
+    steps:
+      - uses: actions/checkout@v4
       # Uploading the README.md is not a core feature of docker/build-push-action yet
       - name: Update README
         uses: christian-korneck/update-container-description-action@v1


### PR DESCRIPTION
This PR adds multiplatform cache to the publish pipeline. According to [this](https://github.com/docker/buildx/issues/1044) and [this](https://github.com/docker/buildx/discussions/1382) the cache in the registry needs to be separated for different build platforms. So, arm64 and amd64 now each get their own cache location.
To only run the update readme step once, it gets its own job.