### PR TITLE
Improved distortion api

### DIFF
--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -243,7 +243,7 @@ class Calibration:
             return Point3d(x=world_points[0, 0], y=world_points[0, 1], z=world_points[0, 2])  # pylint: disable=unsubscriptable-object
 
         world_extrinsics = self.extrinsics.resolve()
-        image_rays = self.points_to_rays(image_coordinates.astype(np.float32).reshape(-1, 1, 2))
+        image_rays = self._points_to_rays(image_coordinates.astype(np.float32).reshape(-1, 1, 2))
         objPoints = image_rays @ world_extrinsics.rotation.matrix.T
         Z = world_extrinsics.z
         t = world_extrinsics.translation_vector
@@ -256,7 +256,7 @@ class Calibration:
 
         return world_points
 
-    def points_to_rays(self, image_points: np.ndarray) -> np.ndarray:
+    def _points_to_rays(self, image_points: np.ndarray) -> np.ndarray:
         """Convert image points to rays in homogeneous coordinates with respect to the camera coordinate frame."""
         K = np.array(self.intrinsics.matrix, dtype=np.float32).reshape((3, 3))
         D = np.array(self.intrinsics.distortion)

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -340,10 +340,13 @@ class Calibration:
             image_points = self.distort_points(image_points, crop=crop)
             return [Point(x=p[0], y=p[1]) for p in image_points]
 
-        K = np.array(self.intrinsics.matrix, dtype=np.float32).reshape((3, 3))
-        D = np.array(self.intrinsics.distortion)
+        if image_points.dtype not in [np.float32, np.float64]:
+            raise ValueError('Image point array must be of type float32 or float64')
 
         image_points = image_points.reshape(-1, 1, 2)
+
+        K = np.array(self.intrinsics.matrix, dtype=np.float32).reshape((3, 3))
+        D = np.array(self.intrinsics.distortion)
 
         if self.intrinsics.model == CameraModel.PINHOLE:
             return self._distort_points_pinhole(image_points).reshape(-1, 2)

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -59,7 +59,7 @@ class Intrinsics:
         return Intrinsics(matrix=K, distortion=D, size=size)
 
 
-log = logging.getLogger('rosys.world.calibration')
+log = logging.getLogger('rosys.vision.calibration')
 
 
 @dataclass(slots=True, kw_only=True)
@@ -397,7 +397,7 @@ class Calibration:
                                                                            fov_scale=1)
         elif self.intrinsics.model == CameraModel.OMNIDIRECTIONAL:
             if crop:
-                logging.warning('Cropping is not yet supported for omnidirectional cameras')
+                log.warning('Cropping is not yet supported for omnidirectional cameras')
             new_K = np.array([[w / 4, 0, w / 2],
                               [0, h / 4, h / 2],
                               [0, 0, 1]])

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -394,7 +394,7 @@ class Calibration:
 
         return dst
 
-    def undistort_image(self, image: Image) -> Image:
+    def undistort_image(self, image: Image, *, crop: bool = False) -> Image:
         """Undistort an image represented as an Image object.
 
         If you already have the image as an unencoded numpy array, use ``undistort_array`` instead.
@@ -407,7 +407,7 @@ class Calibration:
             camera_id=image.camera_id,
             size=image.size,
             time=image.time,
-            data=cv2.imencode('.jpg', self.undistort_array(image.to_array()))[1].tobytes(),
+            data=cv2.imencode('.jpg', self.undistort_array(image.to_array(), crop=crop))[1].tobytes(),
             is_broken=image.is_broken,
             tags=image.tags,
         )

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -467,7 +467,7 @@ class Calibration:
     @deprecated_function(remove_in_version='0.27.0')
     def undistort_array(self, image_array: np.ndarray, crop: bool = False) -> np.ndarray:
         """
-        .. deprecated:: 
+        ### deprecated
             This funciton has been integrated into `undistort_image` and will be removed in Rosys `0.27.0`.
 
         Undistort an image represented as a numpy array.

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -195,7 +195,7 @@ def test_projection_with_custom_coordinate_frame():
         assert np.allclose([p.tuple for p in world_points_at_height], [p.tuple for p in reprojected_world_points_], atol=1e-6), \
             f'batch projection of world points at height {height} did not reproject back to the original points'
 
-    for i, world_point in enumerate(world_points):
+    for world_point in world_points:
         image_point = cam.calibration.project_to_image(world_point)
         assert image_point is not None
         world_point_ = cam.calibration.project_from_image(image_point, target_height=world_point.z)


### PR DESCRIPTION
feat: add crop_parameter to `undistort_image`
style: make `point_to_rays` private
feat: add overloads to accept `list[Point]` in `distort_image` and `undistort_image`
feat: reshape `image_points` to accept a wider range of input points
feat: reshape points array to `Nx2` before returning it
test: add image undistortion and distortion tests
type: type inputs and outputs as `FloatArray` where applicable

BREAKING CHANGE: `distort_points` and `undistort_points` now return arrays of shape `(N, 2)`