### PR TITLE
Add configurable logging level and nicegui keyword arguments to notify function

### DIFF
--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -71,8 +71,10 @@ def notify(message: str,
                'warning',
                'info',
                'ongoing',
-           ] | None = None) -> None:
-    log.info(message)
+           ] | None = None, *,
+           log_level: int = logging.INFO,
+           **kwargs) -> None:
+    log.log(log_level, message, stacklevel=2)
     notifications.append(Notification(time=time(), message=message))
     NEW_NOTIFICATION.emit(message)
     # NOTE show notifications on all pages
@@ -81,7 +83,7 @@ def notify(message: str,
             continue
         with client:
             try:
-                ui.notify(message, type=type)
+                ui.notify(message, type=type, **kwargs)
             except Exception:
                 log.exception('failed to call notify')
 


### PR DESCRIPTION
The `rosys.notify` function always logged as info from rosys.rosys and did not relay NiceGUI keyword arguments so that i.e. the position could not be changed.

Before:
```
2025-04-28 10:49:53.654 [INFO] rosys/rosys.py:77: Test Message
```
After this change:
```
2025-04-28 10:51:02.194 [your loglevel] your_project/your_file.py:line: Test Message
```