### PR TITLE
Add RTSP camera support to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt update && apt install -y \
     libgl1 libglx-mesa0 ffmpeg libsm6 libxext6 \
     avahi-utils iputils-ping \
     jq \
+    gstreamer1.0-tools gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-libav \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python3 -m pip install --upgrade pip


### PR DESCRIPTION
This PR adds required gstreamer packages to the Dockerfile to support RTSP cameras.