### PR TITLE
Formalize `WheelsSimulation` as a `PoseProvider`

### DIFF
--- a/rosys/hardware/gnss/gnss_simulation.py
+++ b/rosys/hardware/gnss/gnss_simulation.py
@@ -16,7 +16,7 @@ class GnssSimulation(Gnss):
     """Simulation of a GNSS receiver."""
 
     def __init__(self, *,
-                 wheels: PoseProvider,
+                 pose_provider: PoseProvider,
                  lat_std_dev: float = 0.01,
                  lon_std_dev: float = 0.01,
                  heading_std_dev: float = 0.01,
@@ -24,7 +24,7 @@ class GnssSimulation(Gnss):
                  latency: float = 0.0,
                  gps_quality: GpsQuality = GpsQuality.RTK_FIXED) -> None:
         """
-        :param wheels: the wheels to use for the simulation
+        :param pose_provider: the pose provider to use for the simulation
         :param lat_std_dev: the standard deviation of the latitude in meters
         :param lon_std_dev: the standard deviation of the longitude in meters
         :param heading_std_dev: the standard deviation of the heading in degrees
@@ -33,7 +33,7 @@ class GnssSimulation(Gnss):
         :param latency: the simulated measurement latency in seconds
         """
         super().__init__()
-        self.wheels = wheels
+        self.pose_provider = pose_provider
         self._is_connected = True
         self._lat_std_dev = lat_std_dev
         self._lon_std_dev = lon_std_dev
@@ -54,7 +54,7 @@ class GnssSimulation(Gnss):
     async def simulate(self) -> None:
         if not self.is_connected:
             return
-        geo_pose = GeoPose.from_pose(self.wheels.pose)
+        geo_pose = GeoPose.from_pose(self.pose_provider.pose)
         noise_lat = np.random.normal(0, self._lat_std_dev)
         noise_lon = np.random.normal(0, self._lon_std_dev)
         noise_magnitude = np.sqrt(noise_lat**2 + noise_lon**2)

--- a/rosys/hardware/imu.py
+++ b/rosys/hardware/imu.py
@@ -105,7 +105,7 @@ class ImuSimulation(Imu, ModuleSimulation):
     """Simulation of an IMU."""
 
     def __init__(self, *,
-                 wheels: PoseProvider,
+                 pose_provider: PoseProvider,
                  interval: float = 0.1,
                  roll: float = 0.0,
                  pitch: float = 0.0,
@@ -114,7 +114,7 @@ class ImuSimulation(Imu, ModuleSimulation):
                  yaw_noise: float = 0.0,
                  **kwargs) -> None:
         super().__init__(**kwargs)
-        self.wheels = wheels
+        self.pose_provider = pose_provider
         self.roll = roll
         self.pitch = pitch
         self.roll_noise = roll_noise
@@ -125,7 +125,7 @@ class ImuSimulation(Imu, ModuleSimulation):
     def simulate(self) -> None:
         roll = np.random.normal(self.roll, self.roll_noise)
         pitch = np.random.normal(self.pitch, self.pitch_noise)
-        yaw = np.random.normal(self.wheels.pose.yaw, self.yaw_noise)
+        yaw = np.random.normal(self.pose_provider.pose.yaw, self.yaw_noise)
         self._emit_measurement(3.0, Rotation.from_euler(roll, pitch, yaw), rosys.time())
 
     def developer_ui(self) -> None:

--- a/rosys/hardware/wheels.py
+++ b/rosys/hardware/wheels.py
@@ -145,4 +145,5 @@ class WheelsSimulation(Wheels, ModuleSimulation, PoseProvider):
                                angular=dt * (right_speed - left_speed) / self.width,
                                time=rosys.time())
         velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=self._pose.time)
+        self.POSE_UPDATED.emit(self._pose)
         self.VELOCITY_MEASURED.emit([velocity])

