### PR TITLE
add to dict for imu and gnss data

### DIFF
--- a/rosys/hardware/gnss/gnss.py
+++ b/rosys/hardware/gnss/gnss.py
@@ -40,6 +40,22 @@ class GnssMeasurement:
     def age(self) -> float:
         return ((self.gnss_time - rosys.time() + SECONDS_HALF_DAY) % SECONDS_DAY) - SECONDS_HALF_DAY
 
+    def to_dict(self) -> dict:
+        return {
+            'time': self.time,
+            'gnss_time': self.gnss_time,
+            'age': self.age,
+            'lat': self.pose.lat,
+            'lon': self.pose.lon,
+            'heading': self.pose.heading,
+            'quality': self.gps_quality.name.lower(),
+            'num_satellites': self.num_satellites,
+            'hdop': self.hdop,
+            'altitude': self.altitude,
+            'latitude_std_dev': self.latitude_std_dev,
+            'longitude_std_dev': self.longitude_std_dev,
+            'heading_std_dev': self.heading_std_dev,
+        }
 
 class Gnss(ABC):
     """A GNSS module that provides measurements from a GNSS receiver."""

--- a/rosys/hardware/imu.py
+++ b/rosys/hardware/imu.py
@@ -20,6 +20,25 @@ class ImuMeasurement:
     rotation: Rotation
     angular_velocity: Rotation
 
+    def to_dict(self) -> dict:
+        return {
+            'time': self.time,
+            'gyro_calibration': self.gyro_calibration,
+            'rotation': {
+                'roll': self.rotation.roll,
+                'pitch': self.rotation.pitch,
+                'yaw': self.rotation.yaw,
+                'roll_deg': self.rotation.roll_deg,
+                'pitch_deg': self.rotation.pitch_deg,
+                'yaw_deg': self.rotation.yaw_deg,
+            },
+            'angular_velocity': {
+                'roll': self.angular_velocity.roll,
+                'pitch': self.angular_velocity.pitch,
+                'yaw': self.angular_velocity.yaw,
+            },
+        }
+
 
 class Imu(Module):
     """A module that provides measurements from an IMU."""


### PR DESCRIPTION
### Motivation
`ImuMeasurement` and `GnssMeasurement` lacked serialization support, making it impossible to save their data to JSON (e.g. for logging or data export). This PR adds `to_dict()` methods to both classes.

### Implementation
Added `to_dict()` to `ImuMeasurement` (`rosys/hardware/imu.py`) and `GnssMeasurement` (`rosys/hardware/gnss/gnss.py`) that serialize all relevant fields to plain Python dicts, which are directly JSON-serializable. 

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
