### PR TITLE
Add optional frame for projection

### DIFF
--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -253,7 +253,7 @@ class Calibration:
         """Project a point in image coordinates to a plane in world coordinates.
 
         :param image_coordinates: The image coordinates to project.
-        :param target_height: The height of the plane in world coordinates.
+        :param target_height: The height of the plane in ``frame`` or world coordinates.
         :param reprojection_tolerance: The reprojection tolerance as a fraction of the maximum image dimension.
         :param frame: The coordinate frame to project to. If none is given, project to world coordinates.
         :return: The world coordinates of the projected point, or None if projection failed.
@@ -268,7 +268,7 @@ class Calibration:
         """Project points in image coordinates to a plane in world coordinates.
 
         :param image_coordinates: The list of image coordinates to project.
-        :param target_height: The height of the plane in world coordinates.
+        :param target_height: The height of the plane in ``frame`` or world coordinates.
         :param reprojection_tolerance: The reprojection tolerance as a fraction of the maximum image dimension.
         :param frame: The coordinate frame to project to. If none is given, project to world coordinates.
         :return: The world coordinates of the projected points, or None if any projection failed.
@@ -283,7 +283,7 @@ class Calibration:
         """Project points in image coordinates to a plane in world coordinates.
 
         :param image_coordinates: (Nx2) The image coordinates to project.
-        :param target_height: The height of the plane in world coordinates.
+        :param target_height: The height of the plane in ``frame`` or world coordinates.
         :param reprojection_tolerance: The reprojection tolerance as a fraction of the maximum image dimension.
         :param frame: The coordinate frame to project to. If none is given, project to world coordinates.
         :return: (Nx3) The world coordinates of the projected points.

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -305,7 +305,10 @@ class Calibration:
                                                   target_height=target_height,
                                                   reprojection_tolerance=reprojection_tolerance,
                                                   frame=frame)
-            return [Point3d(x=point[0], y=point[1], z=point[2]) if not np.isnan(point).any() else None for point in world_array]
+            return [
+                Point3d(x=point[0], y=point[1], z=point[2]).in_frame(frame) if not np.isnan(point).any() else None
+                for point in world_array
+            ]
 
         if len(image_coordinates) == 0:
             return np.empty((0, 3), dtype=np.float64)

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -248,12 +248,14 @@ class Calibration:
     def project_from_image(self,
                            image_coordinates: Point,
                            target_height: float = 0, *,
-                           reprojection_tolerance: float = 0.002) -> Point3d | None:
+                           reprojection_tolerance: float = 0.002,
+                           frame: Frame3d | None = None) -> Point3d | None:
         """Project a point in image coordinates to a plane in world coordinates.
 
         :param image_coordinates: The image coordinates to project.
         :param target_height: The height of the plane in world coordinates.
         :param reprojection_tolerance: The reprojection tolerance as a fraction of the maximum image dimension.
+        :param frame: The coordinate frame to project to. If none is given, project to world coordinates.
         :return: The world coordinates of the projected point, or None if projection failed.
         """
 
@@ -261,12 +263,14 @@ class Calibration:
     def project_from_image(self,
                            image_coordinates: list[Point],
                            target_height: float = 0, *,
-                           reprojection_tolerance: float = 0.002) -> list[Point3d | None]:
+                           reprojection_tolerance: float = 0.002,
+                           frame: Frame3d | None = None) -> list[Point3d | None]:
         """Project points in image coordinates to a plane in world coordinates.
 
         :param image_coordinates: The list of image coordinates to project.
         :param target_height: The height of the plane in world coordinates.
         :param reprojection_tolerance: The reprojection tolerance as a fraction of the maximum image dimension.
