### PR TITLE
Add gnss timestamp to `GnssMeasurement`

### DIFF
--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -317,10 +317,10 @@ class GnssSimulation(Gnss):
         noise_point = geo_pose.point.polar(noise_magnitude, noise_direction)
         noise_heading = np.random.normal(geo_pose.heading, math.radians(self._heading_std_dev))
         noise_pose = GeoPose(lat=noise_point.lat, lon=noise_point.lon, heading=noise_heading)
-
+        timestamp = rosys.time()
         self.last_measurement = GnssMeasurement(
-            time=rosys.time(),
-            gnss_time=rosys.time(),
+            time=timestamp,
+            gnss_time=timestamp,
             pose=noise_pose,
             latitude_std_dev=self._lat_std_dev,
             longitude_std_dev=self._lon_std_dev,


### PR DESCRIPTION
When working with gnss it can be useful to access the timestamp of the `GnssMeasurement` that has come from the gnss device. At the moment we only use the `rosys.time`, so the time that the `NEW_MEASURMENT` Event is callled and not the actual time of the nss measurement in the gnss device. To introduce the timestamp of the incoming Gnss measurment we add the `gnss_time` property to the `GnssMeasurement` dataclass.