### PR TITLE
explicitly install types required by mypy

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
       - name: pre-commit, mypy and pylint
         run: |
           uv run pre-commit run --all-files
-          uv run mypy ./rosys --non-interactive
+          uv run mypy ./rosys
           uv run pylint ./rosys
 
   pytest:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ rosys = "rosys.testing.fixtures"
 
 [dependency-groups]
 dev = [
+    {include-group = "types"},
     "autopep8>=1.5.5,<2",
     "pytest>=9.0.3,<10",  # https://github.com/zauberzeug/rosys/security/dependabot/113
     "pytest-watch>=4.2.0,<5",
@@ -68,6 +69,12 @@ dev = [
     "pre-commit>=4.0.1,<5",
     "filelock>=3.20.3,<4",  # https://github.com/zauberzeug/rosys/security/dependabot/96
     "poetry-dynamic-versioning>=1.8.0,<2",
+]
+types = [
+    "types-aiofiles>=25.1.0",
+    "types-psutil>=5.9.0,<6",
+    "types-requests>=2.32.4",
+    "types-tabulate>=0.8.9,<0.9",
 ]
 docs = [
     "mkdocs==1.5.3",
@@ -103,7 +110,6 @@ max-line-length = 120
 
 [tool.mypy]
 python_version = "3.11"
-install_types = true
 check_untyped_defs = true
 
 [[tool.mypy.overrides]]

--- a/uv.lock
+++ b/uv.lock
@@ -2720,6 +2720,10 @@ dev = [
     { name = "pytest-profiling" },
     { name = "pytest-watch" },
     { name = "sh" },
+    { name = "types-aiofiles" },
+    { name = "types-psutil" },
+    { name = "types-requests" },
+    { name = "types-tabulate" },
 ]
 docs = [
     { name = "black" },
@@ -2733,6 +2737,12 @@ docs = [
     { name = "mkdocs-pymdownx-material-extras" },
     { name = "mkdocs-section-index" },
     { name = "mkdocstrings-python" },
+]
+types = [
+    { name = "types-aiofiles" },
+    { name = "types-psutil" },
+    { name = "types-requests" },
+    { name = "types-tabulate" },
 ]
 
 [package.metadata]
@@ -2791,6 +2801,10 @@ dev = [
     { name = "pytest-profiling", specifier = ">=1.7.0,<2" },
     { name = "pytest-watch", specifier = ">=4.2.0,<5" },
     { name = "sh", specifier = ">=1.14.2,<2" },
+    { name = "types-aiofiles", specifier = ">=25.1.0" },
+    { name = "types-psutil", specifier = ">=5.9.0,<6" },
+    { name = "types-requests", specifier = ">=2.32.4" },
+    { name = "types-tabulate", specifier = ">=0.8.9,<0.9" },
 ]
 docs = [
     { name = "black" },
@@ -2804,6 +2818,12 @@ docs = [
     { name = "mkdocs-pymdownx-material-extras" },
     { name = "mkdocs-section-index" },
     { name = "mkdocstrings-python" },
+]
+types = [
+    { name = "types-aiofiles", specifier = ">=25.1.0" },
+    { name = "types-psutil", specifier = ">=5.9.0,<6" },
+    { name = "types-requests", specifier = ">=2.32.4" },
+    { name = "types-tabulate", specifier = ">=0.8.9,<0.9" },
 ]
 
 [[package]]
@@ -2946,6 +2966,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "25.1.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/42/f5b9b90162d2196f016b87228d6bf43f2c2c0c6501bfd5415001b3eb68bb/types_aiofiles-25.1.0.20260518.tar.gz", hash = "sha256:c0c95eb78755d4fa7b397d4f0332c632714dd7cd0d17f49b96e31d4d7a8d8c76", size = 14891, upload-time = "2026-05-18T06:05:27.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/3d/7a9ed9faafeae3aa3b5bc22fa5b979ff9cf3c83ecbe919b58eae07795b8c/types_aiofiles-25.1.0.20260518-py3-none-any.whl", hash = "sha256:f776bdfb4bec17f743d9ef042e61edf03bdcc7821fc08556fba9b63d873fdea9", size = 14377, upload-time = "2026-05-18T06:05:26.871Z" },
+]
+
+[[package]]
+name = "types-psutil"
+version = "5.9.5.20240516"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/41/5d3d2f7b7e819e85820eadececc121ab805c0cb4cab5d88defb0a37eabed/types-psutil-5.9.5.20240516.tar.gz", hash = "sha256:bb296f59fc56458891d0feb1994717e548a1bcf89936a2877df8792b822b4696", size = 14771, upload-time = "2024-05-16T02:21:20.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/b0/872fd0f7b3998f18447a49b0ebae95994c9f589c79443551030caa8f94f0/types_psutil-5.9.5.20240516-py3-none-any.whl", hash = "sha256:83146ded949a10167d9895e567b3b71e53ebc5e23fd8363eab62b3c76cce7b89", size = 18356, upload-time = "2024-05-16T02:21:18.398Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
+]
+
+[[package]]
+name = "types-tabulate"
+version = "0.8.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/ea/2914c9be43eecae6ddb0f10ae4b51e2f14a711d69393a6e8c8a33ac1b7c7/types-tabulate-0.8.11.tar.gz", hash = "sha256:17a5fa3b5ca453815778fc9865e8ecd0118b07b2b9faff3e2b06fe448174dd5e", size = 2645, upload-time = "2022-06-25T09:17:32.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/79/4a0608d40e0ee84461639040d124455197f73ca865e36ac685900d2be8d4/types_tabulate-0.8.11-py3-none-any.whl", hash = "sha256:af811268241e8fb87b63c052c87d1e329898a93191309d5d42111372232b2e0e", size = 2587, upload-time = "2022-06-25T09:17:31.335Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Motivation

Automatically installing types with mypy can break the dependencies in our local setup. We especially had problems with mypy installing a type package that required a different numpy version. Also the versions of the automatically installed type packages usually don't match the installed packages' versions.

### Implementation

Explicitly specify the required types and remove `--non-interactive` from the pipeline call.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
