### PR TITLE
remove explicit async task creation in `Camera.__init__`

### DIFF
--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -51,15 +51,8 @@ class Camera(abc.ABC):
 
         create_image_route(self)
 
-        self._connect_tasks = set()
-
         if connect_after_init:
-            if asyncio.get_event_loop().is_running():
-                task = asyncio.create_task(self.connect())
-                self._connect_tasks.add(task)
-                task.add_done_callback(self._connect_tasks.discard)
-            else:
-                rosys.on_startup(self.connect)
+            rosys.on_startup(self.connect)
 
     @property
     def streaming(self) -> bool:


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->
Currently, we get the warning "there is no current event loop" when a camera is created before the event loop is created. Critically, this also means that cameras are not automatically connected if they are created before startup, even if their parameter `connect_after_init` is `True`. 
See issue https://github.com/zauberzeug/rosys/issues/368

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->
The if case was removed where we try to determine if startup has happened. It is obsolete since `rosys.on_startup` does this itself and behaves accordingly. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
