### PR TITLE
Introduce `@automation.uninterruptible` decorator

### DIFF
--- a/docs/examples/automations/README.md
+++ b/docs/examples/automations/README.md
@@ -1,0 +1,9 @@
+# Automations
+
+This example demonstrates how to start, pause, resume and stop automations.
+The robot will drive forward and then turn left in an endless loop.
+The `turn_left` function is marked with `@rosys.automation.uninterruptible` which means that it will continue to run even if the automation is interrupted by pausing or stopping it.
+
+```python
+{! examples/automations/main.py !}
+```

--- a/docs/examples/automations/main.py
+++ b/docs/examples/automations/main.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import math
+
+from nicegui import ui
+
+import rosys
+import rosys.helpers
+
+
+async def run() -> None:
+    while True:
+        await forward()
+        await turn_left()
+
+
+async def forward() -> None:
+    start = odometer.prediction
+    while start.distance(odometer.prediction) < 1.0:
+        await wheels.drive(1.0, 0.0)
+        await rosys.sleep(0.1)
+    await wheels.stop()
+
+
+@rosys.automation.uninterruptible
+async def turn_left() -> None:
+    start = odometer.prediction
+    while rosys.helpers.angle(start.yaw, odometer.prediction.yaw) < math.radians(90):
+        await wheels.drive(0.0, 1.0)
+        await rosys.sleep(0.1)
+    await wheels.stop()
+
+
+shape = rosys.geometry.Prism.default_robot_shape()
+wheels = rosys.hardware.WheelsSimulation()
+robot = rosys.hardware.RobotSimulation([wheels])
+odometer = rosys.driving.Odometer(wheels)
+driver = rosys.driving.Driver(wheels, odometer)
+automator = rosys.automation.Automator(None, default_automation=run, on_interrupt=wheels.stop)
+
+with ui.scene():
+    rosys.driving.robot_object(shape, odometer)
+with ui.row():
+    rosys.automation.automation_controls(automator)
+
+ui.run(title='Automations')

--- a/rosys/automation/__init__.py
+++ b/rosys/automation/__init__.py
@@ -1,6 +1,6 @@
 from .app_controls_ import AppButton
 from .app_controls_ import AppControls as app_controls
-from .automation import atomic
+from .automation import uninterruptible
 from .automation_controls_ import AutomationControls as automation_controls
 from .automator import Automator
 from .parallelize import parallelize
@@ -11,7 +11,7 @@ __all__ = [
     'Automator',
     'Schedule',
     'app_controls',
-    'atomic',
     'automation_controls',
     'parallelize',
+    'uninterruptible',
 ]

--- a/rosys/automation/__init__.py
+++ b/rosys/automation/__init__.py
@@ -1,5 +1,6 @@
 from .app_controls_ import AppButton
 from .app_controls_ import AppControls as app_controls
+from .automation import atomic
 from .automation_controls_ import AutomationControls as automation_controls
 from .automator import Automator
 from .parallelize import parallelize
@@ -10,6 +11,7 @@ __all__ = [
     'Automator',
     'Schedule',
     'app_controls',
+    'atomic',
     'automation_controls',
     'parallelize',
 ]

--- a/rosys/automation/automation.py
+++ b/rosys/automation/automation.py
@@ -12,7 +12,10 @@ _CURRENT_AUTOMATION: ContextVar[Automation | None] = ContextVar('rosys_automatio
 
 
 def uninterruptible(func: Callable):
-    """Decorator to make an async function uninterruptible until it exits."""
+    """Decorator to make an async function uninterruptible until it exits.
+
+    Note that ``rosys.automation.parallelize`` will also be uninterruptible if one of its coroutines is marked with this decorator.
+    """
     @functools.wraps(func)
     async def _wrapped(*args, **kwargs):
         automation = _CURRENT_AUTOMATION.get()

--- a/rosys/automation/automation.py
+++ b/rosys/automation/automation.py
@@ -72,14 +72,14 @@ class Automation:
             iter_send, iter_throw = coro_iter.send, coro_iter.throw
             send: Callable = iter_send
             message: Any = None
-            while not self._stop:
+            while not (self._atomic_depth == 0 and self._stop):
                 try:
                     while self._atomic_depth == 0 and not self._can_run.is_set() and not self._stop:
                         yield from self._can_run.wait().__await__()  # pylint: disable=no-member
                 except BaseException as err:
                     send, message = iter_throw, err
 
-                if self._stop:
+                if self._atomic_depth == 0 and self._stop:
                     return None
 
                 try:

--- a/rosys/automation/parallelize.py
+++ b/rosys/automation/parallelize.py
@@ -8,6 +8,8 @@ class parallelize:
     This class allows to combine multiple coroutines into one that can be passed to the
     `automator <https://rosys.io/reference/rosys/automation/#rosys.automation.Automator>`__
     to run them in parallel.
+
+    Note that ``parallelize`` will be uninterruptible if one of its coroutines is marked with ``@rosys.automation.uninterruptible``.
     """
 
     def __init__(self, *coros: Coroutine, return_when_first_completed: bool = False) -> None:


### PR DESCRIPTION
### Motivation

@pascalzauberzeug wondered if we could implement a decorator for marking parts of an automation as uninterruptible so that they keep running until completed when pausing an automation.

### Implementation

With the help of GPT-5 I came up with such a decorator that seems to work nicely:

```py
async def a():
    for i in range(10):
        print(f'a - {i}')
        await asyncio.sleep(0.1)

@rosys.automation.uninterruptible
async def b():
    for i in range(10):
        print(f'b - {i}')
        await asyncio.sleep(0.1)

async def c():
    for i in range(10):
        print(f'c - {i}')
        await asyncio.sleep(0.1)

async def automation():
    await a()
    await b()
    await c()

automator = rosys.automation.Automator(steerer=None, default_automation=automation)
ui.button('start automation', on_click=automator.start)
ui.button('pause automation', on_click=lambda: automator.pause('button clicked'))
ui.button('resume automation', on_click=automator.resume)
ui.button('stop automation', on_click=lambda: automator.stop('button clicked'))
```

While "a" and "c" pause immediately, "b" keeps counting until reaching "c - 0".

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Let decorator add `sleep(0)` after calling the function.
- [x] Find better name? "uninterruptible"? ~~"unstoppable"?~~
- [x] Pytests have been added.
- [x] Documentation has been added.
- [x] Check parallel automations.
