### PR TITLE
Connect DetectorHardware on startup

### DIFF
--- a/rosys/vision/detector_hardware.py
+++ b/rosys/vision/detector_hardware.py
@@ -51,6 +51,7 @@ class DetectorHardware(Detector):
         self.sio.on('disconnect', lambda: self.log.warning('sio disconnect on port %s', self.port))
         self.sio.on('connect_error', lambda err: self.log.warning('sio connect error on %s: %s', self.port, err))
 
+        rosys.on_startup(self.connect)
         rosys.on_repeat(self._ensure_connection, 10.0)
 
     @property


### PR DESCRIPTION
Fixes #349

### Motivation
As stated in #349 there is no reason to wait 10s before the repeated _ensure_connection kicks in.

### Implementation
I went with @NiklasNeugebauer 's suggestion of `connect` via `on_startup` for now since this also results in factually correct log messages (about connecting, rather than reconnecting).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
