### PR TITLE
Add a configuration for garbage_collection_mbyte_limit

### DIFF
--- a/rosys/config.py
+++ b/rosys/config.py
@@ -9,6 +9,7 @@ class Config(Persistable):
         super().__init__()
         self.ui_update_interval: float = 0.1
         self.simulation_speed: float = 1.0
+        self.garbage_collection_mbyte_limit: float = 300
 
     def backup_to_dict(self) -> dict[str, Any]:
         return {'simulation_speed': self.simulation_speed}

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -232,9 +232,10 @@ async def startup() -> None:
         await coroutine
 
 
-async def _garbage_collection(mbyte_limit: float = 300) -> None:
-    if psutil.virtual_memory().free < mbyte_limit * 1_000_000:
-        log.warning('less than %s mb of memory remaining -> start garbage collection', mbyte_limit)
+async def _garbage_collection() -> None:
+    if psutil.virtual_memory().free < config.garbage_collection_mbyte_limit * 1_000_000:
+        log.warning('less than %s mb of memory remaining -> start garbage collection',
+                    config.garbage_collection_mbyte_limit)
         gc.collect()
         await sleep(1)  # NOTE ensure all warnings appear before sending "finished" message
         log.warning('finished garbage collection')


### PR DESCRIPTION
### Motivation
In our project we have a limited amount of Memory. Due to the limit of `300 mb` the collection is run every minute. This will stop all processing. To fix this issue we want to start the `garbage_collection` in times where our system is not doing anything. For this we introduced this feature to set the `garbage_collection_mbyte_limit` to `0`. This is also relevant for systems with smaller memory, to set the limit to the apropriate threshold.
<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation
To make it confiurable in time, we introduce the value `garbage_collection_mbyte_limit` in the `config.py`.

<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
