### PR TITLE
Correctly clean up events after tests

### DIFF
--- a/rosys/event.py
+++ b/rosys/event.py
@@ -107,6 +107,8 @@ class Event(Generic[P]):
 def reset() -> None:
     for event in events:
         event.listeners.clear()
+    events.clear()
     for task in tasks:
         task.cancel()
     tasks.clear()
+    startup_coroutines.clear()


### PR DESCRIPTION
### Motivation & Implementation

I had all tests failing when implementing https://github.com/zauberzeug/field_friend/pull/379 and noticed that events are not cleaned up correctly.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
