### PR TITLE
Fix Gnss noise calculation in simulation

### DIFF
--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -282,12 +282,11 @@ class GnssSimulation(Gnss):
 
         noise_lat = np.random.normal(0, self._lat_std_dev)
         noise_lon = np.random.normal(0, self._lon_std_dev)
-        noise_length = np.sqrt(noise_lat**2 + noise_lon**2)
-        noise_heading = np.random.normal(0, math.radians(self._heading_std_dev))
-
-        direction = math.atan2(noise_lon, noise_lat)
-        noise_point = geo_pose.point.polar(noise_length, direction)
-        noise_pose = GeoPose(lat=noise_point.lat, lon=noise_point.lon, heading=geo_pose.heading + noise_heading)
+        noise_magnitude = np.sqrt(noise_lat**2 + noise_lon**2)
+        noise_direction = math.atan2(noise_lon, noise_lat)
+        noise_point = geo_pose.point.polar(noise_magnitude, noise_direction)
+        noise_heading = np.random.normal(geo_pose.heading, math.radians(self._heading_std_dev))
+        noise_pose = GeoPose(lat=noise_point.lat, lon=noise_point.lon, heading=noise_heading)
 
         self.last_measurement = GnssMeasurement(
             time=rosys.time(),

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -282,10 +282,11 @@ class GnssSimulation(Gnss):
 
         noise_lat = np.random.normal(0, self._lat_std_dev)
         noise_lon = np.random.normal(0, self._lon_std_dev)
+        noise_length = np.sqrt(noise_lat**2 + noise_lon**2)
         noise_heading = np.random.normal(0, math.radians(self._heading_std_dev))
 
         direction = math.atan2(noise_lon, noise_lat)
-        noise_point = geo_pose.point.polar(noise_lat, direction)
+        noise_point = geo_pose.point.polar(noise_length, direction)
         noise_pose = GeoPose(lat=noise_point.lat, lon=noise_point.lon, heading=geo_pose.heading + noise_heading)
 
         self.last_measurement = GnssMeasurement(


### PR DESCRIPTION
While setting up a test for a new gnss antenna configuration, I noticed that the location noise of the gnss simulation is wrong.
When using `_lat_std_dev=1` and `_lon_std_dev=0`, I got this result which makes sense, because we have two cases:

1. noise_lat is positive, which leads to both a positive direction and distance for polar, resulting in a spread on positive x
2. noise_lat is negative, which leads to both negative values canceling each other out, also resulting in a positive spread

![Screenshot 2025-04-23 at 05 49 16](https://github.com/user-attachments/assets/760cba18-fa6b-4a61-a228-da19b4f127ce)

After the fix, I recorded both `_lat_std_dev` and `_lon_std_dev` alternating between 0 and 1, which led to an expected cross:
![Screenshot 2025-04-23 at 05 51 04](https://github.com/user-attachments/assets/dfffba55-03e6-4d43-b85b-f35af3b6e3e6)

Setting both to 1 also shows the expected pattern:
![Screenshot 2025-04-23 at 06 00 22](https://github.com/user-attachments/assets/2cd6c451-9307-4564-9613-a485041d7a4d)

