### PR TITLE
Migrate to NiceGUI 3.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2157,14 +2157,14 @@ test = ["codecov (>=2.1)", "pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
 name = "nicegui"
-version = "2.16.1"
+version = "3.0.3"
 description = "Create web-based user interfaces with Python. The nice way."
 optional = false
-python-versions = "<4.0,>=3.8"
+python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "nicegui-2.16.1-py3-none-any.whl", hash = "sha256:5898a8b0a30b6ea32f446dd055c8baa99f3cb8d7e33d60cf0b7568b6ae6d985a"},
-    {file = "nicegui-2.16.1.tar.gz", hash = "sha256:81cf4c4880edcd721a538a71ee5f5f4841d5e14bfc293fad4763489de296c11e"},
+    {file = "nicegui-3.0.3-py3-none-any.whl", hash = "sha256:f40c37866cedf91d75e8bdfc2730348a007dec69baf8080dfadc0ab3381ab2ab"},
+    {file = "nicegui-3.0.3.tar.gz", hash = "sha256:01ac5e29c7f9b8ef9661d684f2172ff0005fc501004fadb04343e1fb7c9c8891"},
 ]
 
 [package.dependencies]
@@ -2184,13 +2184,10 @@ Pygments = ">=2.15.1,<3.0.0"
 python-engineio = ">=4.12.0"
 python-multipart = ">=0.0.18"
 python-socketio = {version = ">=5.10.0", extras = ["asyncio-client"]}
-requests = ">=2.32.0"
-starlette = {version = ">=0.45.3", markers = "python_version >= \"3.9\""}
+starlette = ">=0.45.3"
 typing-extensions = ">=4.0.0"
-urllib3 = ">=1.26.18,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.0.2 || >2.0.2,<2.0.3 || >2.0.3,<2.0.4 || >2.0.4,<2.0.5 || >2.0.5,<2.0.6 || >2.0.6,<2.0.7 || >2.0.7,<2.1.0 || >2.1.0,<2.2.0 || >2.2.0,<2.2.1 || >2.2.1"
 uvicorn = {version = ">=0.22.0", extras = ["standard"]}
 vbuild = ">=0.8.2"
-wait_for2 = ">=0.3.2"
 watchfiles = ">=0.18.1"
 
 [package.extras]
@@ -3702,17 +3699,6 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "s
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8) ; platform_python_implementation == \"PyPy\" or platform_python_implementation == \"GraalVM\" or platform_python_implementation == \"CPython\" and sys_platform == \"win32\" and python_version >= \"3.13\"", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10) ; platform_python_implementation == \"CPython\""]
 
 [[package]]
-name = "wait-for2"
-version = "0.3.2"
-description = "Asyncio wait_for that can handle simultaneous cancellation and future completion."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "wait_for2-0.3.2.tar.gz", hash = "sha256:93863026dc35f3471104ecf7de1f4a0b31f4c8b12a2241c0d6ee26dcc0c2092a"},
-]
-
-[[package]]
 name = "watchdog"
 version = "6.0.0"
 description = "Filesystem events monitoring"
@@ -4156,4 +4142,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <3.14"
-content-hash = "92d2dbf566c5fe9c75b54778b8a6dacb1e0289204594de6dd0b50529643625b6"
+content-hash = "f7a1a940b409a0b58ac994fd9113f14539653b7171e7cc29cba51ebcc862a7ab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = ["robot", "framework", "automation", "control", "steer"]
 
 [tool.poetry.dependencies]
 python = ">=3.11, <3.14"
-nicegui = ">=2.0.0"
+nicegui = "^3.0.3"
 pyserial = "^3.5"
 numpy = ">=1.20.1,<2.0.0" # required by opencv-python < 4.9.0
 scipy = "^1.7.2"

--- a/rosys/analysis/legacy/objgraph_page.py
+++ b/rosys/analysis/legacy/objgraph_page.py
@@ -43,8 +43,8 @@ def objgraph_page() -> None:
 
         class_search = ui.input('Search Class', value='Client')
         ui.button('Update Graph', on_click=update_graph)
-        class_search_result = ui.html()
-        most_common_search_result = ui.html()
+        class_search_result = ui.html(sanitize=False)
+        most_common_search_result = ui.html(sanitize=False)
 
 
 @run.awaitable

