### PR TITLE
save the position, from witch images have been taken.

### DIFF
--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -253,15 +253,16 @@ class Calibration:
         """
 
     @overload
-    def project_from_image(self, image_coordinates: FloatArray, target_height: float = 0) -> FloatArray:
+    def project_from_image(self, image_coordinates: FloatArray, target_height: float = 0, frame: Frame3d | None = None) -> FloatArray:
         """Project points in image coordinates to a plane in world coordinates.
 
         :param image_coordinates: (Nx2) The image coordinates to project.
         :param target_height: The height of the plane in world coordinates.
+        :param frame: The coordinate frame from which to project the image coordinates to.
         :return: (Nx3) The world coordinates of the projected points.
         """
 
-    def project_from_image(self, image_coordinates: Point | list[Point] | FloatArray, target_height: float = 0) -> Point3d | None | list[Point3d | None] | FloatArray:
+    def project_from_image(self, image_coordinates: Point | list[Point] | FloatArray, target_height: float = 0, frame: Frame3d | None = None) -> Point3d | None | list[Point3d | None] | FloatArray:
         if isinstance(image_coordinates, Point):
             return self.project_from_image([image_coordinates], target_height=target_height)[0]
         if not isinstance(image_coordinates, np.ndarray):
@@ -269,7 +270,7 @@ class Calibration:
             world_array = self.project_from_image(image_array, target_height=target_height)
             return [Point3d(x=point[0], y=point[1], z=point[2]) if not np.isnan(point).any() else None for point in world_array]
 
-        world_extrinsics = self.extrinsics.resolve()
+        world_extrinsics = self.extrinsics.resolve(frame)
         image_rays = self._points_to_rays(image_coordinates.astype(np.float64).reshape(-1, 1, 2))
         objPoints = image_rays @ world_extrinsics.rotation.matrix.T
         Z = world_extrinsics.z

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -270,7 +270,7 @@ class Calibration:
             world_array = self.project_from_image(image_array, target_height=target_height)
             return [Point3d(x=point[0], y=point[1], z=point[2]) if not np.isnan(point).any() else None for point in world_array]
 
-        world_extrinsics = self.extrinsics.resolve(frame)
+        world_extrinsics = self.extrinsics.transform_with(frame.resolve())
         image_rays = self._points_to_rays(image_coordinates.astype(np.float64).reshape(-1, 1, 2))
         objPoints = image_rays @ world_extrinsics.rotation.matrix.T
         Z = world_extrinsics.z

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -270,7 +270,7 @@ class Calibration:
             world_array = self.project_from_image(image_array, target_height=target_height)
             return [Point3d(x=point[0], y=point[1], z=point[2]) if not np.isnan(point).any() else None for point in world_array]
 
-        world_extrinsics = self.extrinsics.transform_with(frame.resolve())
+        world_extrinsics = self.extrinsics.resolve() if frame is None else self.extrinsics.transform_with(frame.resolve())
         image_rays = self._points_to_rays(image_coordinates.astype(np.float64).reshape(-1, 1, 2))
         objPoints = image_rays @ world_extrinsics.rotation.matrix.T
         Z = world_extrinsics.z

--- a/rosys/vision/image.py
+++ b/rosys/vision/image.py
@@ -31,6 +31,7 @@ class Image:
     size: ImageSize
     time: float  # time of recording
     data: bytes | None = None
+    pose: rosys.geometry.Pose3d | None = None # Pose from which the image has been taken
     _detections: dict[str, Detections] = field(default_factory=dict)
     is_broken: bool | None = None
     tags: set[str] = field(default_factory=set)


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
The detection process for an image detector can take time (or could be delayed, etc.). During this time a robot could move. The position prom witch the image has been taken is not saved, thus it is not possible to accurately calculate the positions of detected objects in an image.

<!-- Please provide relevant links to corresponding issues and feature requests. -->


### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
The concept is to save the pose from witch an image has been taken as soon as possible after receiving the image data, thus saving the most accurate position possible.

<!-- Include any important technical decisions or trade-offs made -->
A potential trade-off is additional memory usage. Compared to the image data, this should be minimal.

### Progress

- [ ] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
