### PR TITLE
Allow creating repeaters in stopped state

### DIFF
--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -198,9 +198,9 @@ class Repeater:
             repeater.cancel()
 
 
-def on_repeat(handler: Callable, interval: float, start: bool = True) -> Repeater:
+def on_repeat(handler: Callable, interval: float, start_on_creation: bool = True) -> Repeater:
     repeater = Repeater(handler, interval)
-    if start:
+    if start_on_creation:
         repeater.start()
     return repeater
 

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -198,9 +198,10 @@ class Repeater:
             repeater.cancel()
 
 
-def on_repeat(handler: Callable, interval: float) -> Repeater:
+def on_repeat(handler: Callable, interval: float, start: bool = True) -> Repeater:
     repeater = Repeater(handler, interval)
-    repeater.start()
+    if start:
+        repeater.start()
     return repeater
 
 


### PR DESCRIPTION
### Motivation

I encountered the situation where I wanted to create a `Repeater` to start and stop it later, but it will always start when created.
In this case I didn't want that.

Using this does not work, because when `Repeater.stop()` is called, the repeater is not running yet:
```python
repeater = rosys.on_repeat(FUNCTION, INTERVAL)
repeater.stop()
```

### Implementation

This is why I propose the `start_on_creation` parameter for `rosys.on_repeat`, that is `True` by default.
I'm not sure with the naming, since `start_on_creation` is a little long. At first I just used `start` which I didn't like because the function that is called, is also named `start()`.

This PR will not break anything and will not change the default behaviour.

### Progress

- [ ] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
