### PR TITLE
lizard_firmware.py - flash_core should check esp_pins_core not esp_pins_p0

### DIFF
--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -115,7 +115,7 @@ class LizardFirmware:
     async def flash_core(self) -> None:
         assert isinstance(self.robot_brain.communication, SerialCommunication)
         rosys.notify(f'Flashing Lizard firmware {self.local_version} to Core...')
-        if any(await self.robot_brain.esp_pins_p0.get_strapping_pins()):
+        if any(await self.robot_brain.esp_pins_core.get_strapping_pins()):
             rosys.notify('Flashing Core failed. Check strapping pins.', 'negative')
             return
         self.robot_brain.communication.disconnect()


### PR DESCRIPTION
<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
Fixes an incorrect check in flash_core().
<!-- Please provide relevant links to corresponding issues and feature requests. -->