+        :param frame: The coordinate frame to project to. If none is given, project to world coordinates.
         :return: The world coordinates of the projected points, or None if any projection failed.
         """
 
@@ -274,34 +278,39 @@ class Calibration:
     def project_from_image(self,
                            image_coordinates: FloatArray,
                            target_height: float = 0, *,
-                           reprojection_tolerance: float = 0.002) -> FloatArray:
+                           reprojection_tolerance: float = 0.002,
+                           frame: Frame3d | None = None) -> FloatArray:
         """Project points in image coordinates to a plane in world coordinates.
 
         :param image_coordinates: (Nx2) The image coordinates to project.
         :param target_height: The height of the plane in world coordinates.
         :param reprojection_tolerance: The reprojection tolerance as a fraction of the maximum image dimension.
+        :param frame: The coordinate frame to project to. If none is given, project to world coordinates.
         :return: (Nx3) The world coordinates of the projected points.
         """
 
     def project_from_image(self,
                            image_coordinates: Point | list[Point] | FloatArray,
                            target_height: float = 0, *,
-                           reprojection_tolerance: float = 0.002) -> Point3d | None | list[Point3d | None] | FloatArray:
+                           reprojection_tolerance: float = 0.002,
+                           frame: Frame3d | None = None) -> Point3d | None | list[Point3d | None] | FloatArray:
         if isinstance(image_coordinates, Point):
             return self.project_from_image([image_coordinates],
                                            target_height=target_height,
-                                           reprojection_tolerance=reprojection_tolerance)[0]
+                                           reprojection_tolerance=reprojection_tolerance,
+                                           frame=frame)[0]
         if not isinstance(image_coordinates, np.ndarray):
             image_array = np.array([point.tuple for point in image_coordinates], dtype=np.float64)
             world_array = self.project_from_image(image_array,
                                                   target_height=target_height,
-                                                  reprojection_tolerance=reprojection_tolerance)
+                                                  reprojection_tolerance=reprojection_tolerance,
+                                                  frame=frame)
             return [Point3d(x=point[0], y=point[1], z=point[2]) if not np.isnan(point).any() else None for point in world_array]
 
         if len(image_coordinates) == 0:
             return np.empty((0, 3), dtype=np.float64)
 
-        world_extrinsics = self.extrinsics.resolve()
+        world_extrinsics = self.extrinsics.relative_to(frame)
         image_rays = self._points_to_rays(image_coordinates.astype(np.float64).reshape(-1, 1, 2))
         objPoints = image_rays @ world_extrinsics.rotation.matrix.T
         Z = world_extrinsics.z
@@ -315,7 +324,7 @@ class Calibration:
         # Check if the point is within the reprojection tolerance
         if reprojection_tolerance != float('inf'):
             tolerance_px = max(self.intrinsics.size.width, self.intrinsics.size.height) * reprojection_tolerance
-            reprojection = self.project_to_image(world_array)
+            reprojection = self.project_to_image(world_array, frame=frame)
             distance = np.linalg.norm(reprojection - image_coordinates.reshape(-1, 2), axis=1)
             world_array[distance > tolerance_px, :] = np.nan
 

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -210,7 +210,7 @@ def test_projection_with_custom_coordinate_frame():
         assert np.allclose(world_point.tuple, world_point_.tuple, atol=1e-6)
 
 
-def test_projection_from_one_frame_into_world_frame():
+def test_projection_with_frame_argument():
     cam, world_points = demo_data()
     assert cam.calibration is not None
 
@@ -230,69 +230,21 @@ def test_projection_from_one_frame_into_world_frame():
         assert image_point_from_world is not None
         assert np.allclose(image_point_from_frame.tuple, image_point_from_world.tuple, atol=1e-6)
 
-        world_point_ = cam.calibration.project_from_image(image_point_from_frame, target_height=world_point.z)
+        # Without ``frame`` the result is in world coordinates (legacy behavior).
+        world_point_ = cam.calibration.project_from_image(image_point_from_frame, world_point.z)
         assert world_point_ is not None
         assert np.allclose(world_point.tuple, world_point_.tuple, atol=1e-6)
 
+        # With ``frame=cam_frame`` the result is in frame-local coordinates.
+        frame_point_ = cam.calibration.project_from_image(image_point_from_frame, frame_point.z, frame=cam_frame)
+        assert frame_point_ is not None
+        assert np.allclose(frame_point.tuple, frame_point_.tuple, atol=1e-6)
 
-def test_project_from_image_into_local_frame():
-    """``project_from_image(..., frame=...)`` returns coordinates in the given frame instead of resolving to world.
-
-    Useful when the world frame is e.g. a geo frame with an imprecise origin
-    and we only care about positions relative to the robot.
-    """
-    cam, world_points = demo_data()
-    assert cam.calibration is not None
-
-    frame_registry.clear()
-    robot_frame = Pose3d(x=10.0, y=-5.0, z=0.0).as_frame('robot')
-    cam.calibration.extrinsics.in_frame(robot_frame)
-
-    # Re-attach demo points to the robot frame so they remain visible from the camera.
-    local_points = [p.in_frame(robot_frame) for p in world_points]
-    world_points = [p.resolve() for p in local_points]
-
-    for height in {p.z for p in local_points}:
-        local_at_height = [p for p in local_points if p.z == height]
-        world_at_height = [p for p in world_points if p.z == height]
-        image_points = cam.calibration.project_to_image(world_at_height)
-        assert not any(p is None for p in image_points)
-
-        # Without ``frame`` the result is in world coordinates (legacy behaviour).
-        reprojected_world = cam.calibration.project_from_image(image_points, target_height=height)
-        assert not any(p is None for p in reprojected_world)
-        assert np.allclose([p.tuple for p in world_at_height],
-                           [p.tuple for p in reprojected_world], atol=1e-6)
-
-        # With ``frame=robot_frame`` the result is in robot-local coordinates.
-        reprojected_local = cam.calibration.project_from_image(image_points, target_height=height, frame=robot_frame)
-        assert not any(p is None for p in reprojected_local)
-        assert np.allclose([p.tuple for p in local_at_height],
-                           [p.tuple for p in reprojected_local], atol=1e-6)
-
-
-def test_project_from_image_frame_propagation_through_overloads():
-    """``frame`` must be forwarded by the ``Point`` and numpy-array overloads, not only by ``list[Point]``."""
-    cam, _ = demo_data()
-    assert cam.calibration is not None
-
-    frame_registry.clear()
-    robot_frame = Pose3d(x=10.0, y=-5.0, z=0.0).as_frame('robot')
-    cam.calibration.extrinsics.in_frame(robot_frame)
-
-    local = Point3d(x=0.5, y=0.3, z=0.0).in_frame(robot_frame)
-    image_point = cam.calibration.project_to_image(local.resolve())
-    assert image_point is not None
-
-    single = cam.calibration.project_from_image(image_point, target_height=0.0, frame=robot_frame)
-    assert single is not None
-    assert np.allclose(local.tuple, single.tuple, atol=1e-6)
-
-    array_result = cam.calibration.project_from_image(np.array([image_point.tuple], dtype=np.float64),
-                                                      target_height=0.0,
-                                                      frame=robot_frame)
-    assert not np.isnan(array_result).any()
-    assert np.allclose([local.tuple], array_result, atol=1e-6)
+        # The numpy-array overload must forward ``frame`` as well.
+        image_array = np.array([image_point_from_frame.tuple], dtype=np.float64)
+        frame_array = cam.calibration.project_from_image(image_array, frame_point.z, frame=cam_frame)
+        assert not np.isnan(frame_array).any()
+        assert np.allclose([frame_point.tuple], frame_array, atol=1e-6)
 
 
 def test_fisheye_projection():

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -235,6 +235,66 @@ def test_projection_from_one_frame_into_world_frame():
         assert np.allclose(world_point.tuple, world_point_.tuple, atol=1e-6)
 
 
+def test_project_from_image_into_local_frame():
+    """``project_from_image(..., frame=...)`` returns coordinates in the given frame instead of resolving to world.
+
+    Useful when the world frame is e.g. a geo frame with an imprecise origin
+    and we only care about positions relative to the robot.
+    """
+    cam, world_points = demo_data()
+    assert cam.calibration is not None
+
+    frame_registry.clear()
+    robot_frame = Pose3d(x=10.0, y=-5.0, z=0.0).as_frame('robot')
+    cam.calibration.extrinsics.in_frame(robot_frame)
+
+    # Re-attach demo points to the robot frame so they remain visible from the camera.
+    local_points = [p.in_frame(robot_frame) for p in world_points]
+    world_points = [p.resolve() for p in local_points]
+
+    for height in {p.z for p in local_points}:
+        local_at_height = [p for p in local_points if p.z == height]
+        world_at_height = [p for p in world_points if p.z == height]
+        image_points = cam.calibration.project_to_image(world_at_height)
+        assert not any(p is None for p in image_points)
+
+        # Without ``frame`` the result is in world coordinates (legacy behaviour).
+        reprojected_world = cam.calibration.project_from_image(image_points, target_height=height)
+        assert not any(p is None for p in reprojected_world)
+        assert np.allclose([p.tuple for p in world_at_height],
+                           [p.tuple for p in reprojected_world], atol=1e-6)
+
+        # With ``frame=robot_frame`` the result is in robot-local coordinates.
+        reprojected_local = cam.calibration.project_from_image(image_points, target_height=height, frame=robot_frame)
+        assert not any(p is None for p in reprojected_local)
+        assert np.allclose([p.tuple for p in local_at_height],
+                           [p.tuple for p in reprojected_local], atol=1e-6)
+
+
+def test_project_from_image_frame_propagation_through_overloads():
+    """``frame`` must be forwarded by the ``Point`` and numpy-array overloads, not only by ``list[Point]``."""
+    cam, _ = demo_data()
+    assert cam.calibration is not None
+
+    frame_registry.clear()
+    robot_frame = Pose3d(x=10.0, y=-5.0, z=0.0).as_frame('robot')
+    cam.calibration.extrinsics.in_frame(robot_frame)
+
+    local = Point3d(x=0.5, y=0.3, z=0.0).in_frame(robot_frame)
+    image_point = cam.calibration.project_to_image(local.resolve())
+    assert image_point is not None
+
+    single = cam.calibration.project_from_image(image_point, target_height=0.0, frame=robot_frame)
+    assert single is not None
+    assert np.allclose(local.tuple, single.tuple, atol=1e-6)
+
+    array_result = cam.calibration.project_from_image(np.array([image_point.tuple], dtype=np.float64),
+                                                      target_height=0.0,
+                                                      frame=robot_frame)
+    assert not np.isnan(array_result).any()
+    assert np.allclose([local.tuple], array_result, atol=1e-6)
+
+
 def test_fisheye_projection():
     cam, world_points = demo_fisheye_data()
     assert cam.calibration is not None

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -238,7 +238,9 @@ def test_projection_with_frame_argument():
         # With ``frame=cam_frame`` the result is in frame-local coordinates.
         frame_point_ = cam.calibration.project_from_image(image_point_from_frame, frame_point.z, frame=cam_frame)
         assert frame_point_ is not None
+        assert frame_point_.frame_id == cam_frame.id
         assert np.allclose(frame_point.tuple, frame_point_.tuple, atol=1e-6)
+        assert np.allclose(world_point.tuple, frame_point_.resolve().tuple, atol=1e-6)
 
         # The numpy-array overload must forward ``frame`` as well.
         image_array = np.array([image_point_from_frame.tuple], dtype=np.float64)


### PR DESCRIPTION
### Motivation

`Calibration.project_from_image` always resolved camera extrinsics to the world frame. When the world frame is e.g. a geo frame with imprecise origin, the result inherits that inaccuracy — even when the caller only cares about positions relative to the robot.

### Implementation

Added an optional `frame: Frame3d | None = None` to `project_from_image`. When omitted, behaviour is unchanged (extrinsics resolve to world). When given, `self.extrinsics.relative_to(frame)` is used instead, so the returned coordinates are expressed in `frame`.

The parameter is forwarded through all three overloads (`Point`, `list[Point]`, `FloatArray`) and into the round-trip `project_to_image` call used by the `reprojection_tolerance` check.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).