### PR TITLE
Integrate Lizard's Bluetooth PIN feature

### DIFF
--- a/rosys/automation/app_controls_.py
+++ b/rosys/automation/app_controls_.py
@@ -46,7 +46,6 @@ class AppControls:
 
         self.log = logging.getLogger('rosys.app_controls')
 
-        self.robot_brain = robot_brain
         self.automator = automator
         self.bluetooth = bluetooth
 


### PR DESCRIPTION
### Motivation

[Lizard 0.8.0](https://github.com/zauberzeug/lizard/releases/tag/v0.8.0) introduced pin validation to the Bluetooth module in https://github.com/zauberzeug/lizard/pull/154.
This PR makes it configurable in RoSys.

### Implementation

1. Implement new Bluetooth pin feature
2. Make Bluetooth functionality available as public methods of `BluetoothHardware`
3. Let `AppControls` use the newly added methods. ⚠️ This creates a breaking change, because `AppControls` now expects `BluetoothHardware` as its third argument.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
