### PR TITLE
Fix vendor_to_url mapping in rtsp camera

### DIFF
--- a/rosys/vision/rtsp_camera/vendors.py
+++ b/rosys/vision/rtsp_camera/vendors.py
@@ -27,6 +27,7 @@ mac_prefix_to_vendor: dict[str, VendorType] = {
 
 
 def _vendor_to_url(vendor_type: VendorType, ip: str, substream: int) -> str | None:
+    # pylint: disable=too-many-return-statements
     match vendor_type:
         case VendorType.JOVISION:
             return f'rtsp://admin:admin@{ip}/profile{substream}'


### PR DESCRIPTION
### Motivation

#376 broke the vendor-to-url mapping for device types with more complex f-string expressions since `.format()` (apparently) cannot handle those, resulting in: `KeyError: '"sub" if substream else "main"'`

### Implementation

Use a function with match instead of a dict.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
