### PR TITLE
Rtsp ntp timed image

### DIFF
--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -1,16 +1,11 @@
 import logging
-import statistics
-from collections import deque
 from typing import Any, Literal, Self
 
-from ... import rosys
 from ..camera.configurable_camera import ConfigurableCamera
 from ..camera.transformable_camera import TransformableCamera
 from ..image import Image, ImageArray
 from ..image_processing import process_ndarray_image
 from .rtsp_device import RtspDevice
-
-_JITTER_WINDOW = 30
 
 
 class RtspCamera(ConfigurableCamera, TransformableCamera):
@@ -38,7 +33,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         self.device: RtspDevice | None = None
         self.ip: str | None = ip
         self._last_image_timestamp: float | None = None
-        self._recent_deltas: deque[float] = deque(maxlen=_JITTER_WINDOW)
 
         self._register_parameter('substream', self.get_substream, self.set_substream,
                                  min_value=0, max_value=1, step=1, default_value=substream)
@@ -106,32 +100,10 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         self.device = None
 
     async def _handle_new_image_data(self, image_array: ImageArray, timestamp: float) -> None:
-        t0 = rosys.time()
-        intake_lag = t0 - timestamp
         transformed_image_array = process_ndarray_image(image_array, self.rotation, self.crop)
-        t1 = rosys.time()
         image = Image.from_array(transformed_image_array, camera_id=self.id, time=timestamp)
         self._add_image(image)
-        t2 = rosys.time()
-        if self._last_image_timestamp is not None:
-            delta = timestamp - self._last_image_timestamp
-            self._recent_deltas.append(delta)
-        else:
-            delta = 0.0
         self._last_image_timestamp = timestamp
-        self.log.info('TIMING handle-frame id=%s delta=%.3f intake_lag=%.3f process=%.3f add=%.3f',
-                      self.id, delta, intake_lag, t1 - t0, t2 - t1)
-        if len(self._recent_deltas) == _JITTER_WINDOW:
-            deltas = list(self._recent_deltas)
-            mean = statistics.fmean(deltas)
-            stddev = statistics.pstdev(deltas, mu=mean)
-            self.log.info('JITTER id=%s n=%d mean=%.3f stddev=%.3f min=%.3f max=%.3f '
-                          'fps_avg=%.2f fps_range=%.2f-%.2f',
-                          self.id, _JITTER_WINDOW, mean, stddev, min(deltas), max(deltas),
-                          1.0 / mean if mean > 0 else 0.0,
-                          1.0 / max(deltas) if max(deltas) > 0 else 0.0,
-                          1.0 / min(deltas) if min(deltas) > 0 else 0.0)
-            self._recent_deltas.clear()
 
     async def set_fps(self, fps: int) -> None:
         assert self.device is not None

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -1,11 +1,16 @@
 import logging
+import statistics
+from collections import deque
 from typing import Any, Literal, Self
 
+from ... import rosys
 from ..camera.configurable_camera import ConfigurableCamera
 from ..camera.transformable_camera import TransformableCamera
 from ..image import Image, ImageArray
 from ..image_processing import process_ndarray_image
 from .rtsp_device import RtspDevice
+
+_JITTER_WINDOW = 30
 
 
 class RtspCamera(ConfigurableCamera, TransformableCamera):
@@ -32,6 +37,8 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
         self.device: RtspDevice | None = None
         self.ip: str | None = ip
+        self._last_image_timestamp: float | None = None
+        self._recent_deltas: deque[float] = deque(maxlen=_JITTER_WINDOW)
 
         self._register_parameter('substream', self.get_substream, self.set_substream,
                                  min_value=0, max_value=1, step=1, default_value=substream)
@@ -99,9 +106,32 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         self.device = None
 
     async def _handle_new_image_data(self, image_array: ImageArray, timestamp: float) -> None:
+        t0 = rosys.time()
+        intake_lag = t0 - timestamp
         transformed_image_array = process_ndarray_image(image_array, self.rotation, self.crop)
+        t1 = rosys.time()
         image = Image.from_array(transformed_image_array, camera_id=self.id, time=timestamp)
         self._add_image(image)
