### PR TITLE
Add reconnecting to GNSS hardware

### DIFF
--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -152,7 +152,7 @@ class GnssHardware(Gnss):
                     self.log.error('Could not connect to GNSS device: %s', serial_device_path)
                     await rosys.sleep(self._reconnect_interval)
                     continue
-                self.log.debug('Connected to GNSS device: %s', self.serial_device_path)
+                self.log.info('Connected to GNSS device: %s', serial_device_path)
 
             assert self.serial_connection is not None
             result = await io_bound(self.serial_connection.read_until, b'\r\n')

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -210,12 +210,12 @@ class GnssHardware(Gnss):
         for port in list_ports.comports():
             self.log.debug('Found port: %s - %s', port.device, port.description)
             if 'Septentrio' in port.description:
-                self.log.info('Found GNSS device: %s', port.device)
+                self.log.debug('Found GNSS device: %s', port.device)
                 return port.device
         raise RuntimeError('No GNSS device found')
 
     def _connect_to_device(self, port: str, *, baudrate: int = 115200, timeout: float = 0.2) -> serial.Serial:
-        self.log.info('Connecting to GNSS device "%s"...', port)
+        self.log.debug('Connecting to GNSS device "%s"...', port)
         try:
             return serial.Serial(port=port, baudrate=baudrate, timeout=timeout)
         except serial.SerialException as e:

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -115,7 +115,6 @@ class GnssHardware(Gnss):
         super().__init__()
         self.antenna_pose = antenna_pose or Pose(x=0.0, y=0.0, yaw=0.0)
         self._reconnect_interval = reconnect_interval
-        self.serial_device_path = self._find_device()
         self.serial_connection: serial.Serial | None = None
         rosys.on_startup(self._run)
 
@@ -147,9 +146,10 @@ class GnssHardware(Gnss):
         while True:
             if not self.is_connected:
                 try:
-                    self.serial_connection = self._connect_to_device(self.serial_device_path)
+                    serial_device_path = self._find_device()
+                    self.serial_connection = self._connect_to_device(serial_device_path)
                 except RuntimeError:
-                    self.log.error('Could not connect to GNSS device: %s', self.serial_device_path)
+                    self.log.error('Could not connect to GNSS device: %s', serial_device_path)
                     await rosys.sleep(self._reconnect_interval)
                     continue
                 self.log.debug('Connected to GNSS device: %s', self.serial_device_path)

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -152,6 +152,7 @@ class GnssHardware(Gnss):
                     continue
                 self.log.debug('Connected to GNSS device: %s', self.serial_device_path)
 
+            assert self.serial_connection is not None
             result = await io_bound(self.serial_connection.read_until, b'\r\n')
             if not result:
                 self.log.debug('No data')


### PR DESCRIPTION
The GNSS serial device seems not to be ready right after booting up the computer (https://github.com/zauberzeug/field_friend/issues/264).

With this PR RoSys tries to reconnect every 3 seconds by default.

```
2025-01-23 23:31:27.383 [INFO] rosys/hardware/gnss.py:213: Found GNSS device: /dev/ttyACM1
2025-01-23 23:31:29.253 [INFO] rosys/hardware/gnss.py:218: Connecting to GNSS device "/dev/ttyACM1"...
2025-01-23 23:31:29.256 [ERROR] rosys/hardware/gnss.py:150: Could not connect to GNSS device: /dev/ttyACM1
2025-01-23 23:31:32.257 [INFO] rosys/hardware/gnss.py:218: Connecting to GNSS device "/dev/ttyACM1"...
2025-01-23 23:31:32.259 [INFO] rosys/hardware/gnss.py:153: Connected to GNSS device: /dev/ttyACM1
```

It happens with all of our robots, so releasing this as 0.22.1 would be helpful.