### PR TITLE
Fix Lizard code generation for Bluetooth module

### DIFF
--- a/rosys/hardware/bluetooth.py
+++ b/rosys/hardware/bluetooth.py
@@ -18,7 +18,7 @@ class BluetoothHardware(ModuleHardware):
         self.name = name
         lizard_code = f'bluetooth = Bluetooth("{name}")'
         if pin_code != 'default':
-            lizard_code += self._create_pin_command(pin_code)
+            lizard_code += f'\n{self._create_pin_command(pin_code)}'
         super().__init__(robot_brain, lizard_code=lizard_code)
 
     async def send(self, message: str) -> None:


### PR DESCRIPTION
### Motivation & Implementation

When using the pin_code argument, the corresponding Lizard code was generated without a newline, which leads to an error without a semicolon.
Before:
```python
bluetooth = Bluetooth("example-name")bluetooth.deactivate_pin()
```

With this PR:
```python
bluetooth = Bluetooth("example-name")
bluetooth.deactivate_pin()
```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
