### PR TITLE
typed Events

### DIFF
--- a/rosys/automation/app_controls_.py
+++ b/rosys/automation/app_controls_.py
@@ -39,7 +39,7 @@ class AppControls:
     """
 
     def __init__(self, robot_brain: RobotBrain, automator: Automator) -> None:
-        self.APP_CONNECTED = Event()
+        self.APP_CONNECTED = Event[[]]()
         """an app connected via bluetooth (used to refresh information or similar)"""
 
         self.robot_brain = robot_brain

--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -26,22 +26,22 @@ class Automator:
                  steerer: Steerer | None, *,
                  default_automation: Callable | None = None,
                  on_interrupt: Callable | None = None) -> None:
-        self.AUTOMATION_STARTED = Event()
+        self.AUTOMATION_STARTED = Event[[]]()
         """an automation has been started"""
 
-        self.AUTOMATION_PAUSED = Event()
+        self.AUTOMATION_PAUSED = Event[str]()
         """an automation has been paused (string argument: description of the cause)"""
 
-        self.AUTOMATION_RESUMED = Event()
+        self.AUTOMATION_RESUMED = Event[[]]()
         """an automation has been resumed"""
 
-        self.AUTOMATION_STOPPED = Event()
+        self.AUTOMATION_STOPPED = Event[str]()
         """an automation has been stopped (string argument: description of the cause)"""
 
-        self.AUTOMATION_FAILED = Event()
+        self.AUTOMATION_FAILED = Event[str]()
         """an automation has failed to complete (string argument: description of the cause)"""
 
-        self.AUTOMATION_COMPLETED = Event()
+        self.AUTOMATION_COMPLETED = Event[[]]()
         """an automation has been completed"""
 
         self.log = logging.getLogger('rosys.automator')

--- a/rosys/automation/schedule.py
+++ b/rosys/automation/schedule.py
@@ -54,7 +54,7 @@ class Schedule(persistence.PersistentModule):
 
         self.log = logging.getLogger('rosys.schedule')
 
-        self.SCHEDULE_CHANGED = Event()
+        self.SCHEDULE_CHANGED = Event[[]]()
         """the schedule has changed"""
 
         self.automator = automator

--- a/rosys/driving/keyboard_control_.py
+++ b/rosys/driving/keyboard_control_.py
@@ -21,7 +21,7 @@ class KeyboardControl:
                  default_speed: float = 2.0,
                  connection_timeout: float = 1.0,
                  check_connection_interval: float = 1.0) -> None:
-        self.CONNECTION_INTERRUPTED = Event()
+        self.CONNECTION_INTERRUPTED = Event[[]]()
         """the keyboard control has lost connection to the browser."""
 
         self.steerer = steerer

--- a/rosys/driving/odometer.py
+++ b/rosys/driving/odometer.py
@@ -21,10 +21,10 @@ class Odometer:
     """
 
     def __init__(self, wheels: VelocityProvider) -> None:
-        self.WHEELS_TURNED = Event()
+        self.WHEELS_TURNED = Event[[]]()
         """the wheels have turned with non-zero velocity"""
 
-        self.PREDICTION_UPDATED = Event()
+        self.PREDICTION_UPDATED = Event[[]]()
         """the pose prediction has been updated"""
 
         self.log = logging.getLogger('rosys.odometer')

