### PR TITLE
Remove second subscription to `NEW_IMAGE` event

### DIFF
--- a/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
@@ -39,8 +39,6 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera]):
             self.log.debug('restoring camera: %s', camera_data)
             camera = MjpegCamera.from_dict(camera_data)
             self.add_camera(camera)
-        for camera in self._cameras.values():
-            camera.NEW_IMAGE.subscribe(self.NEW_IMAGE.emit)
 
     async def scan_for_cameras(self) -> list[tuple[str, str]]:
         self.log.debug('scanning for cameras...')

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -40,8 +40,6 @@ class RtspCameraProvider(CameraProvider[RtspCamera]):
         for camera_data in data.get('cameras', {}).values():
             camera = RtspCamera.from_dict(camera_data)
             self.add_camera(camera)
-        for camera in self._cameras.values():
-            camera.NEW_IMAGE.subscribe(self.NEW_IMAGE.emit)
 
     @staticmethod
     async def scan_for_cameras(network_interface: str | None = None) -> list[tuple[str, str]]:

--- a/rosys/vision/simulated_camera/simulated_camera_provider.py
+++ b/rosys/vision/simulated_camera/simulated_camera_provider.py
@@ -35,9 +35,6 @@ class SimulatedCameraProvider(CameraProvider[SimulatedCamera]):
             camera = SimulatedCamera.from_dict(camera_data)
             self.add_camera(camera)
 
-        for camera in self._cameras.values():
-            camera.NEW_IMAGE.subscribe(self.NEW_IMAGE.emit)
-
     async def scan_for_cameras(self) -> AsyncGenerator[str, Any]:
         """Simulated device discovery by returning all camera's IDs.
 


### PR DESCRIPTION
### Motivation

Some camera providers (MJPG, USB, Replay) subscribe twice to the NEW_IMAGE events of the cameras. This results in every image being emmited twice. 

### Implementation

Remove second subscription