### PR TITLE
Ignore `TimeoutError` when restarting the ESP

### DIFF
--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -168,7 +168,9 @@ class RobotBrain:
     async def restart(self) -> None:
         await self.send('core.restart()', force=True)
         try:
-            await self.LINE_RECEIVED.emitted(timeout=1.0)  # Note: we have to wait for the last core message to be sent
+            await self.LINE_RECEIVED.emitted(timeout=1.0)  # NOTE: we have to wait for the last core message to be sent
+        except TimeoutError:
+            pass
         finally:
             self._hardware_time = None
 


### PR DESCRIPTION
### Motivation

When restarting the ESP via `robot_brain.restart()`, it is possible to cause a `TimeoutError` if the ESP is not sending core messages. This exception should be caught and ignored because it is not relevant for the restart procedure.

### Implementation

I simply added an `except` block.
I also changed a related comment to use the `NOTE` marker instead of `Note` to improve discoverability and support VSCode's built-in to-do list features.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
