### PR TITLE
Fix Bumper and EStop event emit order and add arguments to EStop events

### DIFF
--- a/rosys/hardware/bumper.py
+++ b/rosys/hardware/bumper.py
@@ -51,16 +51,16 @@ class BumperHardware(Bumper, ModuleHardware):
 
     def handle_core_output(self, time: float, words: list[str]) -> None:
         previous_active_bumpers = self.active_bumpers.copy()
-        states: dict[str, bool] = {name: words.pop(0) == 'true' for name in self.pins}
         self.active_bumpers.clear()
-        self.active_bumpers.update(name for name, active in states.items() if active)
+        self.active_bumpers.update(name for name in self.pins if words.pop(0) == 'true')
         if self.estop and self.estop.active:
             return
-        for name, active in states.items():
+        for name in self.pins:
+            is_active = name in self.active_bumpers
             was_active = name in previous_active_bumpers
-            if active and not was_active:
+            if is_active and not was_active:
                 self.BUMPER_TRIGGERED.emit(name)
-            elif not active and was_active:
+            elif not is_active and was_active:
                 self.BUMPER_RELEASED.emit(name)
 
 

--- a/rosys/hardware/estop.py
+++ b/rosys/hardware/estop.py
@@ -66,14 +66,14 @@ class EStopHardware(EStop, ModuleHardware):
 
     def handle_core_output(self, time: float, words: list[str]) -> None:
         previous_active_estops = self.active_estops.copy()
-        states = {name: words.pop(0) == 'true' for name in self.pins}
         self.active_estops.clear()
-        self.active_estops.update(name for name, active in states.items() if active)
-        for name, active in states.items():
+        self.active_estops.update(name for name in self.pins if words.pop(0) == 'true')
+        for name in self.pins:
+            is_active = name in self.active_estops
             was_active = name in previous_active_estops
-            if active and not was_active:
+            if is_active and not was_active:
                 self.ESTOP_TRIGGERED.emit(name)
-            elif not active and was_active:
+            elif not is_active and was_active:
                 self.ESTOP_RELEASED.emit(name)
 
 


### PR DESCRIPTION
### Motivation

I noticed that the events of `Bumper` and `EStop` were fired before the new values were written, which led to wrong values in my user code. Especially since the `EStop` events have no argument.

### Implementation

1. Write values before emitting events
2. Add the EStop's name as an argument for `ESTOP_TRIGGERED` and `ESTOP_RELEASED`
3. The software EStop is now handled exactly like the other EStops, but I kept the `is_soft_estop_active` property

⚠️ The order could change event handling in your user code
⚠️ Your event handling functions could fail, because the events will now provide an argument
⚠️ `EStop.pressed_estops: list[int]` was renamed and retyped to `EStop.active_estops: set[str]`
⚠️ `Bumper.active_bumpers: list[str]` retyped to `Bumper.active_bumpers: set[str]`

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
