### PR TITLE
Make throttle at end ramp configurable

### DIFF
--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -25,7 +25,8 @@ class DriveParameters(ModificationContext):
     hook_bending_factor: float = 0
     minimum_drive_distance: float = 0.01
     throttle_at_end_distance: float = 0.5
-    throttle_at_end_linear_speed_min: float = 0.01
+    throttle_at_end_min_speed: float = 0.01
+
 
 @dataclass(slots=True, kw_only=True)
 class DriveState:
@@ -199,10 +200,9 @@ class Driver:
             t = spline.closest_point(hook.x, hook.y)
             if t >= 1.0 and throttle_at_end:
                 target_distance = self.prediction.projected_distance(spline.pose(1.0))
-                linear *= ramp(target_distance,
-                        self.parameters.throttle_at_end_distance, 0.0,
-                        1.0, self.parameters.throttle_at_end_linear_speed_min,
-                        clip=True)
+                throttle_distance = self.parameters.throttle_at_end_distance
+                min_linear_speed = self.parameters.throttle_at_end_min_speed
+                linear *= ramp(target_distance, throttle_distance, 0.0, 1.0, min_linear_speed, clip=True)
             angular = linear * curvature
 
             self.state = DriveState(

--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -24,7 +24,8 @@ class DriveParameters(ModificationContext):
     carrot_distance: float = 0.1
     hook_bending_factor: float = 0
     minimum_drive_distance: float = 0.01
-
+    throttle_at_end_distance: float = 0.5
+    throttle_at_end_linear_speed_min: float = 0.91
 
 @dataclass(slots=True, kw_only=True)
 class DriveState:
@@ -198,7 +199,10 @@ class Driver:
             t = spline.closest_point(hook.x, hook.y)
             if t >= 1.0 and throttle_at_end:
                 target_distance = self.prediction.projected_distance(spline.pose(1.0))
-                linear *= ramp(target_distance, self.parameters.hook_offset, 0.0, 1.0, 0.01, clip=True)
+                linear *= ramp(target_distance,
+                        self.parameters.throttle_at_end_distance, 0.0,
+                        1.0, self.parameters.throttle_at_end_linear_speed_min,
+                        clip=True)
             angular = linear * curvature
 
             self.state = DriveState(

--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -25,7 +25,7 @@ class DriveParameters(ModificationContext):
     hook_bending_factor: float = 0
     minimum_drive_distance: float = 0.01
     throttle_at_end_distance: float = 0.5
-    throttle_at_end_linear_speed_min: float = 0.91
+    throttle_at_end_linear_speed_min: float = 0.01
 
 @dataclass(slots=True, kw_only=True)
 class DriveState:


### PR DESCRIPTION
### Motivation
Currently, the stopping behaviour with throttle_at_end in Driver.drive_spline is not configurable.
This leads to robots (such as the Field Friend) taking a long time to come to a stop.
This could be optimized, but the ramp settings are not configurable.

### Implementation
To allow for changing of the throttling behaviour, we simply swap the ramp arguments with values we add to the driver parameters.
Thus, we can set the min speed (as a factor) and the distance to start throttling.
Perhaps, the code needs some more changes if the throttle distance is larger than the hook distance.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
