### PR TITLE
Add OpenIPC MJPEG camera support

### DIFF
--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -25,7 +25,7 @@ class MjpegDeviceFactory:
                                     username=username, password=password,
                                     control_port=control_port, on_new_image_data=on_new_image_data)
 
-        if mac_to_vendor(mac) == VendorType.GOODCAM:
+        if mac_to_vendor(mac) in {VendorType.GOODCAM, VendorType.OPENIPC}:
             return MjpegDevice(mac, ip,
                                username=username, password=password,
                                on_new_image_data=on_new_image_data)

--- a/rosys/vision/mjpeg_camera/vendors.py
+++ b/rosys/vision/mjpeg_camera/vendors.py
@@ -5,6 +5,7 @@ class VendorType(Enum):
     AXIS = 1
     MOTEC = 2
     GOODCAM = 3
+    OPENIPC = 4
     OTHER = -1
 
 
@@ -15,6 +16,8 @@ def mac_to_vendor(mac: str) -> VendorType:
         return VendorType.MOTEC
     if mac.startswith('2c:6f:51'):
         return VendorType.GOODCAM
+    if mac.startswith('7a:7a:21'):
+        return VendorType.OPENIPC
     return VendorType.OTHER
 
 
@@ -26,4 +29,6 @@ def mac_to_url(mac: str, ip: str, *, index: int | None = None) -> str | None:
         return f'http://{ip}:1001/stream.mjpg'
     if vendor == VendorType.GOODCAM:
         return f'http://{ip}/api/v1/streams/secondary/stream.mjpeg'
+    if vendor == VendorType.OPENIPC:
+        return f'http://{ip}/mjpeg'
     return None


### PR DESCRIPTION
## Motivation

OpenIPC cameras (both Majestic and Divinus streamers) serve MJPEG at `/mjpeg` and share the MAC prefix `7a:7a:21` (set by OpenIPC firmware). Adding vendor detection enables auto-discovery and streaming via the existing `MjpegCameraProvider`.

## Implementation

- Add `OPENIPC` vendor type (enum value 4) with MAC prefix `7a:7a:21` to `vendors.py`
- Add URL mapping: `http://{ip}/mjpeg`
- Add OpenIPC case to `MjpegDeviceFactory` using base `MjpegDevice`

## Test plan

- [x] Verify OpenIPC camera discovered via ARP scan on LAN
- [x] Verify MJPEG stream displays in NiceGUI `ui.interactive_image`

---
🦌 claude-opus-4-6 (1M context)