### PR TITLE
Add a notification to warn about wrong Lizard configuartion

### DIFF
--- a/rosys/hardware/robot.py
+++ b/rosys/hardware/robot.py
@@ -58,7 +58,7 @@ class RobotHardware(Robot):
             rdyp.on()
             en3.on()
         ''')
-        self.output_length = len(output_fields)+2  # add 2 for core and core.millis
+        self.output_length = len(output_fields) + 2  # account for the two words "core" and `core.millis`
         return code
 
     async def update(self) -> None:

--- a/rosys/hardware/robot.py
+++ b/rosys/hardware/robot.py
@@ -74,10 +74,10 @@ class RobotHardware(Robot):
                 if len(words) != self.output_length:
                     current_time = rosys.time()
                     if current_time - self._last_warning_time >= self._warning_cooldown:
-                        rosys.notify(
-                            f'Lizard output configuration is incorrect, expected {self.output_length} parameters, got {len(words)}',
-                            type='negative',
-                            log_level=logging.ERROR)
+                        rosys.notify('Lizard output configuration is incorrect, '
+                                     f'expected {self.output_length} parameters, got {len(words)}',
+                                     type='negative',
+                                     log_level=logging.ERROR)
                         self._last_warning_time = current_time
                     return
                 words.pop(0)

--- a/rosys/hardware/robot.py
+++ b/rosys/hardware/robot.py
@@ -32,6 +32,9 @@ class RobotHardware(Robot):
     def __init__(self, modules: list[Module], robot_brain: RobotBrain) -> None:
         super().__init__(modules)
         self.robot_brain = robot_brain
+        self.output_length = 0
+        self._warning_cooldown = 30.0
+        self._last_warning_time = 0.0
         self.robot_brain.lizard_code = self.generate_lizard_code()
         self.expander_prefixes = set(f'{module.name}:' for module in modules if isinstance(module, ExpanderHardware))
         rosys.on_repeat(self.update, 0.01)
@@ -55,6 +58,7 @@ class RobotHardware(Robot):
             rdyp.on()
             en3.on()
         ''')
+        self.output_length = len(output_fields)+2  # add 2 for core and core.millis
         return code
 
     async def update(self) -> None:
@@ -67,6 +71,15 @@ class RobotHardware(Robot):
             if not words:
                 continue
             if words[0] == 'core':
+                if len(words) != self.output_length:
+                    current_time = rosys.time()
+                    if current_time - self._last_warning_time >= self._warning_cooldown:
+                        rosys.notify(
+                            f'Lizard output configuration is incorrect, expected {self.output_length} parameters, got {len(words)}',
+                            type='negative',
+                            log_level=logging.ERROR)
+                        self._last_warning_time = current_time
+                    return
                 words.pop(0)
                 words.pop(0)
                 for module in self.modules:

--- a/rosys/hardware/robot.py
+++ b/rosys/hardware/robot.py
@@ -32,7 +32,7 @@ class RobotHardware(Robot):
     def __init__(self, modules: list[Module], robot_brain: RobotBrain) -> None:
         super().__init__(modules)
         self.robot_brain = robot_brain
-        self.output_length = 0
+        self._expected_output_length = 0
         self._warning_cooldown = 30.0
         self._last_warning_time = 0.0
         self.robot_brain.lizard_code = self.generate_lizard_code()
@@ -58,7 +58,7 @@ class RobotHardware(Robot):
             rdyp.on()
             en3.on()
         ''')
-        self.output_length = len(output_fields) + 2  # account for the two words "core" and `core.millis`
+        self._expected_output_length = len(output_fields) + 2  # account for the two words "core" and `core.millis`
         return code
 
     async def update(self) -> None:
@@ -71,11 +71,11 @@ class RobotHardware(Robot):
             if not words:
                 continue
             if words[0] == 'core':
-                if len(words) != self.output_length:
+                if len(words) != self._expected_output_length:
                     current_time = rosys.time()
                     if current_time - self._last_warning_time >= self._warning_cooldown:
-                        rosys.notify('Lizard output configuration is incorrect, '
-                                     f'expected {self.output_length} parameters, got {len(words)}',
+                        rosys.notify('Lizard configuration is incorrect, '
+                                     f'expected {self._expected_output_length} words, got {len(words)}',
                                      type='negative',
                                      log_level=logging.ERROR)
                         self._last_warning_time = current_time


### PR DESCRIPTION
### Motivation
When working on robots and introducing new properties to be checked with lizard, it is easy to forget to configure the robot. This is also relevant when changing branches on the robot. This PR aims to notify the user that there is something wrong with the configuration.
<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation
To detect a faulty configuration we are comparing the number of arguments in the `output_fields` with the length of the provided `core_message`. I chose this way of comparison due to the ease of implementation. This will cover most wrong configurations, the only problem will be if two configurations have the same number of paramters, but these parameters are diffrent. This is not a usual case since in practice we mostly add new parameters or remove them. Not change the parameter.

We add `+2` the the `output_length` due to the `core_message` looking like this:
``` 
core <millis> <parameters>
```
And needing to cover `core` and `<millis>` too.

I added a notification timer, in order to prevent message spam. This was chosen, so that the user will be continually informed about the problem and not just once.

<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->

### Progress
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
- [x] Tested on real hardware.
