### PR TITLE
Add guide to install missing cairo library to troubleshooting

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,9 +17,9 @@ The example above is one of the more frequent scenarios.
 It means some code inside a user interaction event handler (e.g. `handle_event()` in `justpy.py`) is blocking.
 Try to figure out which UI event code is responsible by commenting out parts of your logic and try to reproduce the warning systematically.
 
-### macOS Cairo Library Issues
+## macOS Cairo Library Issues
 
-Install system dependencies using Homebrew (Cairo is a 2D graphics library with support for multiple output devices):
+RoSys depends on the 2D graphics library [Cairo](https://cairographics.org/) which needs to be installed via brew on macOS.
 
 ```bash
 brew install cairo pkg-config


### PR DESCRIPTION
### Motivation & Implementation

RoSys depends on Cairo which needs to be installed via brew on macOS. This PR adds a tutorial to the troubleshooting section of the documentation.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).