--- a/rosys/driving/steerer.py
+++ b/rosys/driving/steerer.py
@@ -21,10 +21,10 @@ class Steerer:
     """
 
     def __init__(self, wheels: Drivable, speed_scaling: float = 1.0) -> None:
-        self.STEERING_STARTED = Event()
+        self.STEERING_STARTED = Event[[]]()
         """steering has started"""
 
-        self.STEERING_STOPPED = Event()
+        self.STEERING_STOPPED = Event[[]]()
         """steering has stopped"""
 
         self.log = logging.getLogger('rosys.steerer')

--- a/rosys/event.py
+++ b/rosys/event.py
@@ -88,7 +88,7 @@ class Event(Generic[P]):
         """Waits for an event to be emitted and returns its arguments."""
         future: asyncio.Future[Any] = asyncio.Future()
 
-        def callback(*args: P.args, **kwargs: P.kwargs) -> None:
+        def callback(*args: P.args, **kwargs: P.kwargs) -> None:  # pylint: disable=unused-argument
             if not future.done():
                 future.set_result(args[0] if len(args) == 1 else args if args else None)
 

--- a/rosys/hardware/bumper.py
+++ b/rosys/hardware/bumper.py
@@ -14,7 +14,7 @@ class Bumper(Module, abc.ABC):
         self.estop = estop
         super().__init__(**kwargs)
 
-        self.BUMPER_TRIGGERED = Event()
+        self.BUMPER_TRIGGERED = Event[str]()
         """a bumper was triggered (argument: the bumper name)"""
 
         self.active_bumpers: list[str] = []

--- a/rosys/hardware/estop.py
+++ b/rosys/hardware/estop.py
@@ -17,9 +17,9 @@ class EStop(Module, abc.ABC):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self.ESTOP_TRIGGERED = Event()
+        self.ESTOP_TRIGGERED = Event[[]]()
         """the e-stop was triggered"""
-        self.ESTOP_RELEASED = Event()
+        self.ESTOP_RELEASED = Event[[]]()
         """the e-stop was released"""
         self.active: bool = False
         self.is_soft_estop_active: bool = False

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -58,7 +58,7 @@ class Gnss(ABC):
         self.log = logging.getLogger('rosys.gnss')
         self.last_measurement: GnssMeasurement | None = None
 
-        self.NEW_MEASUREMENT = Event()
+        self.NEW_MEASUREMENT = Event[GnssMeasurement]()
         """a new measurement has been received (argument: ``GnssMeasurement``)"""
 
     @property

--- a/rosys/hardware/imu.py
+++ b/rosys/hardware/imu.py
@@ -30,7 +30,7 @@ class Imu(Module):
         self.offset_rotation = offset_rotation or Rotation.zero()
         self.last_measurement: ImuMeasurement | None = None
 
-        self.NEW_MEASUREMENT = Event()
+        self.NEW_MEASUREMENT = Event[ImuMeasurement]()
         """a new measurement has been received (argument: ImuMeasurement)"""
 
     def _emit_measurement(self, gyro_calibration: float, raw_rotation: Rotation, time: float) -> None:

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -24,9 +24,9 @@ class RobotBrain:
     """
 
     def __init__(self, communication: Communication, *, enable_esp_on_startup: bool = True) -> None:
-        self.LINE_RECEIVED = Event()
+        self.LINE_RECEIVED = Event[str]()
         """a line has been received from the microcontroller (argument: line as string)"""
-        self.FLASH_P0_COMPLETE = Event()
+        self.FLASH_P0_COMPLETE = Event[[]]()
         """flashing p0 was successful and 'Replica complete' was received"""
 
         self.log = logging.getLogger('rosys.robot_rain')

--- a/rosys/hardware/wheels.py
+++ b/rosys/hardware/wheels.py
@@ -18,8 +18,7 @@ class Wheels(Module, abc.ABC):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self.VELOCITY_MEASURED = Event()
-        """new velocity measurements are available for processing (argument: list of velocities)"""
+        self.VELOCITY_MEASURED = Event[list[Velocity]]()
 
         self.linear_target_speed: float = 0.0
         self.angular_target_speed: float = 0.0

--- a/rosys/pathplanning/area_manipulation.py
+++ b/rosys/pathplanning/area_manipulation.py
@@ -41,7 +41,7 @@ class AreaManipulation:
         self.area_color = 'green'
         self.translator: Translator = rosys.translator or Translator()
 
