### PR TITLE
Improve videos page to only include date picker and video titles but no previews

### DIFF
--- a/rosys/analysis/videos_page_.py
+++ b/rosys/analysis/videos_page_.py
@@ -24,19 +24,23 @@ class VideosPage:
                         if selected_date not in all_videos:
                             ui.label('No videos for this date')
                         else:
-                            with ui.grid(columns='auto auto auto').classes('items-center'):
+                            with ui.list().classes('items-center'):
                                 for mp4 in all_videos[selected_date]:
                                     video_date, video_duration = format_video_name(mp4)
-                                    ui.label(video_date)
-                                    ui.label(video_duration)
-                                    with ui.row().classes('gap-1'):
-                                        ui.button(on_click=lambda mp4=mp4: ui.download(mp4)) \
-                                            .props('icon=download flat') \
-                                            .tooltip('download')
-                                        ui.button(on_click=lambda mp4=mp4: mp4.unlink(),
-                                                  color='negative') \
-                                            .props('icon=delete flat') \
-                                            .tooltip('delete')
+                                    with ui.item().classes('p-0'):
+                                        with ui.item_section().props('avatar'):
+                                            ui.button(icon='download', on_click=lambda mp4=mp4: ui.download(mp4)) \
+                                                .props('flat').tooltip('download')
+                                        with ui.item_section().classes('min-w-24'):
+                                            ui.item_label(video_date)
+                                            ui.item_label(video_duration).props('caption')
+                                        with ui.item_section().classes('pl-1'):
+                                            with ui.button(icon='more_vert').props('flat fab-mini'):
+                                                with ui.menu():
+                                                    with ui.menu_item(on_click=lambda mp4=mp4: mp4.unlink()):
+                                                        with ui.item_section().props('side'):
+                                                            ui.icon('delete', color='negative')
+                                                        ui.item_section('delete')
 
             async def watch_videos():
                 async for _ in watchfiles.awatch(VIDEO_FILES):
@@ -58,9 +62,8 @@ def _format_date(date: str) -> str:
 
 def format_video_name(video: Path) -> tuple[str, str]:
     parts = video.stem.split('_')
-    date = _format_date(parts[0])
     time = parts[1].replace('-', ':')
-    return f'{date} {time}', f'{parts[2]} {parts[3]}'
+    return time, f'{parts[2]} {parts[3]}'
 
 
 async def get_all_videos() -> dict[str, list[Path]]:

--- a/rosys/analysis/videos_page_.py
+++ b/rosys/analysis/videos_page_.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 
 import watchfiles
@@ -9,22 +11,62 @@ VIDEO_FILES = Path('~/.rosys/timelapse/videos').expanduser()
 class VideosPage:
 
     def __init__(self) -> None:
+
         @ui.page('/videos', title='Videos')
         async def page():
             @ui.refreshable
-            async def videos():
-                for mp4 in sorted(await run.io_bound(VIDEO_FILES.glob, '*.mp4'), reverse=True):
-                    with ui.row():
-                        with ui.card().tight():
-                            video = ui.video(mp4).classes('w-[800px]')
-                            src = video._props['src']  # pylint: disable=protected-access
-                        with ui.column():
-                            ui.button(on_click=lambda mp4=mp4: mp4.unlink()).props('icon=delete flat')
-                            ui.button(on_click=lambda src=src: ui.download(src)).props('icon=download flat')
+            async def videos(selected_date: str):
+                all_videos = await get_all_videos()
+                with ui.card().tight().props('flat bordered'):
+                    with ui.card_section().classes('w-full bg-primary text-white'):
+                        ui.label(_format_date(selected_date)).classes('text-xl')
+                    with ui.card_section().classes('w-full'):
+                        if selected_date not in all_videos:
+                            ui.label('No videos for this date')
+                        else:
+                            with ui.grid(columns='auto auto auto').classes('items-center'):
+                                for mp4 in all_videos[selected_date]:
+                                    video_date, video_duration = format_video_name(mp4)
+                                    ui.label(video_date)
+                                    ui.label(video_duration)
+                                    with ui.row().classes('gap-1'):
+                                        ui.button(on_click=lambda mp4=mp4: ui.download(mp4)) \
+                                            .props('icon=download flat') \
+                                            .tooltip('download')
+                                        ui.button(on_click=lambda mp4=mp4: mp4.unlink(),
+                                                  color='negative') \
+                                            .props('icon=delete flat') \
+                                            .tooltip('delete')
 
             async def watch_videos():
                 async for _ in watchfiles.awatch(VIDEO_FILES):
                     videos.refresh()
 
-            await videos()
+            ui.label('Timelapse Videos').classes('text-2xl')
+            with ui.row(wrap=False).classes('w-full'):
+                date_picker = ui.date(value=datetime.now().date().strftime('%Y%m%d'),
+                                      mask='YYYYMMDD',
+                                      on_change=lambda e: videos.refresh(e.value))
+                await videos(date_picker.value)
+
             background_tasks.create(watch_videos(), name='watch videos files')
