### PR TITLE
Improve ESP ready state handling

### DIFF
--- a/rosys/automation/app_controls_.py
+++ b/rosys/automation/app_controls_.py
@@ -122,8 +122,11 @@ class AppControls:
                 for prop in get_properties(button):
                     cmd = f'bluetooth.send("{method} /button/{group}/{name}{prop}")'
                     await self.robot_brain.send(cmd)
-        await run('main', self.main_buttons)
-        await run('extra', self.extra_buttons)
+        try:
+            await run('main', self.main_buttons)
+            await run('extra', self.extra_buttons)
+        except EspNotReadyException:
+            self.log.error('Failed to send app controls from %s: ESP not ready', inspect.stack()[1].function)
 
     def _invoke(self, callback: Callable):
         if inspect.iscoroutinefunction(callback):

--- a/rosys/automation/app_controls_.py
+++ b/rosys/automation/app_controls_.py
@@ -56,10 +56,10 @@ class AppControls:
         }
         self.extra_buttons: dict[str, AppButton] = {}
 
-        rosys.on_startup(self._startup_sync)
         rosys.on_shutdown(self.clear)
         rosys.on_repeat(self.refresh, 0.1)
         rosys.NEW_NOTIFICATION.register(self.notify)
+        robot_brain.ESP_CONNECTED.register(self.sync)
         robot_brain.LINE_RECEIVED.register(self.parse)
 
     async def refresh(self) -> None:
@@ -111,10 +111,6 @@ class AppControls:
 
     async def sync(self):
         await self.send('PUT', lambda b: b.get_properties())
-
-    async def _startup_sync(self):
-        await self.robot_brain.ESP_CONNECTED
-        await self.sync()
 
     async def clear(self):
         await self.send('DELETE')

--- a/rosys/automation/app_controls_.py
+++ b/rosys/automation/app_controls_.py
@@ -53,7 +53,7 @@ class AppControls:
         }
         self.extra_buttons: dict[str, AppButton] = {}
 
-        rosys.on_startup(self.sync)
+        rosys.on_startup(self._startup_sync)
         rosys.on_shutdown(self.clear)
         rosys.on_repeat(self.refresh, 0.1)
         rosys.NEW_NOTIFICATION.register(self.notify)
@@ -102,6 +102,10 @@ class AppControls:
 
     async def sync(self):
         await self.send('PUT', lambda b: b.get_properties())
+
+    async def _startup_sync(self):
+        await self.robot_brain.ESP_CONNECTED
+        await self.sync()
 
     async def clear(self):
         await self.send('DELETE')

--- a/rosys/automation/app_controls_.py
+++ b/rosys/automation/app_controls_.py
@@ -56,11 +56,15 @@ class AppControls:
         }
         self.extra_buttons: dict[str, AppButton] = {}
 
-        rosys.on_shutdown(self.clear)
-        rosys.on_repeat(self.refresh, 0.1)
-        rosys.NEW_NOTIFICATION.register(self.notify)
-        robot_brain.ESP_CONNECTED.register(self.sync)
-        robot_brain.LINE_RECEIVED.register(self.parse)
+        def handle_esp_ready():
+            rosys.on_shutdown(self.clear)
+            rosys.on_repeat(self.refresh, 0.1)
+            rosys.NEW_NOTIFICATION.register(self.notify)
+            robot_brain.ESP_CONNECTED.register(self.sync)
+            robot_brain.LINE_RECEIVED.register(self.parse)
+            robot_brain.ESP_CONNECTED.unregister(handle_esp_ready)
+
+        robot_brain.ESP_CONNECTED.register(handle_esp_ready)
 
     async def refresh(self) -> None:
         if not self.main_buttons:  # happens on shutdown

--- a/rosys/hardware/__init__.py
+++ b/rosys/hardware/__init__.py
@@ -10,7 +10,7 @@ from .gnss import Gnss, GnssHardware, GnssMeasurement, GnssSimulation
 from .imu import Imu, ImuHardware, ImuMeasurement, ImuSimulation
 from .module import Module, ModuleHardware, ModuleSimulation
 from .robot import Robot, RobotHardware, RobotSimulation
-from .robot_brain import RobotBrain
+from .robot_brain import EspNotReadyException, RobotBrain
 from .serial import SerialHardware
 from .wheels import Wheels, WheelsHardware, WheelsSimulation
 
