### PR TITLE
Detector tweaks

### DIFF
--- a/rosys/vision/detector_hardware.py
+++ b/rosys/vision/detector_hardware.py
@@ -48,16 +48,10 @@ class DetectorHardware(Detector):
         self.auto_disconnect = auto_disconnect
         self.timeout_count = 0
 
-        self.sio.on('disconnect', self.on_sio_disconnect)
-        self.sio.on('connect_error', self.on_sio_connect_error)
+        self.sio.on('disconnect', lambda: self.log.warning('sio disconnect on port %s', self.port))
+        self.sio.on('connect_error', lambda err: self.log.warning('sio connect error on %s: %s', self.port, err))
 
         rosys.on_repeat(self._ensure_connection, 10.0)
-
-    def on_sio_disconnect(self) -> None:
-        self.log.warning('sio disconnect on port %s', self.port)
-
-    def on_sio_connect_error(self, err) -> None:
-        self.log.warning('sio connect error on %s: %s', self.port, err)
 
     @property
     def is_connected(self) -> bool:


### PR DESCRIPTION
### Motivation

In some projects we found the lazy worker to be problematic and prefer to implement the lazyness in the application code.

There was also a reconnection bug where the rosys-detector module tries to reconnect while the detector still thinks the connection is established. Problem occured when `auto_disconnect` is False and the detector container is stopped and restarted while the rosys container keeps running. This seems to be solved by explicitly calling disconnect before reconnecting. 

### Implementation

- make use of lazy worker optional
- enforce disconnect call  after failed connection attempt 