+        t2 = rosys.time()
+        if self._last_image_timestamp is not None:
+            delta = timestamp - self._last_image_timestamp
+            self._recent_deltas.append(delta)
+        else:
+            delta = 0.0
+        self._last_image_timestamp = timestamp
+        self.log.info('TIMING handle-frame id=%s delta=%.3f intake_lag=%.3f process=%.3f add=%.3f',
+                      self.id, delta, intake_lag, t1 - t0, t2 - t1)
+        if len(self._recent_deltas) == _JITTER_WINDOW:
+            deltas = list(self._recent_deltas)
+            mean = statistics.fmean(deltas)
+            stddev = statistics.pstdev(deltas, mu=mean)
+            self.log.info('JITTER id=%s n=%d mean=%.3f stddev=%.3f min=%.3f max=%.3f '
+                          'fps_avg=%.2f fps_range=%.2f-%.2f',
+                          self.id, _JITTER_WINDOW, mean, stddev, min(deltas), max(deltas),
+                          1.0 / mean if mean > 0 else 0.0,
+                          1.0 / max(deltas) if max(deltas) > 0 else 0.0,
+                          1.0 / min(deltas) if min(deltas) > 0 else 0.0)
+            self._recent_deltas.clear()
 
     async def set_fps(self, fps: int) -> None:
         assert self.device is not None

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -163,15 +163,9 @@ class RtspDevice:
             pipeline_delay_warned = False
 
             # Maps gst running-time PTS (ns) -> on-wire 32-bit RTP timestamp.
-            # The wrap window is chosen once so rtp_ts / 90 lands near host
-            # wall-clock now; per-frame lookup then gives wall-clock directly,
-            # independent of any gst PTS drift between tee branches.
             pts_to_rtp_ts: dict[int, int] = {}
-            k_wrap: int | None = None
-            wrap_ms = (1 << 32) / 90
 
             async def consume_rtp() -> None:
-                nonlocal k_wrap
                 while True:
                     try:
                         pkt = await GDPPacket.read(rtp_reader)
@@ -185,10 +179,6 @@ class RtspDevice:
                         continue
                     rtp_ts = int.from_bytes(pkt.payload[4:8], 'big')
                     pts_to_rtp_ts[pkt.pts_ns] = rtp_ts
-                    if k_wrap is None:
-                        base_ms = rtp_ts / 90.0
-                        k_wrap = round((rosys.time() * 1000 - base_ms) / wrap_ms)
-                        self.log.info('[%s] RTP wrap anchor: rtp_ts=%d k=%d', self._mac, rtp_ts, k_wrap)
                     if len(pts_to_rtp_ts) > 1000:
                         for old in sorted(pts_to_rtp_ts)[:500]:
                             del pts_to_rtp_ts[old]
@@ -220,8 +210,15 @@ class RtspDevice:
                         frame = np.frombuffer(packet.payload, dtype=np.uint8).reshape(height, width, 3)
 
                         rtp_ts = pts_to_rtp_ts.get(packet.pts_ns) if packet.pts_ns != GST_CLOCK_TIME_NONE else None
-                        if rtp_ts is not None and k_wrap is not None:
-                            capture_time = (rtp_ts / 90.0 + k_wrap * wrap_ms) / 1000
+                        if rtp_ts is not None:
+                            # Per-frame wrap-window pick: the rtp_ts represents a
+                            # camera wall-clock moment within seconds of "now", so
+                            # the closest 13.25 h wrap window to rosys.time() is
+                            # always the right one.
+                            base_ms = rtp_ts / 90.0
+                            wrap_ms = (1 << 32) / 90
+                            k = round((rosys.time() * 1000 - base_ms) / wrap_ms)
+                            capture_time = (base_ms + k * wrap_ms) / 1000
                             # The rtp_ts carries vendor-stamped time at VENC output,
                             # which is delayed from actual sensor latch by the
                             # camera-side pipeline (VPE + 3DNR + FRAMEBASE queue +

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 import shlex
 import signal
@@ -20,6 +21,15 @@ from ... import rosys
 from ...vision.image import ImageArray
 from .jovision_rtsp_interface import JovisionInterface
 from .vendors import VendorType, mac_to_url, mac_to_vendor
+
+# Camera-side pipeline delay from sensor frame latch to vendor pack_ts
+# assignment at VENC output. The on-wire RTP timestamp encodes this
+# downstream-of-sensor moment, so to recover sensor-side wall-clock we
+# subtract this constant from the decoded RTP-based timestamp.
+
+# Measured 2026-05-20 with calibrate_pipeline_delay.py script.
+CAMERA_PIPELINE_DELAY_S: float = 0.0985
+CAMERA_PIPELINE_DELAY_CALIBRATED_AT: tuple[int, int] = (1280, 960)
 
 
 class RtspDevice:
