### PR TITLE
Remove quickfix for Lizard issue 66

### DIFF
--- a/rosys/hardware/battery_control.py
+++ b/rosys/hardware/battery_control.py
@@ -19,12 +19,6 @@ class BatteryControlHardware(ModuleHardware):
             {self.name}_reset = {expander.name + "." if expander else ""}Output({reset_pin})
             {self.name}_status = {expander.name + "." if expander else ""}Input({status_pin})
         ''')
-        if expander:
-            lizard_code += remove_indentation(f'''
-                # TODO: remove when lizard issue 66 is fixed.
-                {self.name}_status.level = 0
-                {self.name}_status.active = false
-            ''')
         core_message_fields = [f'{self.name}_status.level']
         super().__init__(robot_brain=robot_brain, lizard_code=lizard_code, core_message_fields=core_message_fields)
 

--- a/rosys/hardware/bumper.py
+++ b/rosys/hardware/bumper.py
@@ -1,7 +1,6 @@
 import abc
 
 from ..event import Event
-from ..helpers import remove_indentation
 from .estop import EStop
 from .expander import ExpanderHardware
 from .module import Module, ModuleHardware, ModuleSimulation
@@ -38,12 +37,6 @@ class BumperHardware(Bumper, ModuleHardware):
         lizard_code = ''
         for pin, number in pins.items():
             lizard_code += f'{name}_{pin} = {expander.name + "." if expander else ""}Input({number})\n'
-            if expander:
-                lizard_code += remove_indentation(f'''
-                    # TODO: remove when lizard issue 66 is fixed.
-                    {name}_{pin}.level = 0
-                    {name}_{pin}.active = false
-                ''')
         core_message_fields = [f'{name}_{pin}.level' for pin in pins]
         super().__init__(robot_brain=robot_brain,
                          lizard_code=lizard_code,


### PR DESCRIPTION
With the next lizard version, 0.6.2, the issue is finally fixed. This PR just reverts https://github.com/zauberzeug/rosys/pull/216
Reconfiguring systems running on any older version than 0.6.2 will not work anymore! 

- [ ] Wait for Lizard 0.6.2