### PR TITLE
Introduce `Automator.abort`

### DIFF
--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -194,8 +194,8 @@ class Automator:
         """
         self.default_automation = default_automation
 
-    def _handle_exception(self, _: Exception) -> None:
-        self.abort(because='an exception occurred in an automation')
+    def _handle_exception(self, e: Exception) -> None:
+        self.abort(because=f'an exception occurred in an automation{f": {e}" if str(e) else ""}')
         if rosys.is_test:
             self.log.exception('automation failed')
 

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -132,7 +132,7 @@ async def test_parallelize_exception(automator: Automator):
         for i in range(5):
             print(f'slow {i}')
             if i == 3:
-                raise ValueError()
+                raise ValueError('i is 3')
             await rosys.sleep(0.5)
 
     async def fast():
@@ -145,7 +145,7 @@ async def test_parallelize_exception(automator: Automator):
 
     automator.start(run())
     await forward(seconds=10)
-    assert failures == ['an exception occurred in an automation']
+    assert failures == ['an exception occurred in an automation: i is 3']
 
 
 @pytest.mark.parametrize('method', ['pause', 'stop'])


### PR DESCRIPTION
### Motivation

I need to let an automation fail from the outside and also emit `AUTOMATION_FAILED`. Before you could only do that by emiting the event yourself or by raising an exception that is handled by `Automator._handle_exception`.

That's why this PR introduces `Automator.abort()`

### Implementation

- Implement `Automator.abort`
- Base `Automator._handle_exception` on `Automator.abort`
- Fix test with new error message
- Rework docstrings

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
