### PR TITLE
add persistence_key parameter CameraProvider Constructor

### DIFF
--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -19,7 +19,7 @@ class CameraProvider(Generic[T], persistence.PersistentModule, metaclass=abc.ABC
     The camera provider also creates an HTTP route to access camera images.
     """
 
-    def __init__(self, persistence_key: str | None = None) -> None:
+    def __init__(self, *, persistence_key: str | None = None) -> None:
         super().__init__(persistence_key=persistence_key)
 
         self.CAMERA_ADDED = Event()

--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -19,8 +19,8 @@ class CameraProvider(Generic[T], persistence.PersistentModule, metaclass=abc.ABC
     The camera provider also creates an HTTP route to access camera images.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, persistence_key: str | None = None) -> None:
+        super().__init__(persistence_key=persistence_key)
 
         self.CAMERA_ADDED = Event()
         """a new camera has been added (argument: camera)"""


### PR DESCRIPTION
Adds the option to set the persistence key on `CameraProvider` instantiation to allow for the creation of two or more `CameraProvider`s while still using persistence.
Without setting the key they would overwrite each other.