### PR TITLE
Fix `throttle_at_end` for `linear_speed_limit` lower than 1m/s

### DIFF
--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -193,7 +193,7 @@ class Driver:
             if drive_backward and not self.parameters.can_drive_backwards:
                 drive_backward = False
                 curvature = (-1 if curvature > 0 else 1) / max(self.parameters.minimum_turning_radius, 0.001)
-            linear: float = -1 if drive_backward else 1
+            linear: float = self.parameters.linear_speed_limit * (-1 if drive_backward else 1)
             t = spline.closest_point(hook.x, hook.y)
             if t >= 1.0 and throttle_at_end:
                 target_distance = self.prediction.projected_distance(spline.pose(1.0))


### PR DESCRIPTION
### Motivation

We noticed that our robot was always overshooting the target position when using `rosys.driving.Driver` functions.
The issue is that `linear_speed_limit` is only used as an upper limit for the linear speed that is sent to the wheels. It's not considered when calculating the factor that throttles the robot near its target.

For example:
`Driver.drive_spline` calculates that the linear speed should be only 0.5, because the robot is close to its target position.
If your robot now has a `linear_speed_limit` of for example 0.3m/s it will keep driving at its maximum speed, until the calculated calculated speed is lower than the limit.
This leads to a very abrupt stop or overshooting if the robot has a low deceleration.


### Implementation

It's fixed by not using 1.0 as a starting point for the linear speed in [`Driver.drive_spline`](https://github.com/zauberzeug/rosys/blob/85a78a9147ea6318e5b87beed3de4fadb486fa12/rosys/driving/driver.py#L196), but instead using `DriveParameters.linear_speed_limit`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
