### PR TITLE
Fix Bumper Core Output with EStops activated

### DIFF
--- a/rosys/hardware/bumper.py
+++ b/rosys/hardware/bumper.py
@@ -51,9 +51,9 @@ class BumperHardware(Bumper, ModuleHardware):
                          estop=estop)
 
     def handle_core_output(self, time: float, words: list[str]) -> None:
+        active_bumpers = [pin for pin in self.pins if int(words.pop(0)) == 1]
         if self.estop and self.estop.active:
             return
-        active_bumpers = [pin for pin in self.pins if int(words.pop(0)) == 1]
         for pin in active_bumpers:
             if pin not in self.active_bumpers:
                 self.BUMPER_TRIGGERED.emit(pin)


### PR DESCRIPTION
I noticed that `BumperHardware` does not pop correctly from the lizard core output list when the estops are active.

`['1', '1', '1', '3', '0.6960', '-0.7180', '0.0101', '0.0000', '1', '1', '73412']` goes into the `BumperHardware` module and `['3', '0.6960', '-0.7180', '0.0101', '0.0000', '1', '1', '73412']` should come out, but it doesn't.

We never noticed because `StatusControlHardware` pops 2 integers, that electrically behave the same as the bumpers. It occurs now because I added a `ImuHardware` module between them.

```
rosys_1       | 2025-01-21 18:14:42.637 [ERROR] rosys/hardware/bumper.py:55: BumperHardware: ['1', '1', '1', '3', '0.6960', '-0.7180', '0.0101', '0.0000', '1', '1', '73412']
rosys_1       | 2025-01-21 18:14:42.637 [ERROR] rosys/hardware/bumper.py:57: BumperHardware: E-stop is active
rosys_1       | 2025-01-21 18:14:42.637 [ERROR] rosys/hardware/imu.py:55: ImuHardware: ['1', '1', '1', '3', '0.6960', '-0.7180', '0.0101', '0.0000', '1', '1', '73412']
rosys_1       | 2025-01-21 18:14:42.638 [ERROR] field_friend/hardware/status_control.py:34: StatusControlHardware: ['-0.7180', '0.0101', '0.0000', '1', '1', '73412']
rosys_1       | 2025-01-21 18:14:42.638 [ERROR] rosys/rosys.py:168: error in "RobotHardware.update"
rosys_1       | Traceback (most recent call last):
rosys_1       |   File "/app/rosys/rosys.py", line 162, in _repeat
rosys_1       |     await invoke(self.handler)
rosys_1       |   File "/app/rosys/helpers/init.py", line 37, in invoke
rosys_1       |     result = await result
rosys_1       |              ^^^^^^^^^^^^
rosys_1       |   File "/app/rosys/hardware/robot.py", line 66, in update
rosys_1       |     cast(ModuleHardware, module).handle_core_output(time, words)
rosys_1       |   File "/app/field_friend/hardware/status_control.py", line 35, in handle_core_output
rosys_1       |     self.rdyp_status = int(words.pop(0)) == 0
rosys_1       |                        ^^^^^^^^^^^^^^^^^
rosys_1       | ValueError: invalid literal for int() with base 10: '-0.7180'
```


After the fix
```
rosys_1       | 2025-01-21 18:16:46.210 [ERROR] rosys/hardware/bumper.py:55: BumperHardware: ['1', '1', '1', '3', '0.6959', '-0.7180', '0.0103', '0.0000', '1', '1', '73440']
rosys_1       | 2025-01-21 18:16:46.211 [ERROR] rosys/hardware/bumper.py:58: BumperHardware: E-stop is active
rosys_1       | 2025-01-21 18:16:46.211 [ERROR] rosys/hardware/imu.py:55: ImuHardware: ['3', '0.6959', '-0.7180', '0.0103', '0.0000', '1', '1', '73440']
rosys_1       | 2025-01-21 18:16:46.211 [ERROR] field_friend/hardware/status_control.py:34: StatusControlHardware: ['1', '1', '73440']
```