--- a/rosys/hardware/wheels.py
+++ b/rosys/hardware/wheels.py
@@ -126,7 +126,7 @@ class WheelsSimulation(Wheels, ModuleSimulation, PoseProvider):
         self._pose.y = value.y
         self._pose.yaw = value.yaw
         self._pose.time = value.time
-        self.POSE_UPDATED.emit(value)
+        self.POSE_UPDATED.emit(self._pose)
 
     async def drive(self, linear: float, angular: float) -> None:
         await super().drive(linear, angular)

--- a/rosys/hardware/wheels.py
+++ b/rosys/hardware/wheels.py
@@ -89,7 +89,7 @@ class WheelsSimulation(Wheels, ModuleSimulation, PoseProvider):
         self.width: float = width
         """The distance between the wheels -- used to calculate actual drift when slip_factor_* is used."""
 
-        self.pose: Pose = Pose(time=rosys.time())
+        self._pose: Pose = Pose(time=rosys.time())
         """Provides the actual pose of the robot which can alter due to slippage."""
 
         self.linear_velocity: float = 0
@@ -116,6 +116,18 @@ class WheelsSimulation(Wheels, ModuleSimulation, PoseProvider):
         self.POSE_UPDATED: Event[Pose] = Event()
         """Emitted when the pose has been updated (argument: current ``Pose``)."""
 
+    @property
+    def pose(self) -> Pose:
+        return self._pose
+
+    @pose.setter
+    def pose(self, value: Pose) -> None:
+        self._pose.x = value.x
+        self._pose.y = value.y
+        self._pose.yaw = value.yaw
+        self._pose.time = value.time
+        self.POSE_UPDATED.emit(value)
+
     async def drive(self, linear: float, angular: float) -> None:
         await super().drive(linear, angular)
         f = self.inertia_factor
@@ -129,8 +141,8 @@ class WheelsSimulation(Wheels, ModuleSimulation, PoseProvider):
         right_speed = self.linear_velocity + self.angular_velocity * self.width / 2
         left_speed *= 1 - self.slip_factor_left
         right_speed *= 1 - self.slip_factor_right
-        self.pose += PoseStep(linear=dt * (left_speed + right_speed) / 2,
-                              angular=dt * (right_speed - left_speed) / self.width,
-                              time=rosys.time())
-        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=self.pose.time)
+        self._pose += PoseStep(linear=dt * (left_speed + right_speed) / 2,
+                               angular=dt * (right_speed - left_speed) / self.width,
+                               time=rosys.time())
+        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=self._pose.time)
         self.VELOCITY_MEASURED.emit([velocity])

--- a/rosys/hardware/wheels.py
+++ b/rosys/hardware/wheels.py
@@ -3,6 +3,7 @@ import abc
 from nicegui import Event
 
 from .. import rosys
+from ..driving.driver import PoseProvider
 from ..geometry import Pose, PoseStep, Velocity
 from ..helpers import remove_indentation
 from .can import CanHardware
@@ -75,7 +76,7 @@ class WheelsHardware(Wheels, ModuleHardware):
         self.VELOCITY_MEASURED.emit([velocity])
 
 
