### PR TITLE
Add 3d visualization for Frame3d 

### DIFF
--- a/examples/camera_arm/main.py
+++ b/examples/camera_arm/main.py
@@ -6,7 +6,7 @@ from nicegui import ui
 
 from rosys import config, persistence
 from rosys.driving import Driver, Odometer, Steerer, joystick, keyboard_control
-from rosys.geometry import Frame3d, Pose3d, Rotation
+from rosys.geometry import Frame3d, Pose3d, Rotation, frame_3d_object
 from rosys.hardware import RobotSimulation, WheelsSimulation
 
 wheels = WheelsSimulation()
@@ -88,12 +88,18 @@ def page():
                 scene.box(width=0.1, height=0.1, depth=arm2.length).move(z=arm2.length / 2)
             with scene.group() as camera_box:
                 scene.box(width=0.1, height=0.1, depth=0.1).material(color='SteelBlue')
-            scene.move_camera(y=-2, z=2)
+            scene.move_camera(y=-1, z=1, look_at_z=0.5)
         with ui.column():
             joystick(steerer, size=50, color='blue')
             ui.slider(min=-math.pi / 2, max=math.pi / 2, step=0.01, value=0, on_change=lambda e: arm1.pitch(e.value))
             ui.slider(min=-math.pi / 2, max=math.pi / 2, step=0.01, value=0, on_change=lambda e: arm2.pitch(e.value))
             ui.slider(min=-math.pi / 4, max=math.pi / 4, step=0.01, value=0, on_change=lambda e: cam.pitch(e.value))
+        with ui.scene() as scene2:
+            frame_3d_object(anchor_frame)
+            frame_3d_object(arm1.base, name='Arm 1 Base')
+            frame_3d_object(arm2.base, name='Arm 2 Base')
+            frame_3d_object(cam.pose, name='Camera')
+            scene2.move_camera(y=-1, z=1, look_at_z=0.5)
 
 
 ui.run(title='Camera Arm')

--- a/examples/camera_arm/main.py
+++ b/examples/camera_arm/main.py
@@ -6,7 +6,7 @@ from nicegui import ui
 
 from rosys import config, persistence
 from rosys.driving import Driver, Odometer, Steerer, joystick, keyboard_control
-from rosys.geometry import Frame3d, Pose3d, Rotation, frame_3d_object
+from rosys.geometry import Frame3d, Pose3d, Rotation, axes_object
 from rosys.hardware import RobotSimulation, WheelsSimulation
 
 wheels = WheelsSimulation()
@@ -95,10 +95,10 @@ def page():
             ui.slider(min=-math.pi / 2, max=math.pi / 2, step=0.01, value=0, on_change=lambda e: arm2.pitch(e.value))
             ui.slider(min=-math.pi / 4, max=math.pi / 4, step=0.01, value=0, on_change=lambda e: cam.pitch(e.value))
         with ui.scene() as scene2:
-            frame_3d_object(anchor_frame)
-            frame_3d_object(arm1.base, name='Arm 1 Base')
-            frame_3d_object(arm2.base, name='Arm 2 Base')
-            frame_3d_object(cam.pose, name='Camera')
+            axes_object(anchor_frame, length=0.15)
+            axes_object(arm1.base, name='Arm 1 Base', length=0.15)
+            axes_object(arm2.base, name='Arm 2 Base', length=0.15)
+            axes_object(cam.pose, name='Camera', length=0.15)
             scene2.move_camera(y=-1, z=1, look_at_z=0.5)
 
 

--- a/rosys/geometry/__init__.py
+++ b/rosys/geometry/__init__.py
@@ -7,6 +7,7 @@ from .point3d import Point3d
 from .polygon import Polygon
 from .pose import Pose, PoseStep
 from .pose3d import Frame3d, Pose3d
+from .pose3d import Frame3dSceneObject as frame_3d_object
 from .prism import Prism
 from .rectangle import Rectangle
 from .rotation import Rotation
@@ -33,4 +34,5 @@ __all__ = [
     'Rotation',
     'Spline',
     'Velocity',
+    'frame_3d_object',
 ]