+
+
+def _format_date(date: str) -> str:
+    return datetime.strptime(date, '%Y%m%d').strftime('%d.%m.%Y')
+
+
+def format_video_name(video: Path) -> tuple[str, str]:
+    parts = video.stem.split('_')
+    date = _format_date(parts[0])
+    time = parts[1].replace('-', ':')
+    return f'{date} {time}', f'{parts[2]} {parts[3]}'
+
+
+async def get_all_videos() -> dict[str, list[Path]]:
+    all_videos = sorted(await run.io_bound(VIDEO_FILES.glob, '*.mp4'), reverse=True)
+    video_date_dict: dict[str, list[Path]] = defaultdict(list)
+    for video in all_videos:
+        video_date = video.stem.split('_')[0]
+        video_date_dict[video_date].append(video)
+    return video_date_dict

--- a/rosys/analysis/videos_page_.py
+++ b/rosys/analysis/videos_page_.py
@@ -2,8 +2,7 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
-import watchfiles
-from nicegui import background_tasks, run, ui
+from nicegui import run, ui
 
 VIDEO_FILES = Path('~/.rosys/timelapse/videos').expanduser()
 
@@ -12,52 +11,48 @@ class VideosPage:
 
     def __init__(self) -> None:
 
+        @ui.page('/video/{name:str}')
+        async def video_page(name: str) -> None:
+            ui.video(VIDEO_FILES / name)
+
         @ui.page('/videos', title='Videos')
         async def page():
             @ui.refreshable
-            async def videos(selected_date: str):
-                all_videos = await get_all_videos()
-                with ui.card().tight().props('flat bordered'):
-                    with ui.card_section().classes('w-full bg-primary text-white'):
-                        ui.label(_format_date(selected_date)).classes('text-xl')
-                    with ui.card_section().classes('w-full'):
-                        if selected_date not in all_videos:
-                            ui.label('No videos for this date')
-                        else:
-                            with ui.list().classes('items-center'):
-                                for mp4 in all_videos[selected_date]:
-                                    video_date, video_duration = format_video_name(mp4)
-                                    with ui.item().classes('p-0'):
-                                        with ui.item_section().props('avatar'):
-                                            ui.button(icon='download', on_click=lambda mp4=mp4: ui.download(mp4)) \
-                                                .props('flat').tooltip('download')
-                                        with ui.item_section().classes('min-w-24'):
-                                            ui.item_label(video_date)
-                                            ui.item_label(video_duration).props('caption')
-                                        with ui.item_section().classes('pl-1'):
-                                            with ui.button(icon='more_vert').props('flat fab-mini'):
-                                                with ui.menu():
-                                                    with ui.menu_item(on_click=lambda mp4=mp4: mp4.unlink()):
-                                                        with ui.item_section().props('side'):
-                                                            ui.icon('delete', color='negative')
-                                                        ui.item_section('delete')
-
-            async def watch_videos():
-                async for _ in watchfiles.awatch(VIDEO_FILES):
-                    videos.refresh()
+            def video_ui() -> None:
+                with ui.card().props('flat bordered'):
+                    if date.value not in all_videos:
+                        ui.label('No videos for this date')
+                        return
+                    with ui.list().classes('items-center'):
+                        for mp4 in all_videos[date.value]:
+                            video_date, video_duration = format_video_name(mp4)
+                            with ui.item().classes('p-0'):
+                                with ui.item_section().props('avatar'):
+                                    ui.button(icon='download', on_click=lambda mp4=mp4: ui.download(mp4)) \
+                                        .props('flat').tooltip('download')
+                                with ui.item_section().classes('min-w-24'):
+                                    with ui.link(target=f'video/{mp4.name}').classes('no-underline'):
+                                        ui.item_label(video_date)
+                                        ui.item_label(video_duration).props('caption')
+                                with ui.item_section().classes('pl-1'):
+                                    with ui.button(icon='more_vert').props('flat fab-mini'):
+                                        with ui.menu():
+                                            def delete_video(mp4: Path = mp4) -> None:
+                                                mp4.unlink()
+                                                all_videos[date.value].remove(mp4)
+                                                video_ui.refresh()
+                                            with ui.menu_item(on_click=delete_video):
+                                                with ui.item_section().props('side'):
+                                                    ui.icon('delete', color='negative')
+                                                ui.item_section('delete')
 
             ui.label('Timelapse Videos').classes('text-2xl')
+            all_videos = await get_all_videos()
+            today = datetime.now().strftime(r'%Y%m%d')
             with ui.row(wrap=False).classes('w-full'):
-                date_picker = ui.date(value=datetime.now().date().strftime('%Y%m%d'),
-                                      mask='YYYYMMDD',
-                                      on_change=lambda e: videos.refresh(e.value))
-                await videos(date_picker.value)
-
-            background_tasks.create(watch_videos(), name='watch videos files')
-
-
-def _format_date(date: str) -> str:
-    return datetime.strptime(date, '%Y%m%d').strftime('%d.%m.%Y')
+                date = ui.date(value=today, mask='YYYYMMDD', on_change=video_ui.refresh).props('flat bordered')
+                date.props['options'] = [datetime.strptime(d, r'%Y%m%d').strftime(r'%Y/%m/%d') for d in all_videos]
+                video_ui()
 
 
 def format_video_name(video: Path) -> tuple[str, str]:


### PR DESCRIPTION
This PR updates the `/videos` page displaying the available timelapse videos.

Since streaming those videos from the robot in most cases takes too many resources and requires a very good internet connection, we decided to only provide a download option for the videos.