### PR TITLE
Mac field for rtspcamera

### DIFF
--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -53,6 +53,13 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         }
 
     @classmethod
+    def args_from_dict(cls, data: dict[str, Any]) -> dict:
+        data = super().args_from_dict(data)
+        if 'mac' not in data:
+            data['mac'] = data['id']
+        return data
+
+    @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Self:
         return cls(**cls.args_from_dict(data))
 

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -12,7 +12,8 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
     def __init__(self,
                  *,
-                 id: str,  # pylint: disable=redefined-builtin
+                 mac: str,
+                 id: str | None = None,  # pylint: disable=redefined-builtin
                  name: str | None = None,
                  connect_after_init: bool = True,
                  fps: int = 5,
@@ -21,6 +22,9 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
                  avdec: Literal['h264', 'h265'] = 'h264',
                  ip: str | None = None,
                  **kwargs) -> None:
+        self.mac = mac
+        if id is None:
+            id = f'{mac}-{substream}'
         super().__init__(id=id,
                          name=name,
                          connect_after_init=connect_after_init,
@@ -44,6 +48,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
             name: param.value for name, param in self._parameters.items()
         }
         return super().to_dict() | parameters | {
+            'mac': self.mac,
             'ip': self.ip,
         }
 
@@ -71,7 +76,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
             self.log.error('no IP address provided for camera %s', self.id)
             return
 
