### PR TITLE
Check Strapping Pins before Flashing P0

### DIFF
--- a/rosys/hardware/__init__.py
+++ b/rosys/hardware/__init__.py
@@ -4,7 +4,6 @@ from .bms import Bms, BmsHardware, BmsSimulation
 from .bumper import Bumper, BumperHardware, BumperSimulation
 from .can import CanHardware
 from .communication import Communication, SerialCommunication, WebCommunication
-from .esp_pins import EspPins
 from .estop import EStop, EStopHardware, EStopSimulation
 from .expander import ExpanderHardware
 from .gnss import Gnss, GnssHardware, GnssMeasurement, GnssSimulation
@@ -29,7 +28,6 @@ __all__ = [
     'EStop',
     'EStopHardware',
     'EStopSimulation',
-    'EspPins',
     'ExpanderHardware',
     'Gnss',
     'GnssHardware',

--- a/rosys/hardware/esp_pins.py
+++ b/rosys/hardware/esp_pins.py
@@ -72,6 +72,10 @@ class EspPins:
         for pin in self._pins.values():
             await self.update_pin(pin)
 
+    async def get_pin_level(self, pin_id: int) -> bool:
+        await self.update_pin(self._pins[pin_id])
+        return self._pins[pin_id].level
+
     async def set_pin_level(self, pin: GpioPin, level: bool) -> None:
         await self.robot_brain.send(f'{self.name}.set_pin_level({pin.gpio}, {1 if level else 0})')
 

--- a/rosys/hardware/esp_pins.py
+++ b/rosys/hardware/esp_pins.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -40,7 +39,6 @@ class EspPins:
 
     def __init__(self, name: str, robot_brain: RobotBrain) -> None:
         self.name = name
-        self.log = logging.getLogger(f'rosys.esp_pins.{name}')
         self.robot_brain = robot_brain
         _pin_numbers: list[int] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
                                    10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
@@ -81,18 +79,12 @@ class EspPins:
     async def set_pin_level(self, pin: GpioPin, level: bool) -> None:
         await self.robot_brain.send(f'{self.name}.set_pin_level({pin.gpio}, {1 if level else 0})')
 
-    async def check_strapping_pins(self) -> bool:
-        gpio_1_level = await self.get_pin_level(0)
-        gpio_2_level = await self.get_pin_level(2)
-        gpio_12_level = await self.get_pin_level(12)
-        strapping_pins_ok = gpio_12_level == 0 and gpio_1_level == 0 and gpio_2_level == 0
-        if gpio_1_level:
-            self.log.warning('GPIO 0 current state is HIGH - must be LOW for boot mode')
-        if gpio_2_level:
-            self.log.warning('GPIO 2 current state is HIGH - must be LOW or floating for flash mode')
-        if gpio_12_level:
-            self.log.warning('GPIO 12 state is HIGH, this can cause issues with flash voltage selection')
-        return strapping_pins_ok
+    async def get_strapping_pins(self) -> list[bool]:
+        """Get the state of the strapping pins.
+
+        See https://github.com/zauberzeug/lizard/issues/75 and https://github.com/zauberzeug/lizard/pull/95.
+        """
+        return [await self.get_pin_level(number) for number in [0, 2, 12]]
 
     def developer_ui(self) -> None:
         with ui.column():

--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -117,7 +117,7 @@ class LizardFirmware:
         rosys.notify(f'Flashing Lizard firmware {self.local_version} to Core...')
         strapping_pins_ok = await self.robot_brain.esp_pins_p0.check_strapping_pins()
         if not strapping_pins_ok:
-            rosys.notify('Failed. Check strapping pins.', 'negative')
+            rosys.notify('Flashing Core failed. Check strapping pins.', 'negative')
             return
         self.robot_brain.communication.disconnect()
         await rosys.sleep(0.3)
@@ -128,11 +128,11 @@ class LizardFirmware:
         rosys.notify('Finished.', 'positive')
 
     async def flash_p0(self, timeout: float = 120) -> None:
+        rosys.notify(f'Flashing Lizard firmware {self.core_version} to P0...')
         strapping_pins_ok = await self.robot_brain.esp_pins_p0.check_strapping_pins()
         if not strapping_pins_ok:
-            rosys.notify('Failed. Check strapping pins.', 'negative')
+            rosys.notify('Flashing P0 failed. Check strapping pins.', 'negative')
             return
-        rosys.notify(f'Flashing Lizard firmware {self.core_version} to P0...')
         await self.robot_brain.send('p0.flash()')
         start = rosys.time()
         deadline = start + timeout

--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -115,8 +115,7 @@ class LizardFirmware:
     async def flash_core(self) -> None:
         assert isinstance(self.robot_brain.communication, SerialCommunication)
         rosys.notify(f'Flashing Lizard firmware {self.local_version} to Core...')
-        strapping_pins_ok = await self.robot_brain.esp_pins_p0.check_strapping_pins()
-        if not strapping_pins_ok:
+        if any(await self.robot_brain.esp_pins_p0.get_strapping_pins()):
             rosys.notify('Flashing Core failed. Check strapping pins.', 'negative')
             return
         self.robot_brain.communication.disconnect()
@@ -129,8 +128,7 @@ class LizardFirmware:
 
     async def flash_p0(self, timeout: float = 120) -> None:
         rosys.notify(f'Flashing Lizard firmware {self.core_version} to P0...')
-        strapping_pins_ok = await self.robot_brain.esp_pins_p0.check_strapping_pins()
-        if not strapping_pins_ok:
+        if any(await self.robot_brain.esp_pins_p0.get_strapping_pins()):
             rosys.notify('Flashing P0 failed. Check strapping pins.', 'negative')
             return
         await self.robot_brain.send('p0.flash()')

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -109,9 +109,11 @@ class RobotBrain:
                         .tooltip('Download the latest Lizard firmware from GitHub')
                     ui.menu_item('Flash Core', on_click=self.lizard_firmware.flash_core) \
                         .tooltip('Flash the downloaded Lizard firmware to the Core microcontroller')
+                    ui.menu_item('Check Core Strapping Pins', on_click=self.esp_pins_core.check_strapping_pins) \
+                        .tooltip('Check if the Core strapping pins are in the correct state for flashing.')
                     ui.menu_item('Flash P0', on_click=self.lizard_firmware.flash_p0) \
                         .tooltip('Flash the downloaded Lizard firmware to the P0 microcontroller')
-                    ui.menu_item('Check P0 Strapping Pins', on_click=self.lizard_firmware.check_p0_strapping_pins) \
+                    ui.menu_item('Check P0 Strapping Pins', on_click=self.esp_pins_p0.check_strapping_pins) \
                         .tooltip('Check if the P0 strapping pins are in the correct state for flashing.')
                     ui.menu_item('Enable', on_click=self.enable_esp) \
                         .tooltip('Enable the microcontroller module (will later be done automatically)')

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -6,6 +6,7 @@ from nicegui import ui
 from .. import rosys
 from ..event import Event
 from .communication import Communication
+from .esp_pins import EspPins
 from .lizard_firmware import LizardFirmware
 
 CLOCK_OFFSET_HISTORY_LENGTH = 100
@@ -40,6 +41,9 @@ class RobotBrain:
         self.hardware_time: float | None = None
         if enable_esp_on_startup:
             rosys.on_startup(self.enable_esp)
+
+        self.esp_pins_core = EspPins(name='core', robot_brain=self)
+        self.esp_pins_p0 = EspPins(name='p0', robot_brain=self)
 
     @property
     def clock_offset(self) -> float | None:
@@ -107,6 +111,8 @@ class RobotBrain:
                         .tooltip('Flash the downloaded Lizard firmware to the Core microcontroller')
                     ui.menu_item('Flash P0', on_click=self.lizard_firmware.flash_p0) \
                         .tooltip('Flash the downloaded Lizard firmware to the P0 microcontroller')
+                    ui.menu_item('Check P0 Strapping Pins', on_click=self.lizard_firmware.check_p0_strapping_pins) \
+                        .tooltip('Check if the P0 strapping pins are in the correct state for flashing.')
                     ui.menu_item('Enable', on_click=self.enable_esp) \
                         .tooltip('Enable the microcontroller module (will later be done automatically)')
                     ui.menu_item('Configure', on_click=self.configure) \

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -107,14 +107,21 @@ class RobotBrain:
                 with ui.menu() as menu:
                     ui.menu_item('Download', on_click=self.lizard_firmware.download) \
                         .tooltip('Download the latest Lizard firmware from GitHub')
+
+                    async def check_strapping_pins_core():
+                        ui.notify(await self.esp_pins_core.get_strapping_pins())
+                    ui.menu_item('Check Core Strapping Pins', on_click=check_strapping_pins_core) \
+                        .tooltip('Check if the Core strapping pins are in the correct state for flashing.')
                     ui.menu_item('Flash Core', on_click=self.lizard_firmware.flash_core) \
                         .tooltip('Flash the downloaded Lizard firmware to the Core microcontroller')
-                    ui.menu_item('Check Core Strapping Pins', on_click=self.esp_pins_core.check_strapping_pins) \
-                        .tooltip('Check if the Core strapping pins are in the correct state for flashing.')
+
+                    async def check_strapping_pins_p0():
+                        ui.notify(await self.esp_pins_p0.get_strapping_pins())
+                    ui.menu_item('Check P0 Strapping Pins', on_click=check_strapping_pins_p0) \
+                        .tooltip('Check if the P0 strapping pins are in the correct state for flashing.')
                     ui.menu_item('Flash P0', on_click=self.lizard_firmware.flash_p0) \
                         .tooltip('Flash the downloaded Lizard firmware to the P0 microcontroller')
-                    ui.menu_item('Check P0 Strapping Pins', on_click=self.esp_pins_p0.check_strapping_pins) \
-                        .tooltip('Check if the P0 strapping pins are in the correct state for flashing.')
+
                     ui.menu_item('Enable', on_click=self.enable_esp) \
                         .tooltip('Enable the microcontroller module (will later be done automatically)')
                     ui.menu_item('Configure', on_click=self.configure) \


### PR DESCRIPTION
In [Lizard's PR #95] (https://github.com/zauberzeug/lizard/pull/95) a check of the pins that could block the flashing was implemented.

This PR added a check and notifications for the UI to warn the user if flashing cannot be performed.

- [x]  Move EspPins to Robotbrain so that they are accessible
- [x]  get_pin_value function for a single Esp pin
- [x]  Function to check the status of p0 strapping pins
- [x]  Prevent flashing when strapping pin is high