### PR TITLE
Fix yaw instability at ±π in GeoPose roundtrip and Spline derivative

### DIFF
--- a/rosys/geometry/geo.py
+++ b/rosys/geometry/geo.py
@@ -94,9 +94,8 @@ class GeoPose:
     def from_pose(cls, pose: Pose) -> GeoPose:
         """Create a geo pose from a pose in the current geo reference."""
         assert GeoReference.current is not None
-        geo_point1 = GeoReference.current.point_to_geo(pose)
-        geo_point2 = GeoReference.current.point_to_geo(pose.transform_pose(Pose(x=1)))
-        return cls(geo_point1.lat, geo_point1.lon, geo_point1.direction(geo_point2))
+        geo_point = GeoReference.current.point_to_geo(pose)
+        return cls(geo_point.lat, geo_point.lon, GeoReference.current.direction - pose.yaw)
 
     @property
     def point(self) -> GeoPoint:
@@ -113,9 +112,8 @@ class GeoPose:
     def to_local(self) -> Pose:
         """Transform to local Cartesian coordinates relative to the current geo reference."""
         assert GeoReference.current is not None
-        point1 = GeoReference.current.point_to_local(self)
-        point2 = GeoReference.current.point_to_local(self.point.polar(1, self.heading))
-        return Pose(x=point1.x, y=point1.y, yaw=point1.direction(point2))
+        point = GeoReference.current.point_to_local(self)
+        return Pose(x=point.x, y=point.y, yaw=GeoReference.current.direction - self.heading)
 
     def __str__(self) -> str:
         lat_deg, lon_deg, heading_deg = self.degree_tuple
@@ -175,9 +173,8 @@ class GeoReference:
 
     def pose_to_geo(self, pose: Pose) -> GeoPose:
         """Convert a local pose to a global geo pose."""
-        geo_point1 = self.point_to_geo(pose)
-        geo_point2 = self.point_to_geo(pose.transform_pose(Pose(x=1)))
-        return GeoPose(geo_point1.lat, geo_point1.lon, geo_point1.direction(geo_point2))
+        geo_point = self.point_to_geo(pose)
+        return GeoPose(geo_point.lat, geo_point.lon, self.direction - pose.yaw)
 
     def point_to_local(self, geo_point: GeoPoint | GeoPose) -> Point:
         """Convert a global point to a local point."""
@@ -185,9 +182,8 @@ class GeoReference:
 
     def pose_to_local(self, geo_pose: GeoPose) -> Pose:
         """Convert a global geo pose to a local pose."""
-        point1 = self.point_to_local(geo_pose)
-        point2 = self.point_to_local(geo_pose.point.polar(1, geo_pose.heading))
-        return Pose(x=point1.x, y=point1.y, yaw=point1.direction(point2))
+        point = self.point_to_local(geo_pose)
+        return Pose(x=point.x, y=point.y, yaw=self.direction - geo_pose.heading)
 
     @property
     def degree_tuple(self) -> tuple[float, float, float]:

--- a/rosys/geometry/spline.py
+++ b/rosys/geometry/spline.py
@@ -32,6 +32,14 @@ class Spline:
     q: float = 0
     r: float = 0
 
+    # Adjacent control-point differences for numerically stable derivative evaluation
+    _dx0: float = 0
+    _dx1: float = 0
+    _dx2: float = 0
+    _dy0: float = 0
+    _dy1: float = 0
+    _dy2: float = 0
+
     def __post_init__(self) -> None:
         self.a = self.start.x
         self.e = self.start.y
@@ -48,6 +56,13 @@ class Spline:
         self.p = self.h - 3 * self.g + 3 * self.f - self.e
         self.q = self.g - 2 * self.f + self.e
         self.r = self.f - self.e
