### PR TITLE
Make the a persistable

### DIFF
--- a/rosys/driving/__init__.py
+++ b/rosys/driving/__init__.py
@@ -1,5 +1,5 @@
 from .drivable import Drivable
-from .driver import Driver, DrivingAbortedException
+from .driver import DriveParameters, Driver, DrivingAbortedException
 from .driver_object import DriverObject as driver_object
 from .joystick_ import Joystick as joystick
 from .keyboard_control_ import KeyboardControl as keyboard_control
@@ -10,6 +10,7 @@ from .steerer import Steerer
 
 __all__ = [
     'Drivable',
+    'DriveParameters',
     'Driver',
     'DrivingAbortedException',
     'Odometer',

--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -1,18 +1,21 @@
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import Any, Protocol, Self
 
 import numpy as np
+from nicegui import binding, ui
 
 from .. import rosys
 from ..analysis import track
 from ..geometry import Point, Pose, Spline
 from ..helpers import ModificationContext, eliminate_2pi, eliminate_pi, ramp
+from ..persistence import Persistable
 from .drivable import Drivable
 from .odometer import Odometer
 from .path_segment import PathSegment
 
 
-@dataclass(slots=True, kw_only=True)
+# slots=True, kw_only=True
+@binding.bindable_dataclass
 class DriveParameters(ModificationContext):
     linear_speed_limit: float = 0.5
     angular_speed_limit: float = 0.5
@@ -26,6 +29,26 @@ class DriveParameters(ModificationContext):
     minimum_drive_distance: float = 0.01
     throttle_at_end_distance: float = 0.5
     throttle_at_end_min_speed: float = 0.01
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            'linear_speed_limit': self.linear_speed_limit,
+            'angular_speed_limit': self.angular_speed_limit,
+            'minimum_turning_radius': self.minimum_turning_radius,
+            'can_drive_backwards': self.can_drive_backwards,
+            'max_detection_age_ramp': self.max_detection_age_ramp,
+            'hook_offset': self.hook_offset,
+            'carrot_offset': self.carrot_offset,
+            'carrot_distance': self.carrot_distance,
+            'hook_bending_factor': self.hook_bending_factor,
+            'minimum_drive_distance': self.minimum_drive_distance,
+            'throttle_at_end_distance': self.throttle_at_end_distance,
+            'throttle_at_end_min_speed': self.throttle_at_end_min_speed,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        return cls(**data)
 
 
 @dataclass(slots=True, kw_only=True)
@@ -47,7 +70,7 @@ class PoseProvider(Protocol):
         ...
 
 
-class Driver:
+class Driver(Persistable):
     """The driver module allows following a given path.
 
     It requires a wheels module (or any drivable hardware representation) to execute individual drive commands.
@@ -55,10 +78,11 @@ class Driver:
     Its `parameters` allow controlling the specific drive behavior.
     """
 
-    def __init__(self, wheels: Drivable, odometer: Odometer | PoseProvider) -> None:
+    def __init__(self, wheels: Drivable, odometer: Odometer | PoseProvider, *, parameters: DriveParameters | None = None) -> None:
+        super().__init__()
         self.wheels = wheels
         self.odometer = odometer
-        self.parameters = DriveParameters()
+        self.parameters = parameters or DriveParameters()
         self.state: DriveState | None = None
         self._abort = False
 
@@ -250,6 +274,27 @@ class Driver:
         age_ramp = self.parameters.max_detection_age_ramp
         age = rosys.time() - self.odometer.detection.time
         return ramp(age, age_ramp[0], age_ramp[1], 1.0, 0.0, clip=True)
+
+    def backup_to_dict(self) -> dict[str, Any]:
+        return {
+            'parameters': self.parameters.to_dict(),
+        }
+
+    def restore_from_dict(self, data: dict[str, Any]) -> None:
+        self.parameters = DriveParameters.from_dict(data['parameters'])
+
+    def developer_ui(self, *, columns: int = 2) -> None:
+        ui.label('Driver').classes('text-center text-bold')
+        with ui.grid(columns=columns):
+            for name, value in self.parameters.to_dict().items():
+                if isinstance(value, float):
+                    ui.number(name, on_change=self.request_backup).bind_value(self.parameters, name)
+                elif isinstance(value, bool):
+                    ui.checkbox(name, on_change=self.request_backup).bind_value(self.parameters, name)
+                elif name == 'max_detection_age_ramp':
+                    self.log.warning('max_detection_age_ramp is not supported in the UI')
+                else:
+                    self.log.error('Unknown type %s of %s', type(value), name)
 
 
 @dataclass(slots=True, kw_only=True)

--- a/rosys/driving/driver.py
+++ b/rosys/driving/driver.py
@@ -35,7 +35,8 @@ class DriveParameters(ModificationContext):
             'linear_speed_limit': self.linear_speed_limit,
             'angular_speed_limit': self.angular_speed_limit,
             'minimum_turning_radius': self.minimum_turning_radius,
-            'can_drive_backwards': self.can_drive_backwards,
+            # TODO: Backup failed: Object of type bool_ is not JSON serializable from /Users/pascal/.rosys/field_friend.driver.json
+            'can_drive_backwards': bool(self.can_drive_backwards),
             'max_detection_age_ramp': self.max_detection_age_ramp,
             'hook_offset': self.hook_offset,
             'carrot_offset': self.carrot_offset,
@@ -288,9 +289,9 @@ class Driver(Persistable):
         with ui.grid(columns=columns):
             for name, value in self.parameters.to_dict().items():
                 if isinstance(value, float):
-                    ui.number(name, on_change=self.request_backup).bind_value(self.parameters, name)
+                    ui.number(name, value=value, on_change=self.request_backup).bind_value_to(self.parameters, name)
                 elif isinstance(value, bool):
-                    ui.checkbox(name, on_change=self.request_backup).bind_value(self.parameters, name)
+                    ui.checkbox(name, value=value, on_change=self.request_backup).bind_value_to(self.parameters, name)
                 elif name == 'max_detection_age_ramp':
                     self.log.warning('max_detection_age_ramp is not supported in the UI')
                 else:


### PR DESCRIPTION
### Motivation & Implementation

For different sizes of the Field Friend, we need different `DriveParameters`, so I made the `Driver` a `Persitable`.
Additionally, to make it easier to experiment with, I added a developer ui and made `DriveParameters` a `bindable_dataclass`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
    - [ ] Fix bool_ bug
    - [ ] Rework UI
    - [ ] We usually use `dataclass(slots=True, kw_only=True)` is that possible with `bindable_dataclass`
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).