@@ -112,88 +122,156 @@ class RtspDevice:
         async def stream() -> AsyncGenerator[tuple[ImageArray, float], None]:
             url = self.url
             self.log.debug('[%s] Starting gstreamer pipeline for %s', self._mac, url)
-            # to try: replace avdec_h264 with nvh264dec ! nvvidconv (!videoconvert)
-            command = f'gst-launch-1.0 --quiet rtspsrc location="{url}" latency=20 buffer-mode=slave protocols=tcp ! rtp{self._avdec}depay ! avdec_{self._avdec} ! videoconvert ! video/x-raw,format=RGB ! queue max-size-buffers=1 leaky=downstream ! gdppay ! fdsink sync=false'
+
+            # Second pipe in addition to stdout, see below.
+            rtp_r_fd, rtp_w_fd = os.pipe()
+
+            # tee splits the rtspsrc output: one branch decodes to RGB (the
+            # existing path); the other forwards application/x-rtp buffers
+            # so the per-frame on-wire RTP timestamp survives to user space.
+            command = (
+                f'gst-launch-1.0 --quiet '
+                f'rtspsrc location="{url}" latency=20 buffer-mode=slave protocols=udp '
+                f'! tee name=t '
+                f't. ! queue max-size-buffers=200 max-size-bytes=10485760 max-size-time=1000000000 '
+                f'! rtp{self._avdec}depay ! avdec_{self._avdec} ! videoconvert '
+                f'! video/x-raw,format=RGB ! queue max-size-buffers=2 leaky=downstream '
+                f'! gdppay ! fdsink fd=1 sync=false '
+                f't. ! queue max-size-buffers=200 max-size-bytes=10485760 max-size-time=1000000000 '
+                f'! gdppay ! fdsink fd={rtp_w_fd} sync=false'
+            )
             self.log.debug('[%s] Running command: %s', self._mac, command)
             process = await asyncio.create_subprocess_exec(
                 *shlex.split(command),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                pass_fds=(rtp_w_fd,),
             )
+            os.close(rtp_w_fd)
             assert process.stdout is not None
             assert process.stderr is not None
             self._capture_process = process
 
-            width = None
-            height = None
-            anchor_pts_ns: int | None = None
-            anchor_rosys_time: float | None = None
-            last_yield_time: float | None = None
-            while process.returncode is None:
-                assert process.stdout is not None
+            loop = asyncio.get_running_loop()
+            rtp_reader = asyncio.StreamReader(limit=2**20)
+            rtp_pipe = os.fdopen(rtp_r_fd, 'rb', buffering=0)
+            await loop.connect_read_pipe(
+                lambda: asyncio.StreamReaderProtocol(rtp_reader),
+                rtp_pipe,
+            )
 
-                try:
-                    packet = await GDPPacket.read(process.stdout)
-                except asyncio.exceptions.IncompleteReadError:
-                    break
+            pipeline_delay_warned = False
 
-                if packet.payload_type == GDPPayloadType.CAPS:
-                    cap_text = packet.payload.decode('utf-8', 'ignore')
+            # Maps gst running-time PTS (ns) -> on-wire 32-bit RTP timestamp.
+            # The wrap window is chosen once so rtp_ts / 90 lands near host
+            # wall-clock now; per-frame lookup then gives wall-clock directly,
+            # independent of any gst PTS drift between tee branches.
+            pts_to_rtp_ts: dict[int, int] = {}
+            k_wrap: int | None = None
+            wrap_ms = (1 << 32) / 90
 
-                    w = GDP_CAPS_WIDTH_REGEX.search(cap_text)
-                    h = GDP_CAPS_HEIGHT_REGEX.search(cap_text)
+            async def consume_rtp() -> None:
+                nonlocal k_wrap
+                while True:
+                    try:
+                        pkt = await GDPPacket.read(rtp_reader)
+                    except asyncio.IncompleteReadError:
+                        return
+                    if pkt.payload_type != GDPPayloadType.BUFFER:
+                        continue
+                    if pkt.pts_ns == GST_CLOCK_TIME_NONE or len(pkt.payload) < 12:
+                        continue
+                    if pkt.pts_ns in pts_to_rtp_ts:
+                        continue
+                    rtp_ts = int.from_bytes(pkt.payload[4:8], 'big')
+                    pts_to_rtp_ts[pkt.pts_ns] = rtp_ts
+                    if k_wrap is None:
+                        base_ms = rtp_ts / 90.0
+                        k_wrap = round((rosys.time() * 1000 - base_ms) / wrap_ms)
+                        self.log.info('[%s] RTP wrap anchor: rtp_ts=%d k=%d', self._mac, rtp_ts, k_wrap)
+                    if len(pts_to_rtp_ts) > 1000:
+                        for old in sorted(pts_to_rtp_ts)[:500]:
+                            del pts_to_rtp_ts[old]
 
