### PR TITLE
Lower RtspDevice childprocess pipe size limit to default

### DIFF
--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -119,7 +119,6 @@ class RtspDevice:
                 *shlex.split(command),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                limit=1024*1024*1024,
             )
             assert process.stdout is not None
             assert process.stderr is not None


### PR DESCRIPTION
### Motivation
The only effect of the larger limit is visibile in situations where we cannot keep up with the frames from there camera.
Then we fail to apply backpressure, leading to the gstreamer process stuffing the process pipe with old images. This is undesirable because 1) we want newer images and 2) this eats up memory.
Notably, readexact on the stream (which we use) buffers beyond the limit to fulfill our request anyway.

### Implementation

We remove the argument to apply the default (64KB).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
