### PR TITLE
Add image recorder / replay module

### DIFF
--- a/rosys/vision/__init__.py
+++ b/rosys/vision/__init__.py
@@ -13,6 +13,7 @@ from .detector_simulation import DetectorSimulation, SimulatedObject
 from .image import Image, ImageSize
 from .mjpeg_camera import MjpegCamera, MjpegCameraProvider
 from .multi_camera_provider import MultiCameraProvider
+from .record_replay import ImageRecorder, ReplayCamera, ReplayCameraProvider
 from .rtsp_camera import RtspCamera, RtspCameraProvider
 from .simulated_camera import SimulatedCalibratableCamera, SimulatedCamera, SimulatedCameraProvider
 from .spatial_resection import SpatialResection, SpatialResectionResult
@@ -38,6 +39,7 @@ __all__ = [
     'DetectorHardware',
     'DetectorSimulation',
     'Image',
+    'ImageRecorder',
     'ImageSize',
     'Intrinsics',
     'MjpegCamera',
@@ -45,6 +47,8 @@ __all__ = [
     'MultiCameraProvider',
     'PointAnnotation',
     'PointDetection',
+    'ReplayCamera',
+    'ReplayCameraProvider',
     'RtspCamera',
     'RtspCameraProvider',
     'SimulatedCalibratableCamera',

--- a/rosys/vision/record_replay/__init__.py
+++ b/rosys/vision/record_replay/__init__.py
@@ -1,0 +1,9 @@
+from .image_recorder import ImageRecorder
+from .replay_camera import ReplayCamera
+from .replay_camera_provider import ReplayCameraProvider
+
+__all__ = [
+    'ImageRecorder',
+    'ReplayCamera',
+    'ReplayCameraProvider',
+]

--- a/rosys/vision/record_replay/constants.py
+++ b/rosys/vision/record_replay/constants.py
@@ -1,0 +1,1 @@
+TIME_FORMAT = '%Y-%m-%d_%H-%M-%S.%f'

--- a/rosys/vision/record_replay/image_recorder.py
+++ b/rosys/vision/record_replay/image_recorder.py
@@ -21,16 +21,16 @@ class ImageRecorder:
         """
         self.camera_provider = camera_provider
         self.data_dir = data_dir.expanduser()
-        self._record = False
+        self._recording = False
 
     @property
-    def record(self) -> bool:
-        return self._record
+    def recording(self) -> bool:
+        return self._recording
 
-    def set_record(self, value: bool):
+    def set_recording(self, value: bool):
         """Enable or disable recording images from the camera provider."""
-        self._record = value
-        if self._record:
+        self._recording = value
+        if self._recording:
             self.camera_provider.NEW_IMAGE.register(self._save_image)
         else:
             self.camera_provider.NEW_IMAGE.unregister(self._save_image)

--- a/rosys/vision/record_replay/image_recorder.py
+++ b/rosys/vision/record_replay/image_recorder.py
@@ -2,7 +2,8 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-from .. import CameraProvider, Image
+from ..camera_provider import CameraProvider
+from ..image import Image
 
 log = logging.getLogger('rosys.image_recorder')
 

--- a/rosys/vision/record_replay/image_recorder.py
+++ b/rosys/vision/record_replay/image_recorder.py
@@ -6,6 +6,7 @@ import aiofiles
 
 from ..camera_provider import CameraProvider
 from ..image import Image
+from .constants import TIME_FORMAT
 
 log = logging.getLogger('rosys.image_recorder')
 
@@ -50,7 +51,7 @@ class ImageRecorder:
         path = self.data_dir / image.camera_id.replace(':', '-')
         path.mkdir(parents=True, exist_ok=True)
 
-        file_path = path / f'{datetime.fromtimestamp(image.time).strftime("%Y-%m-%d_%H-%M-%S.%f")}.jpg'
+        file_path = path / f'{datetime.fromtimestamp(image.time).strftime(TIME_FORMAT)}.jpg'
 
         async with aiofiles.open(file_path, 'wb') as f:
             await f.write(image.data)

--- a/rosys/vision/record_replay/image_recorder.py
+++ b/rosys/vision/record_replay/image_recorder.py
@@ -2,6 +2,8 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
+import aiofiles
+
 from ..camera_provider import CameraProvider
 from ..image import Image
 
@@ -36,8 +38,8 @@ class ImageRecorder:
     async def _save_image(self, image: Image):
         """Save the provided image to the data directory.
 
-        Images are saved to a subfolder that is named with the camera id,
-        with filenames <yyyy-mm-dd_hh-mm-ss.ffffff>.jpg
+        Images are saved to a subfolder named after the camera ID (with ':' replaced by '-'),
+        using filenames in the format YYYY-MM-DD_HH-MM-SS.ffffff.jpg based on the image timestamp.
 
         :param image: the image to save
         """
@@ -50,6 +52,6 @@ class ImageRecorder:
 
         file_path = path / f'{datetime.fromtimestamp(image.time).strftime("%Y-%m-%d_%H-%M-%S.%f")}.jpg'
 
-        with open(file_path, 'wb') as f:
-            f.write(image.data)
+        async with aiofiles.open(file_path, 'wb') as f:
+            await f.write(image.data)
             log.debug('Saved image from camera %s to %s', image.camera_id, file_path)

--- a/rosys/vision/record_replay/image_recorder.py
+++ b/rosys/vision/record_replay/image_recorder.py
@@ -1,0 +1,54 @@
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from .. import CameraProvider, Image
+
+log = logging.getLogger('rosys.image_recorder')
+
+
+class ImageRecorder:
+    """This module saves images from a CameraProvider to disk."""
+
+    def __init__(self, camera_provider: CameraProvider, data_dir: Path) -> None:
+        """This module saves images from a CameraProvider to disk.
+
+        :param camera_provider: the camera provider to record images from
+        :param data_dir: the directory to save images to. Images are saved in subdirectories
+        """
+        self.camera_provider = camera_provider
+        self.data_dir = data_dir.expanduser()
+        self._record = False
+
+    @property
+    def record(self) -> bool:
+        return self._record
+
+    def set_record(self, value: bool):
+        """Enable or disable recording images from the camera provider."""
+        self._record = value
+        if self._record:
+            self.camera_provider.NEW_IMAGE.register(self._save_image)
+        else:
+            self.camera_provider.NEW_IMAGE.unregister(self._save_image)
+
+    async def _save_image(self, image: Image):
+        """Save the provided image to the data directory.
+
+        Images are saved to a subfolder that is named with the camera id,
+        with filenames <yyyy-mm-dd_hh-mm-ss.ffffff>.jpg
+
+        :param image: the image to save
+        """
+        if not image.data:
+            log.debug('No image data to save')
+            return
+
+        path = self.data_dir / image.camera_id.replace(':', '-')
+        path.mkdir(parents=True, exist_ok=True)
+
+        file_path = path / f'{datetime.fromtimestamp(image.time).strftime("%Y-%m-%d_%H-%M-%S.%f")}.jpg'
+
+        with open(file_path, 'wb') as f:
+            f.write(image.data)
+            log.debug('Saved image from camera %s to %s', image.camera_id, file_path)

--- a/rosys/vision/record_replay/replay_camera.py
+++ b/rosys/vision/record_replay/replay_camera.py
@@ -65,7 +65,12 @@ class ReplayCamera(Camera):
         if not self.image_paths:
             return
 
-        closest_past_index = self._find_closest_past_index(timestamp)
+        if timestamp < self.timestamp_array[0]:
+            closest_past_index = 0
+        elif timestamp > self.timestamp_array[-1]:
+            closest_past_index = len(self.image_paths) - 1
+        else:
+            closest_past_index = self._find_closest_past_index(timestamp)
         if closest_past_index in [self.previous_emitted_index, -1]:
             return  # No new image to emit
 

--- a/rosys/vision/record_replay/replay_camera.py
+++ b/rosys/vision/record_replay/replay_camera.py
@@ -10,6 +10,7 @@ from PIL import Image as PILImage
 
 from ..camera import Camera
 from ..image import Image, ImageSize
+from .constants import TIME_FORMAT
 
 log = logging.getLogger('rosys.replay_camera')
 
@@ -47,7 +48,7 @@ class ReplayCamera(Camera):
                 continue
 
             try:
-                timestamp = datetime.strptime(file.stem, '%Y-%m-%d_%H-%M-%S.%f').timestamp()
+                timestamp = datetime.strptime(file.stem, TIME_FORMAT).timestamp()
             except ValueError:
                 log.warning('Skipping file %s, invalid timestamp', file)
                 continue

--- a/rosys/vision/record_replay/replay_camera.py
+++ b/rosys/vision/record_replay/replay_camera.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 import numpy as np
 from PIL import Image as PILImage
 
-from .. import Camera, Image, ImageSize
+from ..camera import Camera
+from ..image import Image, ImageSize
 
 log = logging.getLogger('rosys.replay_camera')
 

--- a/rosys/vision/record_replay/replay_camera.py
+++ b/rosys/vision/record_replay/replay_camera.py
@@ -1,0 +1,86 @@
+import logging
+from datetime import datetime
+from pathlib import Path
+from uuid import uuid4
+
+import numpy as np
+from PIL import Image as PILImage
+
+from .. import Camera, Image, ImageSize
+
+log = logging.getLogger('rosys.replay_camera')
+
+
+class ReplayCamera(Camera):
+    def __init__(self, *,
+                 camera_id: str,
+                 images_dir: Path,
+                 camera_name: str | None = None,
+                 image_history_length=128) -> None:
+
+        self.images_dir = images_dir
+        self.previous_emitted_timestamp = -1.0
+        self.images_by_timestamp: dict[float, Image] = {}
+        self.timestamp_array = np.array([], dtype=float)
+
+        super().__init__(id=camera_id,
+                         name=camera_name,
+                         connect_after_init=False,
+                         base_path_overwrite=str(uuid4()),
+                         image_history_length=image_history_length)
+
+        self._load_images(images_dir)
+
+    def _load_images(self, images_dir: Path) -> None:
+        """Load images from the specified directory.
+
+        The images should be named with their timestamp using to the format <yyyy-mm-dd_hh-mm-ss.ffffff>.jpg
+        """
+
+        for file in images_dir.iterdir():
+            if file.suffix.lower() not in ['.jpg', '.jpeg', '.png']:
+                continue
+
+            try:
+                timestamp = datetime.strptime(file.stem, '%Y-%m-%d_%H-%M-%S.%f').timestamp()
+            except ValueError:
+                log.warning('Skipping file %s, invalid timestamp', file)
+                continue
+
+            try:
+                with open(file, 'rb') as f:
+                    data = f.read()
+                pil_image = PILImage.open(file)
+                width, height = pil_image.size
+                pil_image.close()
+            except Exception as e:
+                log.warning('Could not read image from file %s: %s', file, e)
+                continue
+
+            self.images_by_timestamp[timestamp] = Image(
+                camera_id=self.id,
+                size=ImageSize(width=width, height=height),
+                time=timestamp,
+                data=data
+            )
+        self.timestamp_array = np.array(list(self.images_by_timestamp.keys()), dtype=float)
+
+    def step_to(self, timestamp: float) -> None:
+        """Step to the image closest to the given timestamp."""
+        if not self.images_by_timestamp:
+            return
+
+        closest_index = (np.abs(self.timestamp_array - timestamp)).argmin()
+        closest_timestamp = self.timestamp_array[closest_index]
+        if closest_timestamp == self.previous_emitted_timestamp:
+            return  # No new image to emit
+
+        self.previous_emitted_timestamp = closest_timestamp
+        image = self.images_by_timestamp[closest_timestamp]
+
+        self._add_image(image)
+
+    @property
+    def is_connected(self) -> bool:
+        """To be interpreted as "ready to capture images"."""
+        return True

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -73,15 +73,16 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
 
     def _set_time_interval(self) -> None:
         for camera in self.cameras.values():
-            if not camera.image_paths_by_filename:
+            if not camera.timestamp_array:
                 continue
 
-            timestamps = sorted(camera.image_paths_by_filename.keys())
+            timestamps = camera.timestamp_array
             self._start_time = min(self._start_time, timestamps[0])
             self._end_time = max(self._end_time, timestamps[-1])
             self._current_time = self._start_time
 
     async def _step(self) -> None:
+        print('step', flush=True)
         self._update_time()
         await self._update_camera_images()
 

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -35,6 +35,7 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
         self._running = False
 
     def play(self) -> None:
+        self._last_update_time = rosys.time()
         self._running = True
 
     def stop(self) -> None:
@@ -54,7 +55,7 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
 
         :param percent: a value between 0.0 and 100.0, where 0.0 is the start and 100.0 is the end
         """
-        assert 0.0 <= percent <= 100.0
+        assert 0.0 <= percent <= 100.0, 'Percent must be between 0.0 and 100.0'
         self._set_replay_time(self._start_time + (percent / 100.0) * (self._end_time - self._start_time))
 
     def _set_replay_time(self, time: float) -> None:

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -56,6 +56,7 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
         :param percent: a value between 0.0 and 100.0, where 0.0 is the start and 100.0 is the end
         """
         assert 0.0 <= percent <= 100.0, 'Percent must be between 0.0 and 100.0'
+        self.clear_camera_images()
         self._set_replay_time(self._start_time + (percent / 100.0) * (self._end_time - self._start_time))
 
     def _set_replay_time(self, time: float) -> None:
@@ -103,6 +104,10 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
             return
         for camera in self.cameras.values():
             await camera.load_image_at_time(self._current_time)
+
+    def clear_camera_images(self) -> None:
+        for camera in self.cameras.values():
+            camera.images.clear()
 
     async def update_device_list(self) -> None:
         pass

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -1,0 +1,84 @@
+import logging
+from pathlib import Path
+
+from ...rosys import Repeater
+from .. import CameraProvider
+from .replay_camera import ReplayCamera
+
+log = logging.getLogger('rosys.replay_camera_provider')
+
+
+class ReplayCameraProvider(CameraProvider[ReplayCamera]):
+    """This module collects and simulates cameras by looping over images in a drive."""
+
+    def __init__(self, replay_folder: Path, replay_interval: float = .01) -> None:
+        super().__init__()
+
+        self._start_time: float = float('inf')
+        self._current_time: float = 0.0
+        self._end_time: float = 0.0
+
+        self._play_backspeed = 1.0
+
+        self._find_cameras(replay_folder)
+        self._set_time_interval()
+        self._repeater = Repeater(self._step, interval=replay_interval)
+        self._repeater.start()
+
+    def pause(self) -> None:
+        self._repeater.stop()
+
+    def play(self) -> None:
+        self._repeater.start()
+
+    def stop(self) -> None:
+        self._repeater.stop()
+        self._current_time = self._start_time
+
+    def set_speed(self, speed: float) -> None:
+        """Set the playback speed.
+
+        1.0 is real-time, 2.0 is double speed, 0.5 is half speed.
+        You may use negative values to play backwards.
+        """
+        self._play_backspeed = speed
+
+    def jump_to(self, percent: float) -> None:
+        """Jump to a specific point in the replay.
+
+        :param percent: a value between 0.0 and 100.0, where 0.0 is the start and 100.0 is the end
+        """
+        assert 0.0 <= percent <= 100.0
+        self._current_time = self._start_time + (percent / 100.0) * (self._end_time - self._start_time)
+
+    def _find_cameras(self, replay_folder: Path) -> None:
+        for file in replay_folder.iterdir():
+            if file.is_dir():
+                camera = ReplayCamera(camera_id=file.name,
+                                      images_dir=file,
+                                      camera_name=file.name,
+                                      image_history_length=128)
+                self.add_camera(camera)
+                self.log.info('Added replay camera "%s" from folder "%s"', file.name, file)
+
+    def _set_time_interval(self) -> None:
+        for camera in self.cameras.values():
+            if not camera.images_by_timestamp:
+                continue
+
+            timestamps = sorted(camera.images_by_timestamp.keys())
+            self._start_time = min(self._start_time, timestamps[0])
+            self._end_time = max(self._end_time, timestamps[-1])
+            self._current_time = self._start_time
+
+    async def _step(self) -> None:
+        if self._current_time > self._end_time:
+            self._current_time = self._start_time
+
+        for camera in self.cameras.values():
+            camera.step_to(self._current_time)
+
+        self._current_time += self._repeater.interval * self._play_backspeed
+
+    async def update_device_list(self) -> None:
+        pass

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -82,7 +82,6 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
             self._current_time = self._start_time
 
     async def _step(self) -> None:
-        print('step', flush=True)
         self._update_time()
         await self._update_camera_images()
 

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -73,7 +73,7 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
 
     def _set_time_interval(self) -> None:
         for camera in self.cameras.values():
-            if not camera.timestamp_array:
+            if not camera.image_paths:
                 continue
 
             timestamps = camera.timestamp_array

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 
 from ...rosys import Repeater
-from .. import CameraProvider
+from ..camera_provider import CameraProvider
 from .replay_camera import ReplayCamera
 
 log = logging.getLogger('rosys.replay_camera_provider')

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -9,7 +9,14 @@ log = logging.getLogger('rosys.replay_camera_provider')
 
 
 class ReplayCameraProvider(CameraProvider[ReplayCamera]):
-    """This module collects and simulates cameras by looping over images in a drive."""
+    """This module collects and simulates cameras by looping over images in a drive.
+
+    NOTE: The first image of each camera will be emitted at any time before the timestamp of the second image.
+    Therefore, setting the time to 0.0 will cause all cameras to emit their first image.
+
+    :param replay_folder: path to the root replay folder containing the camera folders
+    :param replay_interval: the interval at which the provider checks for new images (in seconds)
+    """
 
     def __init__(self, replay_folder: Path, replay_interval: float = .01) -> None:
         super().__init__()

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -18,7 +18,7 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
         self._current_time: float = 0.0
         self._end_time: float = 0.0
 
-        self._play_backspeed = 1.0
+        self._playback_speed = 1.0
 
         self._find_cameras(replay_folder)
         self._set_time_interval()
@@ -41,7 +41,7 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
         1.0 is real-time, 2.0 is double speed, 0.5 is half speed.
         You may use negative values to play backwards.
         """
-        self._play_backspeed = speed
+        self._playback_speed = speed
 
     def jump_to(self, percent: float) -> None:
         """Jump to a specific point in the replay.
@@ -78,7 +78,7 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
         for camera in self.cameras.values():
             camera.step_to(self._current_time)
 
-        self._current_time += self._repeater.interval * self._play_backspeed
+        self._current_time += self._repeater.interval * self._playback_speed
 
     async def update_device_list(self) -> None:
         pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,14 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
 from rosys.testing.fixtures import *  # pylint: disable=wildcard-import,unused-wildcard-import # noqa: F403
+
+
+@pytest.fixture
+def recordings_dir():
+    with tempfile.TemporaryDirectory(prefix='rosys-test-', ignore_cleanup_errors=True, delete=False) as tmp_path:
+        d = Path(tmp_path) / 'recordings'
+        d.mkdir()
+        yield d

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from rosys.testing.fixtures import *  # pylint: disable=wildcard-import,unused-w
 
 @pytest.fixture
 def recordings_dir():
-    with tempfile.TemporaryDirectory(prefix='rosys-test-', ignore_cleanup_errors=True, delete=False) as tmp_path:
+    with tempfile.TemporaryDirectory(prefix='rosys-test-', ignore_cleanup_errors=True) as tmp_path:
         d = Path(tmp_path) / 'recordings'
         d.mkdir()
         yield d

--- a/tests/test_recorder_replay.py
+++ b/tests/test_recorder_replay.py
@@ -55,8 +55,8 @@ async def test_playback_replays_images(recordings_dir: Path):
     assert rp.cameras, 'no cameras detected in replay folder'
 
     # ACT
-    await forward(seconds=1.5)
-    await asyncio.sleep(2.0)
+    await forward(seconds=0.1)
+    await asyncio.sleep(0.1)  # wait is needed to ensure the image is loaded
 
     # ASSERT
     replay_cam = next(iter(rp.cameras.values()))

--- a/tests/test_recorder_replay.py
+++ b/tests/test_recorder_replay.py
@@ -78,6 +78,6 @@ def test_find_closest_past_index_unit(tmp_path: Path):
     idx = cam._find_closest_past_index(2.3)
     assert idx == 1
     idx = cam._find_closest_past_index(0.5)
-    assert idx == 0
+    assert idx == -1
     idx = cam._find_closest_past_index(9.0)
     assert idx == len(times) - 1

--- a/tests/test_recorder_replay.py
+++ b/tests/test_recorder_replay.py
@@ -1,0 +1,83 @@
+import asyncio
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from rosys.testing import forward
+from rosys.vision import SimulatedCamera, SimulatedCameraProvider
+from rosys.vision.record_replay.image_recorder import ImageRecorder
+from rosys.vision.record_replay.replay_camera import ReplayCamera
+from rosys.vision.record_replay.replay_camera_provider import ReplayCameraProvider
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_record_images(recordings_dir: Path):
+    # ARRANGE
+    provider = SimulatedCameraProvider(auto_scan=False)
+    cam = SimulatedCamera(id='cam:0', width=64, height=48, fps=1)
+    provider.add_camera(cam)
+    await cam.connect()
+
+    recorder = ImageRecorder(provider, recordings_dir)
+    recorder.set_recording(True)
+
+    # ACT
+    await forward(seconds=1.1)
+
+    # ASSERT
+    cam_dir = recordings_dir / 'cam-0'
+    assert cam_dir.exists()
+    files = sorted(p for p in cam_dir.iterdir() if p.suffix == '.jpg')
+    assert len(files) == 1
+
+    recorder.set_recording(False)
+    await forward(seconds=2.1)
+    files_after = [p for p in cam_dir.iterdir() if p.suffix == '.jpg']
+    assert len(files_after) == len(files)
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_playback_replays_images(recordings_dir: Path):
+    # ARRANGE
+    provider = SimulatedCameraProvider(auto_scan=False)
+    cam = SimulatedCamera(id='cam:1', width=32, height=24, fps=1)
+    provider.add_camera(cam)
+    await cam.connect()
+    recorder = ImageRecorder(provider, recordings_dir)
+    recorder.set_recording(True)
+    await forward(seconds=5.1)
+    recorder.set_recording(False)
+
+    # ACT
+    rp = ReplayCameraProvider(recordings_dir)
+    # ASSERT
+    assert rp.cameras, 'no cameras detected in replay folder'
+
+    # ACT
+    await forward(seconds=1.5)
+    await asyncio.sleep(2.0)
+
+    # ASSERT
+    replay_cam = next(iter(rp.cameras.values()))
+    assert len(replay_cam.images) == 1
+    assert replay_cam.latest_captured_image is not None
+
+
+def test_find_closest_past_index_unit(tmp_path: Path):
+    # build a minimal ReplayCamera with fake files and timestamps
+    img_dir = tmp_path / 'camA'
+    img_dir.mkdir()
+    # create timestamped dummy files
+    times = [1.0, 2.0, 2.5, 5.0]
+    for t in times:
+        p = img_dir / f"{datetime.fromtimestamp(t).strftime('%Y-%m-%d_%H-%M-%S.%f')}.jpg"
+        p.write_bytes(b'jpg')
+
+    cam = ReplayCamera(camera_id='camA', images_dir=img_dir, camera_name='camA')
+    idx = cam._find_closest_past_index(2.3)
+    assert idx == 1
+    idx = cam._find_closest_past_index(0.5)
+    assert idx == 0
+    idx = cam._find_closest_past_index(9.0)
+    assert idx == len(times) - 1


### PR DESCRIPTION
### Motivation

We needed a lightweight solution to record image data and play them back for development purpose. 

### Implementation

Adds `ImageRecorder` that saves all incoming images for one camera provider.
Adds `ReplayCameraProvider` that acts as a camera provider but emits the previously recorded images.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