-                    assert w is not None and h is not None
-                    assert len(w.groups()) == 1
-                    assert len(h.groups()) == 1
-
-                    width = int(w.group(1))
-                    height = int(h.group(1))
-
-                elif packet.payload_type == GDPPayloadType.BUFFER:
-                    assert width is not None and height is not None
-
-                    assert width * height * 3 == len(packet.payload)
-                    frame = np.frombuffer(packet.payload, dtype=np.uint8).reshape(height, width, 3)
-
-                    if packet.pts_ns != GST_CLOCK_TIME_NONE:
-                        if anchor_pts_ns is None:
-                            anchor_pts_ns = packet.pts_ns
-                            anchor_rosys_time = rosys.time()
-                        assert anchor_rosys_time is not None
-                        capture_time = anchor_rosys_time + (packet.pts_ns - anchor_pts_ns) / 1e9
-                    else:
-                        capture_time = rosys.time()
-                    self.log.info('TIMING raw-pts mac=%s pts_ns_raw=0x%016x is_none=%s',
-                                  self._mac, packet.pts_ns,
-                                  packet.pts_ns == GST_CLOCK_TIME_NONE)
-
-                    delta = capture_time - last_yield_time if last_yield_time is not None else 0.0
-                    last_yield_time = capture_time
-                    pts_relative_s = (packet.pts_ns - anchor_pts_ns) / 1e9 if anchor_pts_ns is not None else 0.0
-                    self.log.info('TIMING gstreamer-yield mac=%s delta=%.3f size=%dx%d pts_age=%.3f pts=%.6f',
-                                  self._mac, delta, width, height,
-                                  rosys.time() - capture_time, pts_relative_s)
-                    yield frame, capture_time
+            rtp_task = asyncio.create_task(consume_rtp(), name=f'rtp-ts {self._mac}')
 
             try:
-                await asyncio.wait_for(process.wait(), timeout=5)
-            except TimeoutError:
-                self.log.warning(
-                    '[%s] Stream ended. Timeout while waiting for gstreamer process to terminate', self._mac)
-                return
+                width = None
+                height = None
+                while process.returncode is None:
+                    try:
+                        packet = await GDPPacket.read(process.stdout)
+                    except asyncio.exceptions.IncompleteReadError:
+                        break
 
-            return_code = process.returncode
-            if return_code == -1 * signal.SIGTERM:
-                self.log.debug('gstreamer process %s was terminated using SIGTERM', process.pid)
-            else:
-                error = await process.stderr.read()
-                error_message = error.decode()
-                self.log.error('gstreamer process %s exited with code %s.\nstderr: %s',
-                               process.pid, return_code, error_message)
+                    if packet.payload_type == GDPPayloadType.CAPS:
+                        cap_text = packet.payload.decode('utf-8', 'ignore')
+                        w = GDP_CAPS_WIDTH_REGEX.search(cap_text)
+                        h = GDP_CAPS_HEIGHT_REGEX.search(cap_text)
+                        assert w is not None and h is not None
+                        assert len(w.groups()) == 1
+                        assert len(h.groups()) == 1
+                        width = int(w.group(1))
+                        height = int(h.group(1))
 
