### PR TITLE
add UI to the replay camera provider

### DIFF
--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -73,7 +73,7 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
             new_time = min(self._current_time + skip_time, self._end_time)
             self.jump_to_time(new_time)
 
-        with ui.row().classes('w-full items-center'):
+        with ui.row().classes('w-full items-center gap-2'):
             ui.button(on_click=_skip_back, icon='sym_o_replay') \
                 .props('dense color="secondary" size="md"') \
                 .tooltip(f'<- {skip_time}s')
@@ -86,7 +86,7 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
             ui.slider(min=0.25, max=4, step=0.25, on_change=lambda e: self.set_speed(e.value)) \
                 .bind_value_from(self, '_playback_speed') \
                 .props('label snap') \
-                .classes('w-32')
+                .classes('w-32 ml-4')
         s = ui.slider(min=self._start_time,
                       max=self._end_time,
                       value=self._current_time) \

--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -75,13 +75,13 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
 
         with ui.row().classes('w-full items-center gap-2'):
             ui.button(on_click=_skip_back, icon='sym_o_replay') \
-                .props('dense color="secondary" size="md"') \
+                .props('dense size="md"') \
                 .tooltip(f'<- {skip_time}s')
             ui.button(on_click=self.toggle_running, icon='play_arrow') \
                 .bind_icon_from(self, '_running', backward=lambda p: 'pause' if p else 'play_arrow') \
-                .props('dense color="secondary" size="md"')
+                .props('dense size="md"')
             ui.button(on_click=_skip_forward, icon='sym_o_forward_media') \
-                .props('dense color="secondary" size="md"') \
+                .props('dense size="md"') \
                 .tooltip(f'-> {skip_time}s')
             ui.slider(min=0.25, max=4, step=0.25, on_change=lambda e: self.set_speed(e.value)) \
                 .bind_value_from(self, '_playback_speed') \


### PR DESCRIPTION
### Motivation

To use the `ReplayCameraProvider` we needed a UI to jump to different times. To implement this we needed access to the privat properties of the class, so adding a function that creates a custom UI was the easiest solution. 

### Implementation

The UI now includes buttons to skip back and forth, a play/pause button, a slider to set the playback speed and a slider to jump to a time in between the start and end time. For this slider we needed to bind the `_current_time` and use the `on('change', ...)` event to detect when the user changes the slider value.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
