### PR TITLE
Fix continuous looping for backward playback of ReplayCameraProvider

### DIFF
--- a/rosys/vision/record_replay/replay_camera_provider.py
+++ b/rosys/vision/record_replay/replay_camera_provider.py
@@ -146,6 +146,8 @@ class ReplayCameraProvider(CameraProvider[ReplayCamera]):
         new_replay_time = self._current_time + (now - self._last_update_time) * self._playback_speed
         if new_replay_time > self._end_time:
             new_replay_time = self._start_time + (new_replay_time - self._end_time)
+        if new_replay_time < self._start_time:
+            new_replay_time = self._end_time + (new_replay_time - self._start_time)
         self._set_replay_time(new_replay_time)
         self._last_update_time = now
 


### PR DESCRIPTION
### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->
When using backward replays within the ReplayCameraProvider, the timeline does not loop correctly when it reaches the beginning of the replay.
<!-- Please provide relevant links to corresponding issues and feature requests. -->

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->
Inspired by the forward replay case, we added a check that integrates a loop by setting the new_replay_time to the end of the replay.
<!-- Include any important technical decisions or trade-offs made -->

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
