### PR TITLE
Make IMU gyro calibration threshold configurable

### DIFF
--- a/rosys/hardware/imu.py
+++ b/rosys/hardware/imu.py
@@ -76,7 +76,7 @@ class Imu(Module):
 class ImuHardware(Imu, ModuleHardware):
     """A hardware module that handles the communication with an IMU."""
 
-    def __init__(self, robot_brain: RobotBrain, name: str = 'imu', min_gyro_calibration: float = 1.0, **kwargs) -> None:
+    def __init__(self, robot_brain: RobotBrain, name: str = 'imu', *, min_gyro_calibration: float = 1.0, **kwargs) -> None:
         self.name = name
         self.min_gyro_calibration = min_gyro_calibration
         self.lizard_code = f'{name} = Imu()'
@@ -97,7 +97,6 @@ class ImuHardware(Imu, ModuleHardware):
             float(words.pop(0)),
             float(words.pop(0)),
         )
-
         if gyro_calibration < self.min_gyro_calibration:
             return
         self._emit_measurement(gyro_calibration, raw_rotation, time)

--- a/rosys/hardware/imu.py
+++ b/rosys/hardware/imu.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 
 import numpy as np

--- a/rosys/hardware/imu.py
+++ b/rosys/hardware/imu.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 
 import numpy as np
@@ -76,8 +77,9 @@ class Imu(Module):
 class ImuHardware(Imu, ModuleHardware):
     """A hardware module that handles the communication with an IMU."""
 
-    def __init__(self, robot_brain: RobotBrain, name: str = 'imu', **kwargs) -> None:
+    def __init__(self, robot_brain: RobotBrain, name: str = 'imu', min_gyro_calibration: float = 1.0, **kwargs) -> None:
         self.name = name
+        self.min_gyro_calibration = min_gyro_calibration
         self.lizard_code = f'{name} = Imu()'
         self.core_message_fields = [
             f'{name}.cal_gyr',
@@ -97,7 +99,7 @@ class ImuHardware(Imu, ModuleHardware):
             float(words.pop(0)),
         )
 
-        if gyro_calibration < 1.0:
+        if gyro_calibration < self.min_gyro_calibration:
             return
         self._emit_measurement(gyro_calibration, raw_rotation, time)
 


### PR DESCRIPTION
Currently IMU measurements are ignored if `gyro_calibration < 1`. This PR makes this threshold configurable