### PR TITLE
Stop driver when spline is too short and stop_at_end is True

### DIFF
--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -167,6 +167,8 @@ class Driver:
         :raises DrivingAbortedException: If the driving process is aborted.
         """
         if spline.start.distance(spline.end) < self.parameters.minimum_drive_distance:
+            if stop_at_end:
+                await self.wheels.stop()
             return  # NOTE: skip tiny splines
 
         hook_offset = Point(x=self.parameters.hook_offset, y=0) * (-1 if flip_hook else 1)


### PR DESCRIPTION
### Motivation & Implementation

The driver has the parameter `minimum_drive_distance`, which prevents it from driving splines that are too short. Too short splines can lead to weird turning movements, that's why we want to avoid it.

The problem occurs when we use `drive_spline` with `stop_at_end=False` and after that we try to drive a spline that is too short but this time with `stop_at_end=True`. Regardless whether the robot drives the spline or not, we expect it to stop.

Therefore I let the wheels stop if the spline is too short and `stop_at_end` is `True`.

Here is a short example that shows the behaviour:
```python
#!/usr/bin/env python3

from nicegui import ui

import rosys
from rosys.geometry import Pose, Spline

wheels = rosys.hardware.WheelsSimulation()
robot = rosys.hardware.RobotSimulation([wheels])
odometer = rosys.driving.Odometer(wheels)
driver = rosys.driving.Driver(wheels, odometer)
automator = rosys.automation.Automator(None, on_interrupt=wheels.stop)

with ui.scene():
    shape = rosys.geometry.Prism.default_robot_shape()
    rosys.driving.robot_object(shape, odometer, debug=True)

spline_1 = Spline.from_poses(Pose(x=0, y=0, yaw=0), Pose(x=1, y=0, yaw=0))
spline_2 = Spline.from_poses(Pose(x=1, y=0, yaw=0), Pose(x=1.009, y=0, yaw=0))


async def main():
    await rosys.sleep(10)
    with driver.parameters.set(linear_speed_limit=0.05):
        await driver.drive_spline(spline_1, stop_at_end=False, throttle_at_end=False)
        await driver.drive_spline(spline_2)


rosys.on_startup(main)

ui.run(title='RoSys')

```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