--- a/rosys/geometry/__init__.py
+++ b/rosys/geometry/__init__.py
@@ -6,8 +6,8 @@ from .point import Point
 from .point3d import Point3d
 from .polygon import Polygon
 from .pose import Pose, PoseStep
+from .pose3d import AxesObject as axes_object
 from .pose3d import Frame3d, Pose3d
-from .pose3d import Frame3dObject as frame_3d_object
 from .prism import Prism
 from .rectangle import Rectangle
 from .rotation import Rotation
@@ -34,5 +34,5 @@ __all__ = [
     'Rotation',
     'Spline',
     'Velocity',
-    'frame_3d_object',
+    'axes_object',
 ]

--- a/rosys/geometry/__init__.py
+++ b/rosys/geometry/__init__.py
@@ -7,7 +7,7 @@ from .point3d import Point3d
 from .polygon import Polygon
 from .pose import Pose, PoseStep
 from .pose3d import Frame3d, Pose3d
-from .pose3d import Frame3dSceneObject as frame_3d_object
+from .pose3d import Frame3dObject as frame_3d_object
 from .prism import Prism
 from .rectangle import Rectangle
 from .rotation import Rotation

--- a/rosys/geometry/pose3d.py
+++ b/rosys/geometry/pose3d.py
@@ -4,8 +4,10 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 
 import numpy as np
+from nicegui import ui
 from typing_extensions import Self
 
+from .. import rosys
 from .frame3d_registry import frame_registry
 from .object3d import Object3d
 from .point3d import Point3d
@@ -95,3 +97,31 @@ class Frame3d(Pose3d):
         yield self
         if self.frame_id:
             yield from frame_registry[self.frame_id].ancestors
+
+
+class Frame3dSceneObject(ui.scene.group):
+    def __init__(self, frame: Frame3d | Pose3d, *, name: str = '', show_x: bool = True, show_y: bool = True, show_z: bool = True, length: float = 0.15) -> None:
+        super().__init__()
+        self.frame = frame
+        with self:
+            axes: list[tuple[str, float, float, float]] = []
+            if show_x:
+                axes.append(('#ff0000', 0, 0, -np.pi / 2))
+            if show_y:
+                axes.append(('#00ff00', 0, 0, 0))
+            if show_z:
+                axes.append(('#0000ff', np.pi / 2, 0, 0))
+            for color, rx, ry, rz in axes:
+                with ui.scene.group().rotate(rx, ry, rz):
+                    ui.scene.cylinder(0.02 * length, 0.02 * length, 0.8 * length) \
+                        .move(y=0.4 * length).material(color)
+                    ui.scene.cylinder(0, 0.05 * length, 0.2 * length) \
+                        .move(y=0.9 * length).material(color)
+            if name != '':
+                ui.scene.text(name).move(z=-0.03)
+        rosys.on_repeat(self.update, rosys.config.ui_update_interval)
+
+    def update(self) -> None:
+        resolved_pose = self.frame.resolve()
+        self.move(*resolved_pose.translation)
+        self.rotate(*resolved_pose.rotation.euler)

--- a/rosys/geometry/pose3d.py
+++ b/rosys/geometry/pose3d.py
@@ -99,8 +99,11 @@ class Frame3d(Pose3d):
             yield from frame_registry[self.frame_id].ancestors
 
 
-class Frame3dSceneObject(ui.scene.group):
-    def __init__(self, frame: Frame3d | Pose3d, *, name: str = '', show_x: bool = True, show_y: bool = True, show_z: bool = True, length: float = 0.15) -> None:
+class Frame3dObject(ui.scene.group):
+    """An object for visualizing the coordinate frame of a 3D object in a NiceGUI scene."""
+
+    def __init__(self, frame: Object3d, *,
+                 name: str = '', show_x: bool = True, show_y: bool = True, show_z: bool = True, length: float = 0.15) -> None:
         super().__init__()
         self.frame = frame
         with self:
@@ -113,11 +116,9 @@ class Frame3dSceneObject(ui.scene.group):
                 axes.append(('#0000ff', np.pi / 2, 0, 0))
             for color, rx, ry, rz in axes:
                 with ui.scene.group().rotate(rx, ry, rz):
-                    ui.scene.cylinder(0.02 * length, 0.02 * length, 0.8 * length) \
-                        .move(y=0.4 * length).material(color)
-                    ui.scene.cylinder(0, 0.05 * length, 0.2 * length) \
-                        .move(y=0.9 * length).material(color)
-            if name != '':
+                    ui.scene.cylinder(0.02 * length, 0.02 * length, 0.8 * length).move(y=0.4 * length).material(color)
+                    ui.scene.cylinder(0.00 * length, 0.05 * length, 0.2 * length).move(y=0.9 * length).material(color)
+            if name:
                 ui.scene.text(name).move(z=-0.03)
         rosys.on_repeat(self.update, rosys.config.ui_update_interval)
 

--- a/rosys/geometry/pose3d.py
+++ b/rosys/geometry/pose3d.py
@@ -100,9 +100,9 @@ class Frame3d(Pose3d):
 
 
 class Frame3dObject(ui.scene.group):
-    """An object for visualizing the coordinate frame of a 3D object in a NiceGUI scene."""
+    """An object for visualizing the coordinate frame of a 3D pose in a NiceGUI scene."""
 
-    def __init__(self, frame: Object3d, *,
+    def __init__(self, frame: Pose3d, *,
                  name: str = '', show_x: bool = True, show_y: bool = True, show_z: bool = True, length: float = 0.15) -> None:
         super().__init__()
         self.frame = frame

--- a/rosys/geometry/pose3d.py
+++ b/rosys/geometry/pose3d.py
@@ -99,11 +99,17 @@ class Frame3d(Pose3d):
             yield from frame_registry[self.frame_id].ancestors
 
 
-class Frame3dObject(ui.scene.group):
+class AxesObject(ui.scene.group):
     """An object for visualizing the coordinate frame of a 3D pose in a NiceGUI scene."""
 
-    def __init__(self, frame: Pose3d, *,
-                 name: str = '', show_x: bool = True, show_y: bool = True, show_z: bool = True, length: float = 0.15) -> None:
+    def __init__(self,
+                 frame: Pose3d, *,
+                 name: str = '',
+                 show_x: bool = True,
+                 show_y: bool = True,
+                 show_z: bool = True,
+                 length: float = 1.0,
+                 ) -> None:
         super().__init__()
         self.frame = frame
         with self:


### PR DESCRIPTION
I want to share `Frame3dSceneObject` that I built for easier debugging of 3d frames. You only need nicegui's 3d scene and a `Frame3d`, nothing else is needed and they update their positions themselves.

Here I modified the [camera arm example](https://github.com/zauberzeug/rosys/blob/main/examples/camera_arm/main.py)

https://github.com/user-attachments/assets/c5836746-ebcb-4ee9-ad24-41aff7128b4c

I replaced the given page function
https://github.com/zauberzeug/rosys/blob/10c73721be0cd5da5bff8acce540f0e67e94ea9a/examples/camera_arm/main.py#L68-L96

with this:

```python
def page():
    keyboard_control(steerer)
    with ui.row():
        with ui.scene() as scene:
            scene.move_camera(y=-2, z=2)
            frame_3d_object(anchor_frame)
            frame_3d_object(arm1.base, name='Arm 1 Base')
            frame_3d_object(arm2.base, name='Arm 2 Base')
            frame_3d_object(cam.pose, name='Camera')

        with ui.column():
            joystick(steerer, size=50, color='blue')
            ui.slider(min=-math.pi / 2, max=math.pi / 2, step=0.01, value=0, on_change=lambda e: arm1.pitch(e.value))
            ui.slider(min=-math.pi / 2, max=math.pi / 2, step=0.01, value=0, on_change=lambda e: arm2.pitch(e.value))
            ui.slider(min=-math.pi / 4, max=math.pi / 4, step=0.01, value=0, on_change=lambda e: cam.pitch(e.value))
```