-                if 'Unauthorized' in error_message:
-                    self._authorized = False
+                    elif packet.payload_type == GDPPayloadType.BUFFER:
+                        assert width is not None and height is not None
+                        assert width * height * 3 == len(packet.payload)
+                        frame = np.frombuffer(packet.payload, dtype=np.uint8).reshape(height, width, 3)
+
+                        rtp_ts = pts_to_rtp_ts.get(packet.pts_ns) if packet.pts_ns != GST_CLOCK_TIME_NONE else None
+                        if rtp_ts is not None and k_wrap is not None:
+                            capture_time = (rtp_ts / 90.0 + k_wrap * wrap_ms) / 1000
+                            # The rtp_ts carries vendor-stamped time at VENC output,
+                            # which is delayed from actual sensor latch by the
+                            # camera-side pipeline (VPE + 3DNR + FRAMEBASE queue +
+                            # encode). Subtract the measured delay to recover the
+                            # moment the sensor captured the frame. The constant
+                            # was calibrated for one specific resolution; if the
+                            # stream resolution differs, the delay differs too, so
+                            # we only apply the offset when the resolution matches.
+                            if (width, height) == CAMERA_PIPELINE_DELAY_CALIBRATED_AT:
+                                capture_time -= CAMERA_PIPELINE_DELAY_S
+                            elif not pipeline_delay_warned:
+                                pipeline_delay_warned = True
+                                self.log.warning(
+                                    '[%s] stream %dx%d does not match calibrated '
+                                    '%dx%d; skipping pipeline-delay correction. '
+                                    'Re-run utils/calibrate_pipeline_delay.py for this resolution.',
+                                    self._mac, width, height,
+                                    *CAMERA_PIPELINE_DELAY_CALIBRATED_AT)
+                        else:
+                            # RTP packet for this frame not yet seen on the second
+                            # branch (typical for the first frame, or if the RTP
+                            # branch is briefly behind); fall back to receive time.
+                            self.log.info('[%s] using rosys time for frame', self._mac)
+                            capture_time = rosys.time()
+                        yield frame, capture_time
+
+                try:
+                    await asyncio.wait_for(process.wait(), timeout=5)
+                except TimeoutError:
+                    self.log.warning(
+                        '[%s] Stream ended. Timeout while waiting for gstreamer process to terminate', self._mac)
+                    return
+
+                return_code = process.returncode
+                if return_code == -1 * signal.SIGTERM:
+                    self.log.debug('gstreamer process %s was terminated using SIGTERM', process.pid)
+                else:
+                    error = await process.stderr.read()
+                    error_message = error.decode()
+                    self.log.error('gstreamer process %s exited with code %s.\nstderr: %s',
+                                   process.pid, return_code, error_message)
+
+                    if 'Unauthorized' in error_message:
+                        self._authorized = False
+            finally:
+                rtp_task.cancel()
+                try:
+                    await rtp_task
+                except asyncio.CancelledError:
+                    pass
 
         async for image, timestamp in stream():
             result = self._on_new_image_data(image, timestamp)

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -109,11 +109,11 @@ class RtspDevice:
             self.log.warning('[%s] capture process already running', self._mac)
             return
 
-        async def stream() -> AsyncGenerator[ImageArray, None]:
+        async def stream() -> AsyncGenerator[tuple[ImageArray, float], None]:
             url = self.url
             self.log.debug('[%s] Starting gstreamer pipeline for %s', self._mac, url)
             # to try: replace avdec_h264 with nvh264dec ! nvvidconv (!videoconvert)
