### PR TITLE
Fix last EStop rework

### DIFF
--- a/rosys/hardware/estop.py
+++ b/rosys/hardware/estop.py
@@ -66,7 +66,7 @@ class EStopHardware(EStop, ModuleHardware):
 
     def handle_core_output(self, time: float, words: list[str]) -> None:
         previous_active_estops = self.active_estops.copy()
-        self.active_estops.clear()
+        self.active_estops.difference_update(self.pins)
         self.active_estops.update(name for name in self.pins if words.pop(0) == 'true')
         for name in self.pins:
             is_active = name in self.active_estops


### PR DESCRIPTION
### Motivation & Implementation

In the last PR https://github.com/zauberzeug/rosys/pull/372, we used `Set.clear()` but missed that 'soft' from the software estop will also be removed, breaking the whole feature. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
