### PR TITLE
Close wrapped coroutine on automation stop

### DIFF
--- a/rosys/automation/automation.py
+++ b/rosys/automation/automation.py
@@ -112,6 +112,7 @@ class Automation:
             raise
         finally:
             self._is_waited = False
+            self.coro.close()
             _CURRENT_AUTOMATION.reset(token)
         return None
 

--- a/rosys/automation/automation.py
+++ b/rosys/automation/automation.py
@@ -112,8 +112,8 @@ class Automation:
             raise
         finally:
             self._is_waited = False
-            self.coro.close()
             _CURRENT_AUTOMATION.reset(token)
+            self.coro.close()
         return None
 
     def pause(self) -> None:

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -71,11 +71,16 @@ async def test_finally_block(automator: Automator):
         finally:
             events.append('tock')
 
-    automator.start(run())
-    await forward(seconds=10)
-    automator.stop(because='test')
-    await forward(seconds=1)
-    assert events == ['tick', 'tick', 'tick', 'tick', 'tock']
+    pinned: list = []  # prevent refcount-driven GC from masking the bug
+    for _ in range(2):
+        coro = run()
+        pinned.append(coro)
+        automator.start(coro)
+        await forward(seconds=10)
+        pinned.append(automator.automation)
+        automator.stop(because='test')
+        await forward(seconds=1)
+    assert events == ['tick', 'tick', 'tick', 'tick', 'tock'] * 2
 
 
 async def test_parallelize(automator: Automator):


### PR DESCRIPTION
### Motivation

Fixes #336.

When `Automator.stop()` is called, `Automation.__await__` returns without ever throwing into or closing the wrapped coroutine. The coroutine is left suspended at its current `await` point, so any `try/finally` or `async with` block above that point never runs — only eventual GC of the `Automation` will (non-deterministically) close the coroutine and trigger cleanup. In the live UI this can be deferred indefinitely.

The reported symptom in #336 is leaked `rosys.analysis.track` stacks, but the bug is general: every `finally` / `async with` inside a manually stopped automation is silently skipped (locks not released, hardware not reset, files not closed, etc.).

### Implementation

Add `self.coro.close()` to `Automation.__await__`'s `finally` block. This eagerly does what GC would eventually do — `coro.close()` injects `GeneratorExit` into the suspended frame so cleanup blocks fire deterministically on every exit path (manual stop, normal completion, or exception).

**Trade-off:** a `finally` block that `await`s something will raise `RuntimeError` ("coroutine ignored GeneratorExit") under `coro.close()` — that's the standard Python semantic. Currently those blocks don't run at all, so this is strictly an improvement. Truly cancellable cleanup with `await` inside `finally` would require throwing a dedicated exception instead, which is out of scope here.

The existing `test_finally_block` regression test was passing on `main` for the wrong reason: refcount-driven deallocation closed the coroutine synchronously at the moment `automator.automation = None` was assigned. In a live NiceGUI app, an extra reference (likely a cycle that only the cyclic GC can break) defers that. The test is strengthened to pin refs to the coroutine and the `Automation` during the loop, defeating refcount-driven cleanup and reproducing the live-app behavior. It now fails on `main` and passes with the fix.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will…"
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).