### PR TITLE
use generic camera type `T` for `CAMERA_ADDED` event parameter

### DIFF
--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -22,7 +22,7 @@ class CameraProvider(Generic[T], persistence.PersistentModule, metaclass=abc.ABC
     def __init__(self, *, persistence_key: str | None = None) -> None:
         super().__init__(persistence_key=persistence_key)
 
-        self.CAMERA_ADDED = Event[Camera]()
+        self.CAMERA_ADDED = Event[T]()
         """a new camera has been added (argument: camera)"""
 
         self.CAMERA_REMOVED = Event[str]()


### PR DESCRIPTION
changes the event parameter type to the already existing generic type so that subtypes use their corresponding camera types (e.g. RtspCameraProvider.CAMERA_ADDED now has type `Event[RtspCamera]`)