-        self.MODE_CHANGED = Event()
+        self.MODE_CHANGED = Event[AreaManipulationMode]()
         """the mode has changed (argument: new mode)"""
 
     def create_ui(self) -> ui.row:

--- a/rosys/pathplanning/path_planner.py
+++ b/rosys/pathplanning/path_planner.py
@@ -41,10 +41,8 @@ class PathPlanner(persistence.PersistentModule):
         self.obstacles: dict[str, Obstacle] = {}
         self.areas: dict[str, Area] = {}
 
-        self.OBSTACLES_CHANGED = Event()
-        """the obstacles have changed (argument: dictionary of obstacles)"""
-        self.AREAS_CHANGED = Event()
-        """the areas have changed (argument: list of areas that have changed, can be None for all areas)"""
+        self.OBSTACLES_CHANGED = Event[dict[str, Obstacle]]()
+        self.AREAS_CHANGED = Event[list[Area] | None]()
 
         rosys.on_startup(self.startup)
         rosys.on_shutdown(self.shutdown)

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -42,7 +42,7 @@ class Notification:
     message: str
 
 
-NEW_NOTIFICATION = event.Event()
+NEW_NOTIFICATION = event.Event[str]()
 """notify the user (string argument: message)"""
 
 

--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -42,7 +42,7 @@ class Camera(abc.ABC):
         if polling_interval is not None:
             logger.warning('The `polling_interval` parameter has been removed. All cameras should now use callbacks.')
 
-        self.NEW_IMAGE: Event = Event()
+        self.NEW_IMAGE = Event[Image]()
 
         self.device_connection_lock: asyncio.Condition = asyncio.Condition()
 

--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -22,14 +22,14 @@ class CameraProvider(Generic[T], persistence.PersistentModule, metaclass=abc.ABC
     def __init__(self, *, persistence_key: str | None = None) -> None:
         super().__init__(persistence_key=persistence_key)
 
-        self.CAMERA_ADDED = Event()
+        self.CAMERA_ADDED = Event[Camera]()
         """a new camera has been added (argument: camera)"""
 
-        self.CAMERA_REMOVED = Event()
+        self.CAMERA_REMOVED = Event[str]()
         """a camera has been removed (argument: camera id)"""
 
-        self.NEW_IMAGE = Event()
-        """a new image is available (argument: image)"""
+        self.NEW_IMAGE = Event[Image]()
+        """a new image is available from any camera (argument: image)"""
 
         self._cameras: dict[str, T] = {}
 

--- a/rosys/vision/detector.py
+++ b/rosys/vision/detector.py
@@ -88,7 +88,7 @@ class Detector(abc.ABC):
     def __init__(self, *, name: str | None = None) -> None:
         self.name = name or str(uuid4())
 
-        self.NEW_DETECTIONS = Event()
+        self.NEW_DETECTIONS = Event[Image]()
         """detection on an image is completed (argument: image)"""
 
         self.log = logging.getLogger('rosys.detector')

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -4,7 +4,7 @@ import rosys
 from rosys.event import Event
 from rosys.testing import forward
 
-TEST_EVENT = Event()
+TEST_EVENT = Event[int]()
 
 
 async def test_register_and_unregister():

--- a/tests/test_odometer.py
+++ b/tests/test_odometer.py
@@ -7,7 +7,7 @@ from rosys.testing import approx
 
 
 class DummyVelocityProvider:
-    VELOCITY_MEASURED = Event()
+    VELOCITY_MEASURED = Event[list[Velocity]]()
 
 
 async def test_odometer():


### PR DESCRIPTION
I have have had a lot of situations where I was not exactly sure which values an event would produce or these values changed but the consumer was not changed correctly with it.

This PR adds a Generic ParamSpec to the `Event` class which enables users to optinally initialize their events as
```py
my_event = Event[int, str]()
```
or equivalently
```py
my_event: Event[int, str] = Event
```
to let the type checker correctly check the types of the callback in `my_event.register()` and the other functions.