--- a/rosys/driving/driver_object.py
+++ b/rosys/driving/driver_object.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from nicegui import ui
-from nicegui.elements.scene_objects import Group, Sphere
+from nicegui.elements.scene.scene_objects import Group, Sphere
 
 from ..rosys import config
 from .driver import Driver

--- a/rosys/driving/robot_object_.py
+++ b/rosys/driving/robot_object_.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from nicegui import ui
-from nicegui.elements.scene_objects import Extrusion, Group, Stl
+from nicegui.elements.scene.scene_objects import Extrusion, Group, Stl
 
 from ..geometry import Prism
 from ..rosys import config

--- a/rosys/event.py
+++ b/rosys/event.py
@@ -48,15 +48,15 @@ class Event(Generic[P]):
     def register_ui(self, callback: Callable[P, Any]) -> Event[P]:
         self.register(callback)
         client = context.client
-        if not client.shared:
-            async def register_disconnect():
-                try:
-                    await client.connected(timeout=10.0)
-                    client.on_disconnect(lambda: self.unregister(callback))
-                except TimeoutError:
-                    log.warning('could not register disconnect for callback=%s', callback)
-                    self.unregister(callback)
-            background_tasks.create(register_disconnect())
+
+        async def register_disconnect():
+            try:
+                await client.connected(timeout=10.0)
+                client.on_delete(lambda: self.unregister(callback))
+            except TimeoutError:
+                log.warning('could not register disconnect for callback=%s', callback)
+                self.unregister(callback)
+        background_tasks.create(register_disconnect())
         return self
 
     def unregister(self, callback: Callable[P, Any]) -> None:

--- a/rosys/pathplanning/area_object_.py
+++ b/rosys/pathplanning/area_object_.py
@@ -1,4 +1,4 @@
-from nicegui.elements.scene_objects import Group, Object3D
+from nicegui.elements.scene.scene_objects import Group, Object3D
 
 from .area import Area
 from .area_manipulation import AreaManipulation, AreaManipulationMode

--- a/rosys/pathplanning/obstacle_object_.py
+++ b/rosys/pathplanning/obstacle_object_.py
@@ -1,6 +1,6 @@
 from contextlib import nullcontext
 
-from nicegui.elements.scene_objects import Extrusion, Group
+from nicegui.elements.scene.scene_objects import Extrusion, Group
 
 from .obstacle import Obstacle
 from .path_planner import PathPlanner

--- a/rosys/pathplanning/path_object_.py
+++ b/rosys/pathplanning/path_object_.py
@@ -1,7 +1,7 @@
 from contextlib import nullcontext
 
-from nicegui.elements.scene_object3d import Object3D
-from nicegui.elements.scene_objects import Curve
+from nicegui.elements.scene.scene_object3d import Object3D
+from nicegui.elements.scene.scene_objects import Curve
 
 from ..driving import PathSegment
 

--- a/rosys/persistence/import_export.py
+++ b/rosys/persistence/import_export.py
@@ -46,7 +46,7 @@ def import_button(title: str = 'Import', *,
                   color: str | None = 'primary',
                   on_completion: Callable | None = None) -> ui.button:
     async def restore_from_file(e: events.UploadEventArguments) -> None:
-        import_all(json.load(e.content))
+        import_all(await e.file.json())
         dialog.close()
         if on_completion is not None:
             await helpers.invoke(on_completion)

--- a/rosys/vision/camera_objects_.py
+++ b/rosys/vision/camera_objects_.py
@@ -1,7 +1,7 @@
 import numpy as np
 from nicegui import ui
-from nicegui.elements.scene_object3d import Object3D
-from nicegui.elements.scene_objects import Cylinder, Group, Text, Texture
+from nicegui.elements.scene.scene_object3d import Object3D
+from nicegui.elements.scene.scene_objects import Cylinder, Group, Text, Texture
 
 from .. import run
 from .calibratable_camera_provider import CalibratableCameraProvider


### PR DESCRIPTION
### Motivation

Now that NiceGUI 3.0 is out, we should make sure RoSys is compatible.

### Implementation

- Upgrade NiceGUI dependency to ^3.0.0.
- Add `sanitize=false` to `ui.html`.
- Fix imports for `ui.scene`.
- Remove the condition on `client.shared`.
- Use `on_delete` instead of `on_disconnect`.
- Adjust to new upload event arguments.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
    - [ ] Should we use a sanitizer for `ui.html` on the object graph page?
    - [ ] Should we remove or at least deprecate RoSys events in favor of NiceGUI's `Event`?
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
