### PR TITLE
Improve GNSS message processing to avoid time discrepancies between NMEA messages and RoSys

### DIFF
--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -177,7 +177,11 @@ class GnssHardware(Gnss):
                 time_obj = datetime.strptime(nema_timestamp, '%H%M%S.%f').time()
                 utc_time = datetime.combine(today, time_obj).replace(tzinfo=timezone.utc)
                 timestamp = utc_time.timestamp()
-                self.log.debug('timestamp diff = %s', round(timestamp - rosys_time, 3))
+                diff = round(((timestamp - rosys_time + 43200) % 86400) - 43200, 3)
+                if diff > 0.05:  # NOTE: above 50 ms we will get issues with Kalman filter
+                    self.log.warning('timestamp diff = %s', diff)
+                else:
+                    self.log.debug('timestamp diff = %s', diff)
                 if parts[0] == '$GPGGA':
                     if parts[2] == '' or parts[4] == '':
                         continue

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -183,9 +183,9 @@ class GnssHardware(Gnss):
                 field_index = {'$GPGGA': 1, '$GPGST': 1, '$PSSN': 2}
                 if parts[0] not in field_index:
                     continue
-                nema_timestamp = parts[field_index[parts[0]]]
+                nmea_timestamp = parts[field_index[parts[0]]]
                 today = datetime.now().date()
-                time_obj = datetime.strptime(nema_timestamp, '%H%M%S.%f').time()
+                time_obj = datetime.strptime(nmea_timestamp, '%H%M%S.%f').time()
                 utc_time = datetime.combine(today, time_obj).replace(tzinfo=timezone.utc)
                 timestamp = utc_time.timestamp()
                 diff = round(((timestamp - rosys_time + 43200) % 86400) - 43200, 3)

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -18,6 +18,9 @@ from ..event import Event
 from ..geometry import GeoPoint, GeoPose, Pose
 from ..run import io_bound
 
+SECONDS_DAY = 86400
+SECONDS_HALF_DAY = 43200
+
 
 class GpsQuality(IntEnum):
     INVALID = 0
@@ -110,8 +113,6 @@ class GnssHardware(Gnss):
 
     # Maximum allowed timestamp difference in seconds (default is ok for Kalman Filter with about 1 km/h)
     MAX_TIMESTAMP_DIFF = 0.05
-    SECONDS_DAY = 86400
-    SECONDS_HALF_DAY = 43200
 
     def __init__(self, *, antenna_pose: Pose | None, reconnect_interval: float = 3.0) -> None:
         """
@@ -190,7 +191,7 @@ class GnssHardware(Gnss):
                 time_obj = datetime.strptime(nmea_timestamp, '%H%M%S.%f').time()
                 utc_time = datetime.combine(today, time_obj).replace(tzinfo=timezone.utc)
                 timestamp = utc_time.timestamp()
-                diff = round(((timestamp - rosys_time + self.SECONDS_HALF_DAY) % self.SECONDS_DAY) - self.SECONDS_HALF_DAY, 3)
+                diff = round(((timestamp - rosys_time + SECONDS_HALF_DAY) % SECONDS_DAY) - SECONDS_HALF_DAY, 3)
                 if abs(diff) > self.MAX_TIMESTAMP_DIFF:
                     self.log.warning('timestamp diff = %s (exceeds threshold of %s)', diff, self.MAX_TIMESTAMP_DIFF)
                     continue

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -110,6 +110,8 @@ class GnssHardware(Gnss):
 
     # Maximum allowed timestamp difference in seconds (default is ok for Kalman Filter with about 1 km/h)
     MAX_TIMESTAMP_DIFF = 0.05
+    SECONDS_DAY = 86400
+    SECONDS_HALF_DAY = 43200
 
     def __init__(self, *, antenna_pose: Pose | None, reconnect_interval: float = 3.0) -> None:
         """