-        self.device = RtspDevice(mac=self.id, ip=self.ip,
+        self.device = RtspDevice(mac=self.mac, ip=self.ip,
                                  substream=self.parameters['substream'],
                                  fps=self.parameters['fps'],
                                  on_new_image_data=self._handle_new_image_data,

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -23,9 +23,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
                  ip: str | None = None,
                  **kwargs) -> None:
         self.mac = mac
-        if id is None:
-            id = f'{mac}-{substream}'
-        super().__init__(id=id,
+        super().__init__(id=id or f'{mac}-{substream}',
                          name=name,
                          connect_after_init=connect_after_init,
                          **kwargs)

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -51,12 +51,8 @@ class RtspCameraProvider(CameraProvider[RtspCamera]):
             camera = next((c for c in self._cameras.values() if c.mac == mac), None)
             if camera is None:
                 self.log.debug('found new camera %s', mac)
-                self.add_camera(RtspCamera(mac=mac,
-                                           fps=self.frame_rate,
-                                           substream=self.substream,
-                                           avdec=self.avdec,
-                                           ip=ip))
-                camera = next(c for c in self._cameras.values() if c.mac == mac)
+                camera = RtspCamera(mac=mac, fps=self.frame_rate, substream=self.substream, avdec=self.avdec, ip=ip)
+                self.add_camera(camera)
             if not camera.is_connected:
                 self.log.info('activating authorized camera %s...', camera.id)
                 camera.ip = ip

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -30,12 +30,6 @@ class RtspCameraProvider(CameraProvider[RtspCamera]):
         if auto_scan:
             rosys.on_repeat(self.update_device_list, self.SCAN_INTERVAL)
 
-    def backup_to_dict(self) -> dict:
-        cameras = {}
-        for camera in self._cameras.values():
-            cameras[camera.id] = camera.to_dict()
-        return {'cameras': cameras}
-
     def restore_from_dict(self, data: dict[str, dict]) -> None:
         for camera_data in data.get('cameras', {}).values():
             camera = RtspCamera.from_dict(camera_data)

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -48,14 +48,15 @@ class RtspCameraProvider(CameraProvider[RtspCamera]):
     async def update_device_list(self) -> None:
         self.log.debug('scanning for cameras...')
         for mac, ip in await find_known_cameras(network_interface=self.network_interface):
-            if mac not in self._cameras:
+            camera = next((c for c in self._cameras.values() if c.mac == mac), None)
+            if camera is None:
                 self.log.debug('found new camera %s', mac)
-                self.add_camera(RtspCamera(id=mac,
+                self.add_camera(RtspCamera(mac=mac,
                                            fps=self.frame_rate,
                                            substream=self.substream,
                                            avdec=self.avdec,
                                            ip=ip))
-            camera = self._cameras[mac]
+                camera = next(c for c in self._cameras.values() if c.mac == mac)
             if not camera.is_connected:
                 self.log.info('activating authorized camera %s...', camera.id)
                 camera.ip = ip

--- a/tests/test_camera_persistence.py
+++ b/tests/test_camera_persistence.py
@@ -112,10 +112,15 @@ def test_rtsp_camera_explicit_id(rosys_integration):
 
 
 def test_rtsp_camera_backward_compat(rosys_integration):
-    old_data = {'id': 'aa:bb:cc:dd:ee:ff', 'substream': 1, 'fps': 5,
-                'bitrate': 4096, 'avdec': 'h264', 'ip': '192.168.1.1',
-                'connect_after_init': False}
-    camera = RtspCamera.from_dict(old_data)
+    camera = RtspCamera.from_dict({
+        'id': 'aa:bb:cc:dd:ee:ff',
+        'substream': 1,
+        'fps': 5,
+        'bitrate': 4096,
+        'avdec': 'h264',
+        'ip': '192.168.1.1',
+        'connect_after_init': False,
+    })
     assert camera.mac == 'aa:bb:cc:dd:ee:ff'
     assert camera.id == 'aa:bb:cc:dd:ee:ff'
 

--- a/tests/test_camera_persistence.py
+++ b/tests/test_camera_persistence.py
@@ -160,7 +160,7 @@ def test_storing_calibratable_camera_subclasses_as_dict(rosys_integration):
         pass
 
     for camera_class in [CalibratableRtspCamera, CalibratableUsbCamera, CalibratableMjpegCamera, CalibratableSimulatedCamera]:
-        kwargs: dict = {'id': 'test_cam'}
+        kwargs = {'id': 'test_cam'}
         if issubclass(camera_class, RtspCamera):
             kwargs['mac'] = 'aa:bb:cc:dd:ee:ff'
         camera = camera_class(**kwargs)

--- a/tests/test_camera_persistence.py
+++ b/tests/test_camera_persistence.py
@@ -88,13 +88,36 @@ async def test_storing_mjpeg_camera_as_dict(rosys_integration, base_camera_param
 
 
 def test_storing_rtsp_camera_as_dict(rosys_integration, base_camera_parameters):
-    camera = RtspCamera(fps=1, substream=2, bitrate=4097, avdec='h265', ip='192.168.1.1', **base_camera_parameters)
+    camera = RtspCamera(mac='aa:bb:cc:dd:ee:ff', fps=1, substream=2, bitrate=4097, avdec='h265',
+                        ip='192.168.1.1', **base_camera_parameters)
     camera_as_dict = camera.to_dict()
     restored_camera = RtspCamera.from_dict(camera_as_dict)
     assert isinstance(restored_camera, RtspCamera)
     assert_base_camera_parameters_match(camera, restored_camera)
     assert restored_camera.parameters == camera.parameters
     assert restored_camera.ip == camera.ip
+    assert restored_camera.mac == camera.mac
+
+
+def test_rtsp_camera_auto_id(rosys_integration):
+    camera = RtspCamera(mac='aa:bb:cc:dd:ee:ff', substream=1, connect_after_init=False)
+    assert camera.id == 'aa:bb:cc:dd:ee:ff-1'
+    assert camera.mac == 'aa:bb:cc:dd:ee:ff'
+
+
+def test_rtsp_camera_explicit_id(rosys_integration):
+    camera = RtspCamera(mac='aa:bb:cc:dd:ee:ff', id='my-custom-id', connect_after_init=False)
+    assert camera.id == 'my-custom-id'
+    assert camera.mac == 'aa:bb:cc:dd:ee:ff'
+
+
+def test_rtsp_camera_backward_compat(rosys_integration):
+    old_data = {'id': 'aa:bb:cc:dd:ee:ff', 'substream': 1, 'fps': 5,
+                'bitrate': 4096, 'avdec': 'h264', 'ip': '192.168.1.1',
+                'connect_after_init': False}
+    camera = RtspCamera.from_dict(old_data)
+    assert camera.mac == 'aa:bb:cc:dd:ee:ff'
+    assert camera.id == 'aa:bb:cc:dd:ee:ff'
 
 
 def test_storing_usb_camera_as_dict(rosys_integration, base_camera_parameters):
@@ -137,7 +160,10 @@ def test_storing_calibratable_camera_subclasses_as_dict(rosys_integration):
         pass
 
     for camera_class in [CalibratableRtspCamera, CalibratableUsbCamera, CalibratableMjpegCamera, CalibratableSimulatedCamera]:
-        camera = camera_class(id='test_cam')
+        kwargs: dict = {'id': 'test_cam'}
+        if issubclass(camera_class, RtspCamera):
+            kwargs['mac'] = 'aa:bb:cc:dd:ee:ff'
+        camera = camera_class(**kwargs)
         camera.calibration = calibration
         camera_as_dict = camera.to_dict()
         restored_camera = camera_class.from_dict(camera_as_dict)

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -42,7 +42,7 @@ async def test_rtsp_camera(rosys_integration):
     if len(connected_uids) == 0:
         pytest.skip('No RTSP camera detected. This test requires a physical RTSP camera on the local network.')
     mac, ip = connected_uids[0]
-    camera = RtspCamera(id=mac, ip=ip)
+    camera = RtspCamera(mac=mac, ip=ip)
     await camera.connect()
     for _ in range(5):
         await forward(0.1)


### PR DESCRIPTION
### Motivation

RtspCamera used id as the MAC address, preventing two cameras from sharing the same MAC (e.g., main stream and substream of the same physical device). Closes [#386](https://github.com/zauberzeug/rosys/issues/386).

### Implementation

  - Add required mac parameter to RtspCamera, making id optional (auto-generated as {mac}-{substream})
  - Pass self.mac instead of self.id to RtspDevice
  - Update RtspCameraProvider to look up cameras by mac field
  - Add backward compatibility: old persisted data without mac infers it from id

### Breaking Change

`RtspCamera` has now a mandatory field `mac` and an optional field `id`. If the `id` is not set in the initializer, it is set to`"{mac}-{substream}" (before, the `id` was identical to the `mac`).

Migration:
- When accessing RTSP cameras by their `id`, one has to compare to "{mac}-{substream}" instead of "{mac}". 
- Note: For old persistence data without `mac`, rosys infers it from `id`, thus nothing to do for RTSP cameras created by the provider! However, when the `id` was modified, one needs to adjust or delete the persistence.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
