### PR TITLE
Adapt espresso parameter handling to the new espresso API

### DIFF
--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -269,8 +269,7 @@ class RobotBrain:
         async with self._esp_lock:
             self._hardware_time = None
             rosys.notify('Enabling ESP...')
-            command = ['sudo', './espresso.py', 'enable',
-                       *self._convert_flash_params(self.lizard_firmware.flash_params)]
+            command = ['sudo', './espresso.py', 'enable', *self.lizard_firmware.flash_params]
             self.log.debug('enable: %s', command)
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             if 'Finished.' in output:
@@ -286,8 +285,7 @@ class RobotBrain:
         async with self._esp_lock:
             self._hardware_time = None
             rosys.notify('Disabling ESP...')
-            command = ['sudo', './espresso.py', 'disable', *
-                       self._convert_flash_params(self.lizard_firmware.flash_params)]
+            command = ['sudo', './espresso.py', 'disable', *self.lizard_firmware.flash_params]
             self.log.debug('disable: %s', command)
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             if 'Finished.' in output:
@@ -319,7 +317,7 @@ class RobotBrain:
         async with self._esp_lock:
             self._hardware_time = None
             rosys.notify('Resetting ESP...')
-            command = ['sudo', './espresso.py', 'reset', *self._convert_flash_params(self.lizard_firmware.flash_params)]
+            command = ['sudo', './espresso.py', 'reset', *self.lizard_firmware.flash_params]
             self.log.debug('reset: %s', command)
             output = await rosys.run.sh(command, timeout=None, working_dir=self.lizard_firmware.PATH)
             if 'Finished.' in output:
@@ -328,17 +326,6 @@ class RobotBrain:
             else:
                 self.log.error(output)
                 rosys.notify('Resetting ESP: failed', 'negative')
-
-    def _convert_flash_params(self, flash_params: list[str]) -> list[str]:
-        """Until the deprecation of the flash.py script, we need to convert the flash_params to espresso parameters."""
-        espresso_parameters = []
-        self.log.debug('flash_params: %s', flash_params)
-        if 'nand' in flash_params:
-            espresso_parameters.append('--nand')
-        if 'swap' in flash_params:
-            espresso_parameters.append('--swap')
-        self.log.debug('espresso_parameters: %s', espresso_parameters)
-        return espresso_parameters
 
     def __del__(self) -> None:
         self.communication.disconnect()


### PR DESCRIPTION
### Motivation
With the switch to Jetpack 6, we had to make some changes to the `espresso.py` script in Lizard. We took this opportunity to simplify the flash parameters.
https://github.com/zauberzeug/lizard/pull/187

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation
With the new `espresso.py` version, we autodetect the Jetson and the JetPack version. We also renamed the `--swap` parameter.
<!-- What is the concept behind the implementation? How does it work? -->
<!-- Include any important technical decisions or trade-offs made -->
### Breaking ⛔️
This change to the `flash_params` relies on the new `espresso.py` version. This will be shipped in Lizard 0.10.0. https://github.com/zauberzeug/lizard/releases/tag/v0.10.0
- The Jetson parameters are no longer needed. 
- The `v05` parameter is no longer needed.
- The `nand` parameter will now be `--nand`.
- When your params were `orin` and not `v05` you now have to include `--swap`
- Use the `espresso.py` version of Lizard >= 0.10.0.
### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