+
+        self._dx0 = self.b - self.a
+        self._dx1 = self.c - self.b
+        self._dx2 = self.d - self.c
+        self._dy0 = self.f - self.e
+        self._dy1 = self.g - self.f
+        self._dy2 = self.h - self.g
 
     def __repr__(self) -> str:
         return f'{type(self).__qualname__}(' + ' ~ '.join([
@@ -108,7 +123,7 @@ class Spline:
     def gx(self, t: np.ndarray) -> np.ndarray: ...
 
     def gx(self, t: float | np.ndarray) -> float | np.ndarray:
-        return 3 * (self.m * t**2 + 2 * self.n * t + self.o)
+        return 3 * ((1 - t)**2 * self._dx0 + 2 * (1 - t) * t * self._dx1 + t**2 * self._dx2)
 
     @overload
     def ggx(self, t: float) -> float: ...
@@ -126,7 +141,7 @@ class Spline:
     def gy(self, t: np.ndarray) -> np.ndarray: ...
 
     def gy(self, t: float | np.ndarray) -> float | np.ndarray:
-        return 3 * (self.p * t**2 + 2 * self.q * t + self.r)
+        return 3 * ((1 - t)**2 * self._dy0 + 2 * (1 - t) * t * self._dy1 + t**2 * self._dy2)
 
     @overload
     def ggy(self, t: float) -> float: ...

--- a/tests/test_geometry_2d.py
+++ b/tests/test_geometry_2d.py
@@ -1,6 +1,9 @@
+import math
+
+import numpy as np
 import pytest
 
-from rosys.geometry import Line, LineSegment, Point, Pose, PoseStep, Rectangle
+from rosys.geometry import Line, LineSegment, Point, Pose, PoseStep, Rectangle, Spline
 from rosys.testing import approx
 
 
@@ -73,3 +76,25 @@ def test_rectangle_contains_point():
     assert not rectangle.contains(out2)
     assert rectangle.contains(in1)
     assert rectangle.contains(in2)
+
+
+@pytest.mark.parametrize('yaw', [0, math.pi / 4, math.pi / 2, math.pi, -math.pi / 2, -math.pi])
+def test_spline_boundary_yaw(yaw: float) -> None:
+    """Spline.yaw at t=0 and t=1 must match the input poses."""
+    spline = Spline.from_poses(Pose(x=0, y=0, yaw=0), Pose(x=-1, y=0, yaw=yaw))
+    assert spline.yaw(0) == pytest.approx(0, abs=1e-6)
+    assert spline.yaw(1) == pytest.approx(yaw, abs=1e-6)
+
+
+def test_spline_yaw_stability_near_pi() -> None:
+    """Spline.yaw(1) must not flip from +pi to -pi when positions are np.float64.
+
+    GeoReference.point_to_local returns np.float64 coordinates. When the tangent
+    at t=1 points along -x (yaw=pi), the y-derivative is nearly zero and its sign
+    can flip due to floating-point cancellation in the polynomial evaluation.
+    """
+    spline = Spline.from_poses(
+        Pose(x=np.float64(3.499999999085846), y=np.float64(1.49999999981608), yaw=math.pi / 2),
+        Pose(x=np.float64(2.000000000229767), y=np.float64(2.999999999937638), yaw=math.pi),
+    )
+    assert spline.yaw(1) == pytest.approx(math.pi, abs=0.01)

--- a/tests/test_geometry_geo.py
+++ b/tests/test_geometry_geo.py
@@ -2,7 +2,7 @@ import math
 
 import pytest
 
-from rosys.geometry import Fixpoint, GeoPoint, GeoPose, GeoReference, Point
+from rosys.geometry import Fixpoint, GeoPoint, GeoPose, GeoReference, Point, Pose
 from rosys.geometry.geo import RADIUS
 
 CIRCUMFERENCE = RADIUS * 2 * math.pi
@@ -81,9 +81,22 @@ def test_point_to_local(direction: str) -> None:
 
 
 @pytest.mark.usefixtures('geo_reference')
-@pytest.mark.parametrize('heading_degrees', (0, 45, 90, 179, -45, -90, -179))
+@pytest.mark.parametrize('heading_degrees', (0, 45, 90, 179, 180, -45, -90, -179, -180))
 def test_pose_to_local(heading_degrees: int) -> None:
     pose = GeoPose.from_degrees(lat=0, lon=0.001, heading=heading_degrees).to_local()
     assert pose.x == pytest.approx(0)
     assert pose.y == pytest.approx(-0.001 * ONE_DEGREE_ARC_LENGTH)
     assert pose.yaw == pytest.approx(math.radians(-heading_degrees))
+
+
+@pytest.mark.parametrize('x, y', [(1, 3), (2, 3), (0, 0), (5, 5)])
+@pytest.mark.parametrize('yaw', [0, math.pi / 2, math.pi, -math.pi / 2, -math.pi])
+def test_geopose_roundtrip(x: float, y: float, yaw: float) -> None:
+    """Pose -> GeoPose -> Pose must preserve yaw within a small tolerance for all positions."""
+    GeoReference.update_current(
+        GeoReference(GeoPoint.from_degrees(lat=51.98333489813455, lon=7.434242465994318)),
+    )
+    roundtrip = GeoPose.from_pose(Pose(x=x, y=y, yaw=yaw)).to_local()
+    assert roundtrip.x == pytest.approx(x, abs=1e-3)
+    assert roundtrip.y == pytest.approx(y, abs=1e-3)
+    assert roundtrip.yaw == pytest.approx(yaw, abs=0.01)


### PR DESCRIPTION
### Motivation

`GeoPose.from_pose(...).to_local()` can flip the yaw from `+π` to `-π` (or vice versa) depending on the position.
Both `from_pose` and `to_local` used a two-point projection + `atan2` to convert between local yaw and geographic heading.
For headings near ±π, the projected point has a near-zero y-offset whose sign is position-dependent, causing `atan2` to return `+π` at one position and `-π` at another.

Additionally, `Spline.gx`/`gy` evaluated the derivative via polynomial coefficients that mix all four control points.
At `t=0` and `t=1`, large intermediate terms cancel to near-zero, and the residual sign varies by Python version and whether coordinates are `float` vs `np.float64`.

### Implementation

**GeoPose**: replace the two-point projection with a direct formula: `heading = direction - yaw` / `yaw = direction - heading`.
No `atan2`, no point projection — exact roundtrip.
Applied to `from_pose`, `to_local`, `pose_to_geo`, and `pose_to_local`.

**Spline**: switch `gx`/`gy` from the expanded polynomial form (`m*t² + 2n*t + o`) to the de Casteljau form using adjacent control-point differences (`(1-t)²·d₀ + 2(1-t)t·d₁ + t²·d₂`).
Mathematically equivalent, but numerically stable because it avoids catastrophic cancellation of O(1) terms.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).