### PR TITLE
Send optional periodic heartbeat signals to the ESP

### DIFF
--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -22,9 +22,16 @@ class RobotBrain:
     The clock offset is calculated by comparing the hardware time with the system time and averaging the differences over a number of samples.
     If the offset changes significantly, a notification is sent and the offset history is cleared.
     """
-    HEARTBEAT_INTERVAL = 0.5
 
-    def __init__(self, communication: Communication, *, enable_esp_on_startup: bool = True, use_espresso: bool = False) -> None:
+    def __init__(self, communication: Communication, *, enable_esp_on_startup: bool = True, use_espresso: bool = False, heartbeat_interval: float | None = None) -> None:
+        """
+        Initialize the RobotBrain and connect to the microcontroller.
+
+        :param communication: The communication object to use for reading and writing messages
+        :param enable_esp_on_startup: Whether to enable the ESP on startup (default: ``True``)
+        :param use_espresso: Whether to use the new espresso.py for controlling the ESP instead of the old flash.py (default: ``False``)
+        :param heartbeat_interval: If not ``None``, the interval in seconds at which to send heartbeat messages to the ESP (default: ``None``)
+        """
         self.ESP_CONNECTED = Event[[]]()
         """ESP has been connected and Lizard is ready to use"""
         self.LINE_RECEIVED = Event[str]()
@@ -45,12 +52,13 @@ class RobotBrain:
         self._use_espresso = use_espresso
         if enable_esp_on_startup:
             rosys.on_startup(self.enable_esp)
+        if heartbeat_interval is not None:
+            rosys.on_repeat(self.send_heartbeat, heartbeat_interval)
 
         self.esp_pins_core = EspPins(name='core', robot_brain=self)
         self.esp_pins_p0 = EspPins(name='p0', robot_brain=self)
 
         self._esp_lock = asyncio.Lock()
-        rosys.on_repeat(self._send_heartbeat, self.HEARTBEAT_INTERVAL)
 
     @property
     def clock_offset(self) -> float | None:
@@ -63,13 +71,6 @@ class RobotBrain:
     @property
     def is_ready(self) -> bool:
         return self._hardware_time is not None
-
-    async def _send_heartbeat(self) -> None:
-        """Send a heartbeat command to the microcontroller to check if it's still connected and to keep the connection alive."""
-        if not self.is_ready:
-            self.log.debug('Skipping heartbeat because ESP is not ready')
-            return
-        await self.send('core.heartbeat()')
 
     def developer_ui(self) -> None:
         version_select: ui.select
@@ -163,6 +164,13 @@ class RobotBrain:
 
         ui.label().bind_text_from(self, 'clock_offset', lambda offset: f'Clock offset: {offset or 0:.3f} s')
         ui.label().bind_text_from(self, 'is_ready', lambda ready: f'Ready: {ready}')
+
+    async def send_heartbeat(self) -> None:
+        """Send a heartbeat command to the microcontroller to let it know that RoSys is still running."""
+        if not self.is_ready:
+            self.log.debug('Skipping heartbeat because ESP is not ready')
+            return
+        await self.send('core.heartbeat()')
 
     async def configure(self) -> None:
         rosys.notify('Configuring Lizard...')

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -170,7 +170,7 @@ class RobotBrain:
         if not self.is_ready:
             self.log.debug('Skipping heartbeat because ESP is not ready')
             return
-        await self.send('core.heartbeat()')
+        await self.send('core.keep_alive()')
 
     async def configure(self) -> None:
         rosys.notify('Configuring Lizard...')

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -53,7 +53,7 @@ class RobotBrain:
         if enable_esp_on_startup:
             rosys.on_startup(self.enable_esp)
         if heartbeat_interval is not None:
-            rosys.on_repeat(self.send_heartbeat, heartbeat_interval)
+            rosys.on_repeat(self._send_heartbeat, heartbeat_interval)
 
         self.esp_pins_core = EspPins(name='core', robot_brain=self)
         self.esp_pins_p0 = EspPins(name='p0', robot_brain=self)
@@ -165,8 +165,8 @@ class RobotBrain:
         ui.label().bind_text_from(self, 'clock_offset', lambda offset: f'Clock offset: {offset or 0:.3f} s')
         ui.label().bind_text_from(self, 'is_ready', lambda ready: f'Ready: {ready}')
 
-    async def send_heartbeat(self) -> None:
-        """Send a heartbeat command to the microcontroller to let it know that RoSys is still running."""
+    async def _send_heartbeat(self) -> None:
+        """Send a ``core.keep_alive()`` command to the microcontroller to let it know that RoSys is still running."""
         if not self.is_ready:
             self.log.debug('Skipping heartbeat because ESP is not ready')
             return

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -22,6 +22,7 @@ class RobotBrain:
     The clock offset is calculated by comparing the hardware time with the system time and averaging the differences over a number of samples.
     If the offset changes significantly, a notification is sent and the offset history is cleared.
     """
+    HEARTBEAT_INTERVAL = 0.5
 
     def __init__(self, communication: Communication, *, enable_esp_on_startup: bool = True, use_espresso: bool = False) -> None:
         self.ESP_CONNECTED = Event[[]]()
@@ -49,6 +50,7 @@ class RobotBrain:
         self.esp_pins_p0 = EspPins(name='p0', robot_brain=self)
 
         self._esp_lock = asyncio.Lock()
+        rosys.on_repeat(self._send_heartbeat, self.HEARTBEAT_INTERVAL)
 
     @property
     def clock_offset(self) -> float | None:
@@ -61,6 +63,13 @@ class RobotBrain:
     @property
     def is_ready(self) -> bool:
         return self._hardware_time is not None
+
+    async def _send_heartbeat(self) -> None:
+        """Send a heartbeat command to the microcontroller to check if it's still connected and to keep the connection alive."""
+        if not self.is_ready:
+            self.log.debug('Skipping heartbeat because ESP is not ready')
+            return
+        await self.send('core.heartbeat()')
 
     def developer_ui(self) -> None:
         version_select: ui.select


### PR DESCRIPTION
### Motivation

When RoSys loses connection or crashes, the ESP has no way to detect this and continues operating with stale state. A periodic heartbeat lets the microcontroller know that RoSys is still alive, enabling it to take safety actions (e.g. stopping motors) when heartbeats stop arriving.

### Implementation

Add an optional `heartbeat_interval` parameter to `RobotBrain.__init__()`. When set, the Robot Brain will call Lizard's `core.heartbeat()` at the specified interval.

`core.heartbeat` is a new feature of Lizard which is not yet released. This PR will work regardless, because the message RoSys will still be received even if it can't be interpreted.
https://github.com/zauberzeug/lizard/pull/200

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).