### PR TITLE
Add `STATE_UPDATED` event to BMS

### DIFF
--- a/rosys/hardware/bms.py
+++ b/rosys/hardware/bms.py
@@ -23,8 +23,8 @@ class Bms(Module, abc.ABC):
         :param battery_low_threshold: If provided, the BATTERY_LOW event will be emitted when the battery percentage gets below this threshold.
         """
         super().__init__(**kwargs)
-        self.NEW_STATE = Event[BmsState]()
-        """a new state has been received (argument: ``BmsState``)"""
+        self.STATE_UPDATED = Event[BmsState]()
+        """The BMS state has been updated with new data (argument: ``BmsState``)"""
         self.CHARGING_STARTED = Event[[]]()
         """The battery started charging"""
         self.CHARGING_STOPPED = Event[[]]()
@@ -136,7 +136,7 @@ class BmsHardware(Bms, ModuleHardware):
         self.state.is_charging = is_charging
         self.state.last_update = rosys.time()
         self.raw_data = result
-        self.NEW_STATE.emit(self.state)
+        self.STATE_UPDATED.emit(self.state)
 
 
 class BmsSimulation(Bms, ModuleSimulation):
@@ -173,7 +173,7 @@ class BmsSimulation(Bms, ModuleSimulation):
         self.state.temperature = self.AVERAGE_TEMPERATURE + \
             self.TEMPERATURE_AMPLITUDE * np.sin(self.TEMPERATURE_FREQUENCY * rosys.time())
         self.state.last_update = rosys.time()
-        self.NEW_STATE.emit(self.state)
+        self.STATE_UPDATED.emit(self.state)
 
     def developer_ui(self) -> None:
         super().developer_ui()


### PR DESCRIPTION
### Motivation & Implementation

In our [ROS project](https://github.com/zauberzeug/feldfreund_devkit_ros) I want to relay hardware measurements to ROS.
Modules like the [Odometer](https://github.com/zauberzeug/rosys/blob/34eb55d8928e5a7571ce35c16ddc9ec467f8de4b/rosys/driving/odometer.py#L28) and [GNSS](https://github.com/zauberzeug/rosys/blob/34eb55d8928e5a7571ce35c16ddc9ec467f8de4b/rosys/hardware/gnss/gnss.py#L51) already provide events for this.

That's why this PR introduces `BMS.STATE_UPDATED`
I wasn't quite sure with the naming but took inspiration from the Odometer.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
