### PR TITLE
Use Bernstein form for Spline derivative evaluation

### DIFF
--- a/rosys/geometry/spline.py
+++ b/rosys/geometry/spline.py
@@ -108,7 +108,7 @@ class Spline:
     def gx(self, t: np.ndarray) -> np.ndarray: ...
 
     def gx(self, t: float | np.ndarray) -> float | np.ndarray:
-        return 3 * (self.m * t**2 + 2 * self.n * t + self.o)
+        return 3 * ((1 - t)**2 * (self.b - self.a) + 2 * (1 - t) * t * (self.c - self.b) + t**2 * (self.d - self.c))
 
     @overload
     def ggx(self, t: float) -> float: ...
@@ -117,7 +117,7 @@ class Spline:
     def ggx(self, t: np.ndarray) -> np.ndarray: ...
 
     def ggx(self, t: float | np.ndarray) -> float | np.ndarray:
-        return 6 * (self.m * t + self.n)
+        return 6 * ((1 - t) * (self.c - 2 * self.b + self.a) + t * (self.d - 2 * self.c + self.b))
 
     @overload
     def gy(self, t: float) -> float: ...
@@ -126,7 +126,7 @@ class Spline:
     def gy(self, t: np.ndarray) -> np.ndarray: ...
 
     def gy(self, t: float | np.ndarray) -> float | np.ndarray:
-        return 3 * (self.p * t**2 + 2 * self.q * t + self.r)
+        return 3 * ((1 - t)**2 * (self.f - self.e) + 2 * (1 - t) * t * (self.g - self.f) + t**2 * (self.h - self.g))
 
     @overload
     def ggy(self, t: float) -> float: ...
@@ -135,7 +135,7 @@ class Spline:
     def ggy(self, t: np.ndarray) -> np.ndarray: ...
 
     def ggy(self, t: float | np.ndarray) -> float | np.ndarray:
-        return 6 * (self.p * t + self.q)
+        return 6 * ((1 - t) * (self.g - 2 * self.f + self.e) + t * (self.h - 2 * self.g + self.f))
 
     @overload
     def yaw(self, t: float) -> float: ...


### PR DESCRIPTION
### Motivation

The power basis form (e.g. `m*t² + 2*n*t + o`) mixes all four control points into coefficients with alternating signs. At `t=1`, this evaluates `m + 2n + o` — three large terms that cancel to `d-c`, with the residual sign depending on floating-point rounding. The Bernstein form uses non-negative weights over simple adjacent differences (`b-a`, `c-b`, `d-c`), so no cancellation occurs during evaluation.

Extracted from #393 — the Spline improvement stands on its own without the GeoPose changes.

### Implementation

Switch `gx`/`gy`/`ggx`/`ggy` from power basis to Bernstein form using adjacent control-point differences. Mathematically equivalent, but avoids catastrophic cancellation of large intermediate terms at evaluation time.

Verified by evaluating all four derivatives at three random points along a random spline — results match `main` to ULP-level precision:

```python
spline = Spline(
    start=Point(x=0.17, y=-3.42),
    control1=Point(x=2.91, y=1.08),
    control2=Point(x=5.63, y=-0.74),
    end=Point(x=8.35, y=2.19),
)
for t in [0.17, 0.53, 0.91]:
    print(f'gx={spline.gx(t):.15e}  gy={spline.gy(t):.15e}  ggx={spline.ggx(t):.15e}  ggy={spline.ggy(t):.15e}')
```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels.
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.