### PR TITLE
Clear `Persistable` instances after test

### DIFF
--- a/rosys/persistence/backup_schedule.py
+++ b/rosys/persistence/backup_schedule.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from pathlib import Path
 
-from .. import rosys
+from .. import core
 from .import_export import export_all
 
 
@@ -24,7 +24,7 @@ class BackupSchedule:
         self.backup_count = backup_count
         self.log = logging.getLogger('rosys.persistence')
 
-        rosys.on_repeat(self.backup, 60)
+        core.on_repeat(self.backup, 60)
 
     def backup(self) -> None:
         """Backup the persistence files every day at the specified time."""

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -20,6 +20,7 @@ from .config import Config
 from .geometry.frame3d_registry import frame_registry
 from .helpers import invoke, is_stopping
 from .helpers import is_test as is_test_
+from .persistence import Persistable
 
 warnings.filterwarnings('once', category=DeprecationWarning, module='rosys')
 
@@ -288,6 +289,7 @@ def reset_after_test() -> None:
     event.reset()
     frame_registry.clear()
 
+    Persistable.instances.clear()
     register_base_startup_handlers()
 
 


### PR DESCRIPTION
We had issues running our tests with multiple fixtures, because the persistence keys were not cleared after a test.

```
        if key is None:
            key = self.__module__
        if not key.strip('.'):
            raise ValueError('Key is empty')
        if not KEY_PATTERN.match(key):
            raise ValueError(f'Key "{key}" contains invalid characters')
        if key in self.instances:
>           raise ValueError(f'Key "{key}" is already used by another persistent object')
E           ValueError: Key "field_friend.robot_locator" is already used by another persistent object

../rosys/rosys/persistence/persistable.py:57: ValueError
```