### PR TITLE
Add `BUMPER_RELEASED` event

### DIFF
--- a/rosys/hardware/bumper.py
+++ b/rosys/hardware/bumper.py
@@ -50,16 +50,16 @@ class BumperHardware(Bumper, ModuleHardware):
                          estop=estop)
 
     def handle_core_output(self, time: float, words: list[str]) -> None:
-        bumpers: dict[str, bool] = {pin: words.pop(0) == 'true' for pin in self.pins}
-        for pin, active in bumpers.items():
+        states: dict[str, bool] = {name: words.pop(0) == 'true' for name in self.pins}
+        for name, active in states.items():
             if self.estop and self.estop.active:
                 continue
-            was_active = pin in self.active_bumpers
+            was_active = name in self.active_bumpers
             if active and not was_active:
-                self.BUMPER_TRIGGERED.emit(pin)
+                self.BUMPER_TRIGGERED.emit(name)
             elif not active and was_active:
-                self.BUMPER_RELEASED.emit(pin)
-        self.active_bumpers[:] = [pin for pin, active in bumpers.items() if active]
+                self.BUMPER_RELEASED.emit(name)
+        self.active_bumpers[:] = [name for name, active in states.items() if active]
 
 
 class BumperSimulation(Bumper, ModuleSimulation):


### PR DESCRIPTION
### Motivation & Implementation

The `Bumper` module was missing an `BUMPER_RELEASED` event like the `EStop` module [has](https://github.com/zauberzeug/rosys/blob/34eb55d8928e5a7571ce35c16ddc9ec467f8de4b/rosys/hardware/estop.py#L23).

Now, when a `Bumper` was active before and is not anymore the event will be emitted.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Hardware test
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
