### PR TITLE
Make logging and video pages customizable

### DIFF
--- a/rosys/analysis/logging_page.py
+++ b/rosys/analysis/logging_page.py
@@ -21,27 +21,30 @@ class LoggingPage:
     """
 
     def __init__(self, group_names: list[str] | None = None) -> None:
-        group_names = group_names or []
+        self.group_names = group_names or []
 
         @ui.page('/logging')
         def page():
-            loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]  # pylint: disable=no-member
-            groups = {name: [l for l in loggers if l.name.startswith(name)] for name in group_names}
-            groups['others'] = [l for l in loggers if not l.name.startswith(tuple(group_names))]
+            self._content()
 
-            @ui.refreshable
-            def _column(group_name: str, loggers: list[logging.Logger]) -> None:
-                with ui.column():
-                    ui.label(group_name).classes('text-xl')
-                    for logger in sorted(loggers, key=lambda logger: logger.name.lower()):
-                        ui.select(LEVELS, label=logger.name, value=logger.getEffectiveLevel(),
-                                  on_change=lambda e, logger=logger: _update_level(logger, e.value)) \
-                            .classes('w-64').props('dense outlined')
+    def _content(self) -> None:
+        loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]  # pylint: disable=no-member
+        groups = {name: [l for l in loggers if l.name.startswith(name)] for name in self.group_names}
+        groups['others'] = [l for l in loggers if not l.name.startswith(tuple(self.group_names))]
 
-            def _update_level(logger: logging.Logger, level: int) -> None:
-                logger.setLevel(level)
-                _column.refresh()
+        @ui.refreshable
+        def _column(group_name: str, loggers: list[logging.Logger]) -> None:
+            with ui.column():
+                ui.label(group_name).classes('text-xl')
+                for logger in sorted(loggers, key=lambda logger: logger.name.lower()):
+                    ui.select(LEVELS, label=logger.name, value=logger.getEffectiveLevel(),
+                              on_change=lambda e, logger=logger: _update_level(logger, e.value)) \
+                        .classes('w-64').props('dense outlined')
 
-            with ui.row():
-                for name, loggers in groups.items():
-                    _column(name, loggers)
+        def _update_level(logger: logging.Logger, level: int) -> None:
+            logger.setLevel(level)
+            _column.refresh()
+
+        with ui.row():
+            for name, loggers in groups.items():
+                _column(name, loggers)

--- a/rosys/analysis/videos_page_.py
+++ b/rosys/analysis/videos_page_.py
@@ -12,47 +12,53 @@ class VideosPage:
     def __init__(self) -> None:
 
         @ui.page('/video/{name:str}')
-        async def video_page(name: str) -> None:
-            ui.video(VIDEO_FILES / name)
+        def video_page(name: str) -> None:
+            self._video_page_content(name)
 
         @ui.page('/videos', title='Videos')
         async def page():
-            @ui.refreshable
-            def video_ui() -> None:
-                with ui.card().props('flat bordered'):
-                    if date.value not in all_videos:
-                        ui.label('No videos for this date')
-                        return
-                    with ui.list().classes('items-center'):
-                        for mp4 in all_videos[date.value]:
-                            video_date, video_duration = format_video_name(mp4)
-                            with ui.item().classes('p-0'):
-                                with ui.item_section().props('avatar'):
-                                    ui.button(icon='download', on_click=lambda mp4=mp4: ui.download(mp4)) \
-                                        .props('flat').tooltip('download')
-                                with ui.item_section().classes('min-w-24'):
-                                    with ui.link(target=f'video/{mp4.name}').classes('no-underline'):
-                                        ui.item_label(video_date)
-                                        ui.item_label(video_duration).props('caption')
-                                with ui.item_section().classes('pl-1'):
-                                    with ui.button(icon='more_vert').props('flat fab-mini'):
-                                        with ui.menu():
-                                            def delete_video(mp4: Path = mp4) -> None:
-                                                mp4.unlink()
-                                                all_videos[date.value].remove(mp4)
-                                                video_ui.refresh()
-                                            with ui.menu_item(on_click=delete_video):
-                                                with ui.item_section().props('side'):
-                                                    ui.icon('delete', color='negative')
-                                                ui.item_section('delete')
+            await self._content()
 
-            ui.label('Timelapse Videos').classes('text-2xl')
-            all_videos = await get_all_videos()
-            today = datetime.now().strftime(r'%Y%m%d')
-            with ui.row(wrap=False).classes('w-full'):
-                date = ui.date(value=today, mask='YYYYMMDD', on_change=video_ui.refresh).props('flat bordered')
-                date.props['options'] = [datetime.strptime(d, r'%Y%m%d').strftime(r'%Y/%m/%d') for d in all_videos]
-                video_ui()
+    async def _content(self) -> None:
+        @ui.refreshable
+        def video_ui() -> None:
+            with ui.card().props('flat bordered'):
+                if date.value not in all_videos:
+                    ui.label('No videos for this date')
+                    return
+                with ui.list().classes('items-center'):
+                    for mp4 in all_videos[date.value]:
+                        video_date, video_duration = format_video_name(mp4)
+                        with ui.item().classes('p-0'):
+                            with ui.item_section().props('avatar'):
+                                ui.button(icon='download', on_click=lambda mp4=mp4: ui.download(mp4)) \
+                                    .props('flat').tooltip('download')
+                            with ui.item_section().classes('min-w-24'):
+                                with ui.link(target=f'video/{mp4.name}').classes('no-underline'):
+                                    ui.item_label(video_date)
+                                    ui.item_label(video_duration).props('caption')
+                            with ui.item_section().classes('pl-1'):
+                                with ui.button(icon='more_vert').props('flat fab-mini'):
+                                    with ui.menu():
+                                        def delete_video(mp4: Path = mp4) -> None:
+                                            mp4.unlink()
+                                            all_videos[date.value].remove(mp4)
+                                            video_ui.refresh()
+                                        with ui.menu_item(on_click=delete_video):
+                                            with ui.item_section().props('side'):
+                                                ui.icon('delete', color='negative')
+                                            ui.item_section('delete')
+
+        ui.label('Timelapse Videos').classes('text-2xl')
+        all_videos = await get_all_videos()
+        today = datetime.now().strftime(r'%Y%m%d')
+        with ui.row(wrap=False).classes('w-full'):
+            date = ui.date(value=today, mask='YYYYMMDD', on_change=video_ui.refresh).props('flat bordered')
+            date.props['options'] = [datetime.strptime(d, r'%Y%m%d').strftime(r'%Y/%m/%d') for d in all_videos]
+            video_ui()
+
+    def _video_page_content(self, name: str) -> None:
+        ui.video(VIDEO_FILES / name)
 
 
 def format_video_name(video: Path) -> tuple[str, str]:


### PR DESCRIPTION
### Motivation & Implementation

As I already did for the KPI page in https://github.com/zauberzeug/rosys/pull/327, I moved the content of the logging and video pages from the page declarator into another function.

This allows giving the pages a custom header for example, like I did in https://github.com/zauberzeug/field_friend/pull/376.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
