### PR TITLE
Generate breaking change warnings for release notes

### DIFF
--- a/fetch_milestone.py
+++ b/fetch_milestone.py
@@ -42,7 +42,7 @@ for issue in issues:
     numbers_str = ', '.join(f'#{number}' for number in sorted(numbers))
     note = f'{title.strip()} ({numbers_str} by @{user})'
     if 'breaking change' in labels:
-        note += '\n  ⚠️  **Breaking change:** add information regarding the breaking change'
+        note += '\n  ⚠️  **Breaking change:** TODO: add information regarding the breaking change'
     if 'bug' in labels:
         sections['Bugfixes'].append(note)
     elif 'enhancement' in labels:

--- a/fetch_milestone.py
+++ b/fetch_milestone.py
@@ -41,6 +41,8 @@ for issue in issues:
     numbers = [issue['number']] + [int(match) for pattern in number_patterns for match in re.findall(pattern, body)]
     numbers_str = ', '.join(f'#{number}' for number in sorted(numbers))
     note = f'{title.strip()} ({numbers_str} by @{user})'
+    if 'breaking change' in labels:
+        note += '\n  ⚠️  **Breaking change:** add information regarding the breaking change'
     if 'bug' in labels:
         sections['Bugfixes'].append(note)
     elif 'enhancement' in labels:


### PR DESCRIPTION
We introduced a new "breaking change" label, but had to make sure to remember it when writing release notes ([0.24.0](https://github.com/zauberzeug/rosys/releases/tag/v0.24.0)).

This PR adds the following line below pull requests with this label:

> ⚠️  **Breaking change:** TODO: add information regarding the breaking change



Full output:
```
❯ python3 fetch_milestone.py 0.24.0
### New features and enhancements

- Add gnss timestamp to `GnssMeasurement` (#288 by @Johannes-Thiel)
- Improve GNSS message processing to avoid time discrepancies between NMEA messages and RoSys (#285 by @rodja)
- Implement new esp disabling (#284 by @pascalzauberzeug)
- Add another dahua mac prefix (#283 by @denniswittich)
- add reolink vendor mac and url (#282 by @NiklasNeugebauer)
- Allow inverting e-stops and bumpers (#281 by @Johannes-Thiel)
  ⚠️  **Breaking change:** TODO: add information regarding the breaking change
- Add configurable logging level and nicegui keyword arguments to notify function (#280 by @pascalzauberzeug)
- Add retry utility for handling function retries (#278 by @pascalzauberzeug)
- Add properties to Rotation to get roll, pitch and yaw in degrees (#277 by @pascalzauberzeug)
- Make color parameter configurable in detection SVG rendering (#273 by @pascalzauberzeug)
- Add download functionality for lizard configs (#272 by @pascalzauberzeug)
- Introduce a new `Persistable` mixin (#266 by @falkoschindler)
  ⚠️  **Breaking change:** TODO: add information regarding the breaking change

### Bugfixes

- Handle missing NMEA timestamp (#287 by @pascalzauberzeug)
- Fix compatibility with NiceGUI 2.16.x (#286 by @pascalzauberzeug)
- Fix Gnss noise calculation in simulation (#279 by @pascalzauberzeug)
- use generic camera type `T` for `CAMERA_ADDED` event parameter (#274 by @NiklasNeugebauer)

### Documentation

- Merge examples/ folder into docs/examples/ (#275 by @falkoschindler)
```