### PR TITLE
Make the driver's minimum spline length configurable

### DIFF
--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -23,6 +23,7 @@ class DriveParameters(ModificationContext):
     carrot_offset: float = 0.6
     carrot_distance: float = 0.1
     hook_bending_factor: float = 0
+    minimum_drive_distance: float = 0.01
 
 
 @dataclass(slots=True, kw_only=True)
@@ -163,7 +164,7 @@ class Driver:
         :param stop_at_end: Whether to stop at the end of the spline (default: ``True``).
         :raises DrivingAbortedException: If the driving process is aborted.
         """
-        if spline.start.distance(spline.end) < 0.01:
+        if spline.start.distance(spline.end) < self.parameters.minimum_drive_distance:
             return  # NOTE: skip tiny splines
 
         hook_offset = Point(x=self.parameters.hook_offset, y=0) * (-1 if flip_hook else 1)


### PR DESCRIPTION
### Motivation

There was a hardcoded minimum length for splines in the `Driver` class, which was too high for our needs.

### Implementation

I decided against another parameter for `drive_spline`, because I would have to add it to `drive_path` and `drive_to` as well, which is already quite cluttered. Instead I used `DriveParameters` and kept the old distance of 1cm as the default value.
### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
