### PR TITLE
Add retry utility for handling function retries

### DIFF
--- a/rosys/run.py
+++ b/rosys/run.py
@@ -147,7 +147,7 @@ def tear_down() -> None:
 
 async def retry(func: Callable, *,
                 max_attempts: int = 3,
-                max_timeout: float = 10,
+                max_timeout: float | None = None,
                 on_failed: Callable | None = None,
                 logging_callback: Callable[[int, int], None] | None = None,
                 raise_on_failure: bool = False) -> bool:
@@ -159,7 +159,7 @@ async def retry(func: Callable, *,
 
     :param func: The function to retry
     :param max_attempts: Maximum number of retry attempts
-    :param max_timeout: Maximum time in seconds to wait for each attempt
+    :param max_timeout: Optional maximum time in seconds to wait for each attempt
     :param on_failed: Optional callback to execute after each failed attempt
     :param logging_callback: Optional callback to log the current attempt number and max attempts
     :param raise_on_failure: If `True`, raises RuntimeError after all attempts fail

--- a/rosys/run.py
+++ b/rosys/run.py
@@ -7,6 +7,7 @@ import subprocess
 import uuid
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from functools import wraps
 from inspect import signature
 from pathlib import Path
@@ -146,40 +147,35 @@ def tear_down() -> None:
     log.info('teardown complete.')
 
 
+@dataclass(slots=True, kw_only=True, frozen=True)
+class OnFailedArguments:
+    attempt: int
+    max_attempts: int
+
+
 async def retry(func: Callable, *,
                 max_attempts: int = 3,
                 max_timeout: float | None = None,
-                on_failed: Callable | None = None,
-                raise_on_failure: bool = False) -> tuple[bool, Any]:
-    """Call a function multiple times with customizable retry conditions.
+                on_failed: Callable | None = None) -> Any:
+    """Call a function repeatedly until it succeeds or reaches the maximum number of attempts.
 
-    This function attempts to run a function multiple times until it succeeds or reaches the maximum number of attempts.
-    It allows customization of retry count, timeout duration, failure and logging callbacks.
-
-    :param func: An async function to retry
+    :param func: A function to retry
     :param max_attempts: Maximum number of retry attempts
     :param max_timeout: Optional maximum time in seconds to wait per attempt
-    :param on_failed: Optional callback to execute after each failed attempt. Can optionally accept
-                     `attempt` (current 0-based attempt number) and `max_attempts` as keyword arguments.
-    :param raise_on_failure: If ``True``, raises RuntimeError after all attempts fail
-    :return: A tuple containing (success: bool, result: Any) where success indicates if the function succeeded
-             and result contains the return value of the function if successful, None otherwise
-    :raises RuntimeError: If ``raise_on_failure`` is ``True`` and all attempts fail
+    :param on_failed: Optional callback to execute after each failed attempt. Can optionally accept argument of type `OnFailedArguments`
+    :return: Result of the called function
+    :raises RuntimeError: If all attempts fail
     """
     for attempt in range(max_attempts):
         try:
-            result = await asyncio.wait_for(func(), timeout=max_timeout)
-            return True, result
+            return await asyncio.wait_for(func(), timeout=max_timeout)
         except Exception:
             if on_failed is None:
                 continue
-            sig = signature(on_failed)
-            kwargs = {k: v for k, v in {'attempt': attempt, 'max_attempts': max_attempts}.items()
-                      if k in sig.parameters}
-            if asyncio.iscoroutinefunction(on_failed):
-                await on_failed(**kwargs)
+            if signature(on_failed).parameters:
+                result = on_failed(OnFailedArguments(attempt=attempt, max_attempts=max_attempts))
             else:
-                on_failed(**kwargs)
-    if raise_on_failure:
-        raise RuntimeError(f'Running {func.__name__} failed.')
-    return False, None
+                result = on_failed()
+            if asyncio.iscoroutinefunction(on_failed):
+                await result
+    raise RuntimeError(f'Running {func.__name__} failed.')

--- a/rosys/run.py
+++ b/rosys/run.py
@@ -160,9 +160,9 @@ async def retry(func: Callable, *,
     """Call a function repeatedly until it succeeds or reaches the maximum number of attempts.
 
     :param func: A function to retry
-    :param max_attempts: Maximum number of retry attempts
+    :param max_attempts: Maximum number of attempts
     :param max_timeout: Optional maximum time in seconds to wait per attempt
-    :param on_failed: Optional callback to execute after each failed attempt. Can optionally accept argument of type `OnFailedArguments`
+    :param on_failed: Optional callback to execute after each failed attempt (optional argument of type ``OnFailedArguments``)
     :return: Result of the called function
     :raises RuntimeError: If all attempts fail
     """

--- a/rosys/run.py
+++ b/rosys/run.py
@@ -151,20 +151,19 @@ async def retry(func: Callable, *,
                 on_failed: Callable | None = None,
                 logging_callback: Callable[[int, int], None] | None = None,
                 raise_on_failure: bool = False) -> bool:
-    """Retry a function multiple times with customizable retry conditions.
+    """Call a function multiple times with customizable retry conditions.
 
-    This function attempts to execute a function multiple times until it succeeds
-    or reaches the maximum number of attempts. It allows customization of retry count,
-    timeout duration, failure and logging callbacks.
+    This function attempts to run a function multiple times until it succeeds or reaches the maximum number of attempts.
+    It allows customization of retry count, timeout duration, failure and logging callbacks.
 
-    :param func: The function to retry
+    :param func: An async function to retry
     :param max_attempts: Maximum number of retry attempts
-    :param max_timeout: Optional maximum time in seconds to wait for each attempt
+    :param max_timeout: Optional maximum time in seconds to wait per attempt
     :param on_failed: Optional callback to execute after each failed attempt
-    :param logging_callback: Optional callback to log the current attempt number and max attempts
-    :param raise_on_failure: If `True`, raises RuntimeError after all attempts fail
-    :return: `True` if the function succeeded within the attempts, `False` otherwise
-    :raises RuntimeError: If `raise_on_failure` is `True` and all attempts fail
+    :param logging_callback: Optional callback to log failed attempts (arguments: current 0-based attempt number and ``max_attempt``)
+    :param raise_on_failure: If ``True``, raises RuntimeError after all attempts fail
+    :return: ``True`` if the function succeeded within the attempts, ``False`` otherwise
+    :raises RuntimeError: If ``raise_on_failure`` is ``True`` and all attempts fail
     """
     for attempt in range(max_attempts):
         try:

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,61 @@
+import pytest
+
+from rosys import run
+
+
+@pytest.mark.asyncio
+async def test_retry():
+    events = []
+
+    async def func():
+        events.append('call')
+        raise ValueError()
+
+    # with logging callback
+    events.clear()
+    await run.retry(func, logging_callback=lambda attempt, max_attempts: events.append(f'failed {attempt}/{max_attempts}'))
+    assert events == [
+        'call',
+        'failed 0/3',
+        'call',
+        'failed 1/3',
+        'call',
+        'failed 2/3',
+    ]
+
+    # with on_failed callback
+    events.clear()
+    await run.retry(func, on_failed=lambda: events.append('failed'))
+    assert events == [
+        'call',
+        'failed',
+        'call',
+        'failed',
+        'call',
+        'failed',
+    ]
+
+    # with async on_failed callback
+    async def handle_failed():
+        events.append('failed')
+
+    events.clear()
+    await run.retry(func, on_failed=handle_failed)
+    assert events == [
+        'call',
+        'failed',
+        'call',
+        'failed',
+        'call',
+        'failed',
+    ]
+
+    # with raise_on_failure
+    events.clear()
+    with pytest.raises(RuntimeError):
+        await run.retry(func, raise_on_failure=True)
+    assert events == [
+        'call',
+        'call',
+        'call',
+    ]


### PR DESCRIPTION
We encounter the situation quite often where we want to run a hardware controlling function that can fail because of timings for example. But running it in a loop until it's done is problematic aswell.

So this PR adds the `retry` function wrapper, that runs a given function with a maximum number of tries and and other optional parameters like a timeout and a `on_failed` function that is called when an attempt fails.

@falkoschindler I'm not sure whether we should return a boolean or the return value of the function or both. Probably both?