### PR TITLE
Add download functionality for lizard configs

### DIFF
--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -126,6 +126,8 @@ class RobotBrain:
                         .tooltip('Enable the microcontroller module (will later be done automatically)')
                     ui.menu_item('Configure', on_click=self.configure) \
                         .tooltip('Configure the microcontroller with the Lizard startup file')
+                    ui.menu_item('Download Config', on_click=lambda: ui.download(self.lizard_code.encode('utf-8'), 'config.liz')) \
+                        .tooltip('Download the lizard config file')
                     ui.menu_item('Restart', on_click=self.restart) \
                         .tooltip('Restart the microcontroller')
                 ui.button(on_click=menu.open).props('icon=more_vert flat round')

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -127,7 +127,7 @@ class RobotBrain:
                     ui.menu_item('Configure', on_click=self.configure) \
                         .tooltip('Configure the microcontroller with the Lizard startup file')
                     ui.menu_item('Download Config', on_click=lambda: ui.download(self.lizard_code.encode('utf-8'), 'config.liz')) \
-                        .tooltip('Download the lizard config file')
+                        .tooltip('Download the Lizard config file')
                     ui.menu_item('Restart', on_click=self.restart) \
                         .tooltip('Restart the microcontroller')
                 ui.button(on_click=menu.open).props('icon=more_vert flat round')


### PR DESCRIPTION
To debug the lizard config generated by RoSys without writing it to the microcontroller, this PR adds a menu item to the ui of the robot brain to download the `.liz` file containing the config.
