### PR TITLE
Reset GNSS buffer after discarding a late message

### DIFF
--- a/rosys/hardware/gnss.py
+++ b/rosys/hardware/gnss.py
@@ -197,6 +197,7 @@ class GnssHardware(Gnss):
                 diff = round(((timestamp - rosys_time + SECONDS_HALF_DAY) % SECONDS_DAY) - SECONDS_HALF_DAY, 3)
                 if abs(diff) > self.MAX_TIMESTAMP_DIFF:
                     self.log.warning('timestamp diff = %s (exceeds threshold of %s)', diff, self.MAX_TIMESTAMP_DIFF)
+                    self.serial_connection.reset_input_buffer()
                     continue
                 else:
                     self.log.debug('timestamp diff = %s', diff)


### PR DESCRIPTION
### Motivation

With https://github.com/zauberzeug/rosys/pull/285 we introduced a check if the delay between the GNSS messages and the time when RoSys handles them is too big.
From there we noticed that if some piece of code blocks the main loop for too long, a lot of GNSS updates will be discarded.

The following log is an example for that. The decreasing difference hints that it needs to work of a queue one by one until messages are accepted again.
```
13.876s BLOCKING CODE DONE
13.932s timestamp diff = -0.433s (exceeds threshold of 0.1)
13.939s timestamp diff = -0.439s (exceeds threshold of 0.1)
13.941s timestamp diff = -0.441s (exceeds threshold of 0.1)
13.943s timestamp diff = -0.343s (exceeds threshold of 0.1)
13.945s timestamp diff = -0.345s (exceeds threshold of 0.1)
13.947s timestamp diff = -0.347s (exceeds threshold of 0.1)
13.951s timestamp diff = -0.251s (exceeds threshold of 0.1)
13.953s timestamp diff = -0.253s (exceeds threshold of 0.1)
13.955s timestamp diff = -0.255s (exceeds threshold of 0.1)
13.957s timestamp diff = -0.157s (exceeds threshold of 0.1)
13.959s timestamp diff = -0.160s (exceeds threshold of 0.1)
13.961s timestamp diff = -0.161s (exceeds threshold of 0.1)
```

### Implementation

That's why this PR just resets the serial buffer when a message comes in too late. This way only one message has to be discarded and the following ones are accepted again.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
