### PR TITLE
Add properties to Rotation to get roll, pitch and yaw in degrees

### DIFF
--- a/rosys/geometry/rotation.py
+++ b/rosys/geometry/rotation.py
@@ -46,12 +46,24 @@ class Rotation:
         return np.arctan2(self.R[2][1], self.R[2][2])
 
     @property
+    def roll_deg(self) -> float:
+        return np.rad2deg(self.roll)
+
+    @property
     def pitch(self) -> float:
         return np.arctan2(-self.R[2][0], np.sqrt(self.R[2][1]**2 + self.R[2][2]**2))
 
     @property
+    def pitch_deg(self) -> float:
+        return np.rad2deg(self.pitch)
+
+    @property
     def yaw(self) -> float:
         return np.arctan2(self.R[1][0], self.R[0][0])
+
+    @property
+    def yaw_deg(self) -> float:
+        return np.rad2deg(self.yaw)
 
     @property
     def euler(self) -> tuple[float, float, float]:

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -14,7 +14,7 @@ from serial.tools import list_ports
 from .. import rosys
 from ..driving.driver import PoseProvider
 from ..event import Event
-from ..geometry import GeoPoint, GeoPose, Pose3d, Rotation
+from ..geometry import GeoPoint, GeoPose, Pose
 from ..run import io_bound
 
 
@@ -107,13 +107,13 @@ class Gnss(ABC):
 class GnssHardware(Gnss):
     """This hardware module connects to a Septentrio SimpleRTK3b (Mosaic-H) GNSS receiver."""
 
-    def __init__(self, *, antenna_pose: Pose3d | None, reconnect_interval: float = 3.0) -> None:
+    def __init__(self, *, antenna_pose: Pose | None, reconnect_interval: float = 3.0) -> None:
         """
         :param antenna_pose: the pose of the main antenna in the robot's coordinate frame (yaw: direction to the auxiliary antenna)
         :param reconnect_interval: the interval to wait before reconnecting to the device
         """
         super().__init__()
-        self.antenna_pose = antenna_pose or Pose3d(x=0.0, y=0.0, z=0.0, rotation=Rotation.zero())
+        self.antenna_pose = antenna_pose or Pose(x=0.0, y=0.0, yaw=0.0)
         self._reconnect_interval = reconnect_interval
         self.serial_connection: serial.Serial | None = None
         rosys.on_startup(self._run)
@@ -190,7 +190,7 @@ class GnssHardware(Gnss):
                     last_raw_heading = float(parts[4] or 0.0)
                     last_heading_accuracy = float(parts[7] or 'inf')
                 if last_gga_timestamp == last_gst_timestamp == last_pssn_timestamp != '':
-                    last_heading = last_raw_heading + self.antenna_pose.rotation.yaw_deg
+                    last_heading = last_raw_heading + self.antenna_pose.yaw_deg
                     antenna_pose = GeoPose.from_degrees(last_raw_latitude, last_raw_longitude, last_heading)
                     robot_pose = antenna_pose.relative_shift_by(x=-self.antenna_pose.x, y=-self.antenna_pose.y)
                     self.last_measurement = GnssMeasurement(


### PR DESCRIPTION
This PR adds handy properties to `Rotation` to get roll, pitch and yaw in degrees, like the ones we have in `Pose`.

For context, the old description:

> Our robot's gnss antennas are quite high above the ground and to calculate the correct position on ground level, we have to add the z coordinate to the `antenna_pose`.
> I also added handy degree properties to `Rotation`, like the ones we have in `Pose`.