-class WheelsSimulation(Wheels, ModuleSimulation):
+class WheelsSimulation(Wheels, ModuleSimulation, PoseProvider):
     """This module simulates two wheels.
 
     Drive and stop commands impact internal velocities (linear and angular).
@@ -88,7 +89,7 @@ class WheelsSimulation(Wheels, ModuleSimulation):
         self.width: float = width
         """The distance between the wheels -- used to calculate actual drift when slip_factor_* is used."""
 
-        self.pose: Pose = Pose(time=rosys.time())
+        self._pose: Pose = Pose(time=rosys.time())
         """Provides the actual pose of the robot which can alter due to slippage."""
 
         self.linear_velocity: float = 0
@@ -112,6 +113,13 @@ class WheelsSimulation(Wheels, ModuleSimulation):
         self.slip_factor_right: float = 0
         """The factor of slippage for the right wheel (0 = no slippage, 1 = full slippage)."""
 
+        self.POSE_UPDATED: Event[Pose] = Event()
+        """Emitted when the pose has been updated (argument: current ``Pose``)."""
+
+    @property
+    def pose(self) -> Pose:
+        return self._pose
+
     async def drive(self, linear: float, angular: float) -> None:
         await super().drive(linear, angular)
         f = self.inertia_factor
@@ -125,8 +133,8 @@ class WheelsSimulation(Wheels, ModuleSimulation):
         right_speed = self.linear_velocity + self.angular_velocity * self.width / 2
         left_speed *= 1 - self.slip_factor_left
         right_speed *= 1 - self.slip_factor_right
-        self.pose += PoseStep(linear=dt * (left_speed + right_speed) / 2,
-                              angular=dt * (right_speed - left_speed) / self.width,
-                              time=rosys.time())
-        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=self.pose.time)
+        self._pose += PoseStep(linear=dt * (left_speed + right_speed) / 2,
+                               angular=dt * (right_speed - left_speed) / self.width,
+                               time=rosys.time())
+        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=self._pose.time)
         self.VELOCITY_MEASURED.emit([velocity])

--- a/rosys/hardware/wheels.py
+++ b/rosys/hardware/wheels.py
@@ -89,7 +89,7 @@ class WheelsSimulation(Wheels, ModuleSimulation, PoseProvider):
         self.width: float = width
         """The distance between the wheels -- used to calculate actual drift when slip_factor_* is used."""
 
-        self._pose: Pose = Pose(time=rosys.time())
+        self.pose: Pose = Pose(time=rosys.time())
         """Provides the actual pose of the robot which can alter due to slippage."""
 
         self.linear_velocity: float = 0
@@ -116,10 +116,6 @@ class WheelsSimulation(Wheels, ModuleSimulation, PoseProvider):
         self.POSE_UPDATED: Event[Pose] = Event()
         """Emitted when the pose has been updated (argument: current ``Pose``)."""
 
-    @property
-    def pose(self) -> Pose:
-        return self._pose
-
     async def drive(self, linear: float, angular: float) -> None:
         await super().drive(linear, angular)
         f = self.inertia_factor
@@ -133,8 +129,8 @@ class WheelsSimulation(Wheels, ModuleSimulation, PoseProvider):
         right_speed = self.linear_velocity + self.angular_velocity * self.width / 2
         left_speed *= 1 - self.slip_factor_left
         right_speed *= 1 - self.slip_factor_right
-        self._pose += PoseStep(linear=dt * (left_speed + right_speed) / 2,
-                               angular=dt * (right_speed - left_speed) / self.width,
-                               time=rosys.time())
-        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=self._pose.time)
+        self.pose += PoseStep(linear=dt * (left_speed + right_speed) / 2,
+                              angular=dt * (right_speed - left_speed) / self.width,
+                              time=rosys.time())
+        velocity = Velocity(linear=self.linear_velocity, angular=self.angular_velocity, time=self.pose.time)
         self.VELOCITY_MEASURED.emit([velocity])


### PR DESCRIPTION
### Motivation

`WheelsSimulation` is passed to `GnssSimulation` as a `PoseProvider` but doesn't fully implement the protocol after the change in https://github.com/zauberzeug/rosys/pull/391, causing a mypy error: `Argument "wheels" to "GnssSimulation" has incompatible type "WheelsSimulation"; expected "PoseProvider"`.

### Implementation

- `WheelsSimulation` now inherits from `PoseProvider`, adding a `POSE_UPDATED` event and turning `pose` into a property with a setter that emits the event on each update.
- The internal pose field is renamed to `_pose` to back the new property.

**Breaking change:**
- `GnssSimulation.wheels` is renamed to `pose_provider` to match the type it already accepted.
- `ImuSimulation.wheels` is renamed to `pose_provider` to match the type it already accepted.


### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).