### PR TITLE
deal with model_info is none

### DIFF
--- a/rosys/vision/detector_hardware.py
+++ b/rosys/vision/detector_hardware.py
@@ -198,7 +198,7 @@ class DetectorHardware(Detector):
             raise DetectorException('Invalid response from detector')
 
         try:
-            model_info_dict = response.get('model_info', {})
+            model_info_dict = response.get('model_info', {}) or {}
             return DetectorInfo(
                 operation_mode=response['operation_mode'],
                 state=response.get('state'),


### PR DESCRIPTION
There was a small bug when a detector returned the value None for the key 'model_info' in the response of the about dict. 