-            command = f'gst-launch-1.0 --quiet rtspsrc location="{url}" latency=0 protocols=tcp ! rtp{self._avdec}depay ! avdec_{self._avdec} ! videoconvert ! video/x-raw,format=RGB ! queue max-size-buffers=1 leaky=downstream ! gdppay ! fdsink sync=false'
+            command = f'gst-launch-1.0 --quiet rtspsrc location="{url}" latency=20 buffer-mode=slave protocols=tcp ! rtp{self._avdec}depay ! avdec_{self._avdec} ! videoconvert ! video/x-raw,format=RGB ! queue max-size-buffers=1 leaky=downstream ! gdppay ! fdsink sync=false'
             self.log.debug('[%s] Running command: %s', self._mac, command)
             process = await asyncio.create_subprocess_exec(
                 *shlex.split(command),
@@ -126,6 +126,9 @@ class RtspDevice:
 
             width = None
             height = None
+            anchor_pts_ns: int | None = None
+            anchor_rosys_time: float | None = None
+            last_yield_time: float | None = None
             while process.returncode is None:
                 assert process.stdout is not None
 
@@ -153,7 +156,25 @@ class RtspDevice:
                     assert width * height * 3 == len(packet.payload)
                     frame = np.frombuffer(packet.payload, dtype=np.uint8).reshape(height, width, 3)
 
-                    yield frame
+                    if packet.pts_ns != GST_CLOCK_TIME_NONE:
+                        if anchor_pts_ns is None:
+                            anchor_pts_ns = packet.pts_ns
+                            anchor_rosys_time = rosys.time()
+                        assert anchor_rosys_time is not None
+                        capture_time = anchor_rosys_time + (packet.pts_ns - anchor_pts_ns) / 1e9
+                    else:
+                        capture_time = rosys.time()
+                    self.log.info('TIMING raw-pts mac=%s pts_ns_raw=0x%016x is_none=%s',
+                                  self._mac, packet.pts_ns,
+                                  packet.pts_ns == GST_CLOCK_TIME_NONE)
+
+                    delta = capture_time - last_yield_time if last_yield_time is not None else 0.0
+                    last_yield_time = capture_time
+                    pts_relative_s = (packet.pts_ns - anchor_pts_ns) / 1e9 if anchor_pts_ns is not None else 0.0
+                    self.log.info('TIMING gstreamer-yield mac=%s delta=%.3f size=%dx%d pts_age=%.3f pts=%.6f',
+                                  self._mac, delta, width, height,
+                                  rosys.time() - capture_time, pts_relative_s)
+                    yield frame, capture_time
 
             try:
                 await asyncio.wait_for(process.wait(), timeout=5)
@@ -174,8 +195,7 @@ class RtspDevice:
                 if 'Unauthorized' in error_message:
                     self._authorized = False
 
-        async for image in stream():
-            timestamp = rosys.time()
+        async for image, timestamp in stream():
             result = self._on_new_image_data(image, timestamp)
             if isinstance(result, Awaitable):
                 await result
@@ -224,23 +244,42 @@ class GDPPayloadType(Enum):
     EVENT_NONE = 3
 
 
-# See https://maemo.org/api_refs/5.0/5.0-final/gstreamer-libs-0.10/gstreamer-libs-gstdataprotocol.html for header format
+# GDP header layout (gst-plugins-bad 1.x):
+# 0-1   version
+# 2     flags
+# 3     padding
+# 4-5   payload type (1=BUFFER, 2=CAPS, large for events)
+# 6-9   payload length
+# 10-17 PTS (uint64 nanoseconds, GST_CLOCK_TIME_NONE if unset)
+# 18-25 DTS or duration (we don't currently use either)
+# 26-33 reserved/other (typically GST_CLOCK_TIME_NONE)
+# 34-41 reserved/other (typically GST_CLOCK_TIME_NONE)
+# 42-43 buffer flags
+# 44-57 ABI padding
+# 58-59 CRC header
+# 60-61 CRC payload
 GDPPACKET_FORMAT = struct.Struct('>HcxHIQQQQH14sHH')
 GDP_CAPS_WIDTH_REGEX = re.compile(r'width=\(int\)\s*(\d+)')
 GDP_CAPS_HEIGHT_REGEX = re.compile(r'height=\(int\)\s*(\d+)')
 GDP_HEADER_SIZE = 62
 
 
+GST_CLOCK_TIME_NONE = 0xFFFFFFFFFFFFFFFF
+
+
 @dataclass(slots=True, kw_only=True)
 class GDPPacket:
     payload_type: GDPPayloadType
     payload: bytes
+    pts_ns: int  # presentation timestamp in nanoseconds, or GST_CLOCK_TIME_NONE if absent
 
     @staticmethod
     async def read(stream: asyncio.StreamReader) -> GDPPacket:
         header_bytes = await stream.readexactly(GDP_HEADER_SIZE)
-        _version, _flags, gdp_type, length, *_ = GDPPACKET_FORMAT.unpack(header_bytes)
+        _version, _flags, gdp_type, length, pts, _q1, _q2, _q3, *_ = \
+            GDPPACKET_FORMAT.unpack(header_bytes)
         return GDPPacket(
             payload_type=GDPPayloadType(gdp_type) if gdp_type < 3 else GDPPayloadType.EVENT_NONE,
             payload=await stream.readexactly(length),
+            pts_ns=pts,
         )


### PR DESCRIPTION
### Motivation

We want precise timing of camera frames to match them to the robot pose.

### Implementation

Relies on [divinius](https://github.com/zauberzeug/divinus/pull/9) to provide ntp-time information encoded in the rtsp timestamp. The timestamp wraps roughly every 13 hours, but we snap it to the closest rosys time (camera time should never be >13 hours off). Note that it requires an additional camera-specific offset for true timing that requires external calibration and so far has only been done for a specific camera with specific resolution, so this requires some more cleanup.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