@@ -28,6 +28,7 @@ __all__ = [
     'EStop',
     'EStopHardware',
     'EStopSimulation',
+    'EspNotReadyException',
     'ExpanderHardware',
     'Gnss',
     'GnssHardware',

--- a/rosys/hardware/bms.py
+++ b/rosys/hardware/bms.py
@@ -67,7 +67,7 @@ class BmsHardware(Bms, ModuleHardware):
         self.message_hooks[name] = self._handle_bms
 
     async def _request(self) -> None:
-        if rosys.time() > self.state.last_update + self.UPDATE_INTERVAL:
+        if self.robot_brain.is_ready and rosys.time() > self.state.last_update + self.UPDATE_INTERVAL:
             await self.robot_brain.send(f'{self.name}.send(0xdd, 0xa5, 0x03, 0x00, 0xff, 0xfd, 0x77)')
 
     def _handle_bms(self, line: str) -> None:

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -197,12 +197,11 @@ class RobotBrain:
             if 'Replica complete' in line:
                 self.FLASH_P0_COMPLETE.emit()
             self.LINE_RECEIVED.emit(line)
-            if hardware_time is None:
-                continue
-            if self._hardware_time is None:
-                rosys.notify('ESP connected', 'positive')
-                self.ESP_CONNECTED.emit()
-            self._hardware_time = hardware_time
+            if hardware_time is not None:
+                if self._hardware_time is None:
+                    rosys.notify('ESP connected', 'positive')
+                    self.ESP_CONNECTED.emit()
+                self._hardware_time = hardware_time
             lines.append((self._hardware_time, line))
         if millis is not None:
             self._handle_clock_offset(rosys.time() - millis / 1000)

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -207,9 +207,13 @@ class RobotBrain:
         self._clock_offset = sum(self._clock_offsets) / len(self._clock_offsets)
 
     async def send(self, msg: str) -> None:
+        if not self.is_ready:
+            raise EspNotReadyException('Sending message failed because ESP is not ready')
         await self.communication.send(augment(msg))
 
     async def send_and_await(self, msg: str, ack: str, *, timeout: float = float('inf')) -> str | None:
+        if not self.is_ready:
+            raise EspNotReadyException('Sending message failed because ESP is not ready')
         self.waiting_list[ack] = None
         await self.send(msg)
         t0 = rosys.time()
@@ -317,6 +321,11 @@ class RobotBrain:
 
     def __repr__(self) -> str:
         return f'<RobotBrain {self.communication}>'
+
+
+class EspNotReadyException(Exception):
+    """Raised when trying to use the ESP before it is ready."""
+    pass
 
 
 def augment(line: str) -> str:

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -24,7 +24,7 @@ class RobotBrain:
     If the offset changes significantly, a notification is sent and the offset history is cleared.
     """
 
-    def __init__(self, communication: Communication, *, enable_esp_on_startup: bool = True) -> None:
+    def __init__(self, communication: Communication, *, enable_esp_on_startup: bool = True, use_espresso: bool = False) -> None:
         self.LINE_RECEIVED = Event[str]()
         """a line has been received from the microcontroller (argument: line as string)"""
         self.FLASH_P0_COMPLETE = Event[[]]()
@@ -40,6 +40,7 @@ class RobotBrain:
         self._clock_offset: float | None = None
         self._clock_offsets: deque[float] = deque(maxlen=CLOCK_OFFSET_HISTORY_LENGTH)
         self._hardware_time: float | None = None
+        self._use_espresso = use_espresso
         if enable_esp_on_startup:
             rosys.on_startup(self.enable_esp)
 
@@ -219,6 +220,10 @@ class RobotBrain:
     async def enable_esp(self) -> None:
         if self._esp_lock.locked():
             return
+        if self._use_espresso:
+            await self._enable_espresso()
+            return
+        self.log.warning('Lizard\'s flash.py will be deprecated in the future, consider updating Lizard and using the new espresso.py instead')
         async with self._esp_lock:
             self._hardware_time = None
             rosys.notify('Enabling ESP...')
@@ -226,6 +231,22 @@ class RobotBrain:
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             self.log.debug(output)
             rosys.notify('Enabling ESP: done', 'positive')
+
+    async def _enable_espresso(self) -> None:
+        if self._esp_lock.locked():
+            return
+        async with self._esp_lock:
+            self._hardware_time = None
+            rosys.notify('Enabling ESP...')
+            command = ['sudo', './espresso.py', 'enable', *self._convert_flash_params(self.lizard_firmware.flash_params)]
+            self.log.debug('enable: %s', command)
+            output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
+            if 'Finished.' in output:
+                self.log.debug(output)
+                rosys.notify('Enabling ESP: done', 'positive')
+            else:
+                self.log.error(output)
+                rosys.notify('Enabling ESP: failed', 'negative')
 
     async def disable_esp(self) -> None:
         if self._esp_lock.locked():
@@ -246,6 +267,10 @@ class RobotBrain:
     async def reset_esp(self) -> None:
         if self._esp_lock.locked():
             return
+        if self._use_espresso:
+            await self._reset_espresso()
+            return
+        self.log.warning('Lizard\'s flash.py will be deprecated in the future, consider updating Lizard and using the new espresso.py instead')
         async with self._esp_lock:
             self._hardware_time = None
             rosys.notify('Resetting ESP...')
@@ -253,6 +278,22 @@ class RobotBrain:
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             self.log.debug(output)
             rosys.notify('Resetting ESP: done', 'positive')
+
+    async def _reset_espresso(self) -> None:
+        if self._esp_lock.locked():
+            return
+        async with self._esp_lock:
+            self._hardware_time = None
+            rosys.notify('Resetting ESP...')
+            command = ['sudo', './espresso.py', 'reset', *self._convert_flash_params(self.lizard_firmware.flash_params)]
+            self.log.debug('reset: %s', command)
+            output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
+            if 'Finished.' in output:
+                self.log.debug(output)
+                rosys.notify('Resetting ESP: done', 'positive')
+            else:
+                self.log.error(output)
+                rosys.notify('Resetting ESP: failed', 'negative')
 
     def _convert_flash_params(self, flash_params: list[str]) -> list[str]:
         """Until the deprecation of the flash.py script, we need to convert the flash_params to espresso parameters."""

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -237,11 +237,9 @@ class RobotBrain:
         self.log.warning('Lizard\'s flash.py will be deprecated in the future, consider updating Lizard and using the new espresso.py instead')
         async with self._esp_lock:
             self._hardware_time = None
-            rosys.notify('Enabling ESP...')
             command = ['sudo', './flash.py', *self.lizard_firmware.flash_params, 'enable']
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             self.log.debug(output)
-            rosys.notify('Enabling ESP: done', 'positive')
 
     async def _enable_espresso(self) -> None:
         if self._esp_lock.locked():
@@ -254,10 +252,8 @@ class RobotBrain:
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             if 'Finished.' in output:
                 self.log.debug(output)
-                rosys.notify('Enabling ESP: done', 'positive')
             else:
                 self.log.error(output)
-                rosys.notify('Enabling ESP: failed', 'negative')
 
     async def disable_esp(self) -> None:
         if self._esp_lock.locked():
@@ -270,10 +266,8 @@ class RobotBrain:
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             if 'Finished.' in output:
                 self.log.debug(output)
-                rosys.notify('Disabling ESP: done', 'positive')
             else:
                 self.log.error(output)
-                rosys.notify('Disabling ESP: failed', 'negative')
 
     async def reset_esp(self) -> None:
         if self._esp_lock.locked():
@@ -284,27 +278,22 @@ class RobotBrain:
         self.log.warning('Lizard\'s flash.py will be deprecated in the future, consider updating Lizard and using the new espresso.py instead')
         async with self._esp_lock:
             self._hardware_time = None
-            rosys.notify('Resetting ESP...')
             command = ['sudo', './flash.py', *self.lizard_firmware.flash_params, 'reset']
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             self.log.debug(output)
-            rosys.notify('Resetting ESP: done', 'positive')
 
     async def _reset_espresso(self) -> None:
         if self._esp_lock.locked():
             return
         async with self._esp_lock:
             self._hardware_time = None
-            rosys.notify('Resetting ESP...')
             command = ['sudo', './espresso.py', 'reset', *self._convert_flash_params(self.lizard_firmware.flash_params)]
             self.log.debug('reset: %s', command)
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             if 'Finished.' in output:
                 self.log.debug(output)
-                rosys.notify('Resetting ESP: done', 'positive')
             else:
                 self.log.error(output)
-                rosys.notify('Resetting ESP: failed', 'negative')
 
     def _convert_flash_params(self, flash_params: list[str]) -> list[str]:
         """Until the deprecation of the flash.py script, we need to convert the flash_params to espresso parameters."""

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -321,7 +321,6 @@ class RobotBrain:
 
 class EspNotReadyException(Exception):
     """Raised when trying to use the ESP before it is ready."""
-    pass
 
 
 def augment(line: str) -> str:

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -202,6 +202,8 @@ class RobotBrain:
                     rosys.notify('ESP connected', 'positive')
                     self.ESP_CONNECTED.emit()
                 self._hardware_time = hardware_time
+            if self._hardware_time is None:
+                continue
             lines.append((self._hardware_time, line))
         if millis is not None:
             self._handle_clock_offset(rosys.time() - millis / 1000)


### PR DESCRIPTION
We had issues where hardware commands were sent before the ESP was done booting and instead of just trying to re-send the commands, this PR does:

1. Add `RobotBrain.is_ready` property based on `RobotBrain.hardware_time`
2. Make use of new `espresso.py` optional for enable and reset, but keep `flash.py` as default for now
3. Raise new `EspNotReadyException`, when trying to send a Lizard command when the ESP is not ready
4. Remove old enable etc. notifications, that were not accurate and quite spamy
5. Implement new features in `AppControls` and `BmsHardware`, because they failed when I tested this PR