### PR TITLE
improve docstrings in Autoupload enum

### DIFF
--- a/rosys/vision/detector.py
+++ b/rosys/vision/detector.py
@@ -13,16 +13,16 @@ from .uploads import Uploads
 
 
 class Autoupload(Enum):
-    """Configures the auto-submitting of images to the Learning Loop"""
+    """Configuration options for image auto-upload behavior to the Learning Loop"""
 
     FILTERED = 'filtered'
-    """only submit images with novel detections and in an uncertainty range (this is the default)"""
+    """Upload mode for images with novel detections within uncertainty thresholds (default)"""
 
     DISABLED = 'disabled'
-    """no auto-submitting"""
+    """Upload mode where no images are auto-uploaded"""
 
     ALL = 'all'
-    """submit all images which are run through the detector"""
+    """Upload mode where every processed image is uploaded"""
 
 
 class DetectorException(Exception):


### PR DESCRIPTION
Rephrases the docstrings in the Autoupload enum to better reflect its role as a configuration type rather than an active component.

Changes:
- Rewrites class docstring to describe the enum's purpose as configuration options
- Changes member docstrings from action statements to descriptive mode definitions
- Removes misleading implications about the enum performing actions itself

The enum is a pure type definition, and these changes make its purpose clearer to developers.