### PR TITLE
fix rename from prediction to pose in example

### DIFF
--- a/docs/examples/automations/main.py
+++ b/docs/examples/automations/main.py
@@ -14,8 +14,8 @@ async def run() -> None:
 
 
 async def forward() -> None:
-    start = odometer.prediction
-    while start.distance(odometer.prediction) < 1.0:
+    start = odometer.pose
+    while start.distance(odometer.pose) < 1.0:
         await wheels.drive(1.0, 0.0)
         await rosys.sleep(0.1)
     await wheels.stop()
@@ -23,8 +23,8 @@ async def forward() -> None:
 
 @rosys.automation.uninterruptible
 async def turn_left() -> None:
-    start = odometer.prediction
-    while rosys.helpers.angle(start.yaw, odometer.prediction.yaw) < math.radians(90):
+    start = odometer.pose
+    while rosys.helpers.angle(start.yaw, odometer.pose.yaw) < math.radians(90):
         await wheels.drive(0.0, 1.0)
         await rosys.sleep(0.1)
     await wheels.stop()


### PR DESCRIPTION
### Motivation

This renaming in the automations example was missed in #391.

### Implementation

Rename from `odometer.prediction` to `odometer.pose`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