@@ -188,7 +190,7 @@ class GnssHardware(Gnss):
                 time_obj = datetime.strptime(nmea_timestamp, '%H%M%S.%f').time()
                 utc_time = datetime.combine(today, time_obj).replace(tzinfo=timezone.utc)
                 timestamp = utc_time.timestamp()
-                diff = round(((timestamp - rosys_time + 43200) % 86400) - 43200, 3)
+                diff = round(((timestamp - rosys_time + self.SECONDS_HALF_DAY) % self.SECONDS_DAY) - self.SECONDS_HALF_DAY, 3)
                 if abs(diff) > self.MAX_TIMESTAMP_DIFF:
                     self.log.warning('timestamp diff = %s (exceeds threshold of %s)', diff, self.MAX_TIMESTAMP_DIFF)
                     continue

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -180,6 +180,7 @@ class GnssHardware(Gnss):
                 diff = round(((timestamp - rosys_time + 43200) % 86400) - 43200, 3)
                 if diff > 0.05:  # NOTE: above 50 ms we will get issues with Kalman Filter
                     self.log.warning('timestamp diff = %s', diff)
+                    continue
                 else:
                     self.log.debug('timestamp diff = %s', diff)
                 if parts[0] == '$GPGGA':

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -201,7 +201,7 @@ class GnssHardware(Gnss):
                     last_pssn_timestamp = timestamp
                     last_raw_heading = float(parts[4] or 0.0)
                     last_heading_accuracy = float(parts[7] or 'inf')
-                if last_gga_timestamp > 0 and last_gst_timestamp > 0 and last_pssn_timestamp > 0:
+                if last_gga_timestamp == last_gst_timestamp == last_pssn_timestamp:
                     last_heading = last_raw_heading + self.antenna_pose.yaw_deg
                     antenna_pose = GeoPose.from_degrees(last_raw_latitude, last_raw_longitude, last_heading)
                     robot_pose = antenna_pose.relative_shift_by(x=-self.antenna_pose.x, y=-self.antenna_pose.y)

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -240,7 +240,7 @@ class GnssHardware(Gnss):
                 return port.device
         raise RuntimeError('No GNSS device found')
 
-    def _connect_to_device(self, port: str, *, baudrate: int = 460800, timeout: float = 0.2) -> serial.Serial:
+    def _connect_to_device(self, port: str, *, baudrate: int = 921600, timeout: float = 0.2) -> serial.Serial:
         self.log.debug('Connecting to GNSS device "%s"...', port)
         try:
             return serial.Serial(port=port, baudrate=baudrate, timeout=timeout)

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -144,7 +144,6 @@ class GnssHardware(Gnss):
         last_gga_timestamp = ''
         last_gst_timestamp = ''
         last_pssn_timestamp = ''
-        self.serial_connection.reset_input_buffer()  # NOTE: start with empty buffer
         while True:
             if not self.is_connected:
                 try:
@@ -225,10 +224,12 @@ class GnssHardware(Gnss):
                 return port.device
         raise RuntimeError('No GNSS device found')
 
-    def _connect_to_device(self, port: str, *, baudrate: int = 115200, timeout: float = 0.2) -> serial.Serial:
+    def _connect_to_device(self, port: str, *, baudrate: int = 460800, timeout: float = 0.2) -> serial.Serial:
         self.log.debug('Connecting to GNSS device "%s"...', port)
         try:
-            return serial.Serial(port=port, baudrate=baudrate, timeout=timeout)
+            serial_connection = serial.Serial(port=port, baudrate=baudrate, timeout=timeout)
+            serial_connection.reset_input_buffer()  # NOTE: make sure the buffer is empty, OS might have data stored
+            return serial_connection
         except serial.SerialException as e:
             raise RuntimeError(f'Could not connect to GNSS device: {port}') from e
 

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -243,8 +243,7 @@ class GnssHardware(Gnss):
     def _connect_to_device(self, port: str, *, baudrate: int = 460800, timeout: float = 0.2) -> serial.Serial:
         self.log.debug('Connecting to GNSS device "%s"...', port)
         try:
-            serial_connection = serial.Serial(port=port, baudrate=baudrate, timeout=timeout)
-            return serial_connection
+            return serial.Serial(port=port, baudrate=baudrate, timeout=timeout)
         except serial.SerialException as e:
             raise RuntimeError(f'Could not connect to GNSS device: {port}') from e
 

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -201,7 +201,7 @@ class GnssHardware(Gnss):
                     last_pssn_timestamp = timestamp
                     last_raw_heading = float(parts[4] or 0.0)
                     last_heading_accuracy = float(parts[7] or 'inf')
-                if last_gga_timestamp == last_gst_timestamp == last_pssn_timestamp != '':
+                if last_gga_timestamp > 0 and last_gst_timestamp > 0 and last_pssn_timestamp > 0:
                     last_heading = last_raw_heading + self.antenna_pose.yaw_deg
                     antenna_pose = GeoPose.from_degrees(last_raw_latitude, last_raw_longitude, last_heading)
                     robot_pose = antenna_pose.relative_shift_by(x=-self.antenna_pose.x, y=-self.antenna_pose.y)

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -108,6 +108,7 @@ class Gnss(ABC):
 class GnssHardware(Gnss):
     """This hardware module connects to a Septentrio SimpleRTK3b (Mosaic-H) GNSS receiver."""
 
+    # Maximum allowed timestamp difference in seconds (default is ok for Kalman Filter with about 1 km/h)
     MAX_TIMESTAMP_DIFF = 0.05
 
     def __init__(self, *, antenna_pose: Pose | None, reconnect_interval: float = 3.0) -> None:
@@ -146,8 +147,6 @@ class GnssHardware(Gnss):
         last_gga_timestamp = 0.0
         last_gst_timestamp = 0.0
         last_pssn_timestamp = 0.0
-
-        # Maximum allowed timestamp difference in seconds (default is ok for Kalman Filter with about 1 km/h)
 
         while True:
             if not self.is_connected:

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -163,8 +163,6 @@ class GnssHardware(Gnss):
                 await rosys.sleep(0.1)
                 assert self.serial_connection is not None
                 self.serial_connection.reset_input_buffer()
-                self.serial_connection.send_break(duration=0.25)
-                self.serial_connection.reset_input_buffer()
 
             assert self.serial_connection is not None
             result = await io_bound(self.serial_connection.read_until, b'\r\n')

--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -141,9 +141,9 @@ class GnssHardware(Gnss):
         last_num_satellites = 0
         last_hdop = 0.0
         last_altitude = 0.0
-        last_gga_timestamp = ''
-        last_gst_timestamp = ''
-        last_pssn_timestamp = ''
+        last_gga_timestamp = 0.0
+        last_gst_timestamp = 0.0
+        last_pssn_timestamp = 0.0
         while True:
             if not self.is_connected:
                 try:
@@ -178,7 +178,7 @@ class GnssHardware(Gnss):
                 utc_time = datetime.combine(today, time_obj).replace(tzinfo=timezone.utc)
                 timestamp = utc_time.timestamp()
                 diff = round(((timestamp - rosys_time + 43200) % 86400) - 43200, 3)
-                if diff > 0.05:  # NOTE: above 50 ms we will get issues with Kalman filter
+                if diff > 0.05:  # NOTE: above 50 ms we will get issues with Kalman Filter
                     self.log.warning('timestamp diff = %s', diff)
                 else:
                     self.log.debug('timestamp diff = %s', diff)


### PR DESCRIPTION
This PR makes various fixes to ensure we do not run into time discrepancies between NMEA messages and RoSys:

- clearing the serial buffer before starting the processing loop ensures we start fresh and do not spend time processing old messages
-  increasing the baud rate ensures we are reading as fast as possible
- warn when timestamps between RoSys and NMEA diverge more than 50 ms (which is kind of a barrier for a functioning Kalman Filter when driving about 1 km/h)
- debug log the time diff for easier debugging