### PR TITLE
Add VELOCITY_COMMANDED and CORE_MESSAGE_RECEIVED events for MCAP logging

### DIFF
--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -38,6 +38,8 @@ class RobotBrain:
         """a line has been received from the microcontroller (argument: line as string)"""
         self.FLASH_P0_COMPLETE = Event[[]]()
         """flashing p0 was successful and 'Replica complete' was received"""
+        self.CORE_MESSAGE_RECEIVED = Event[float]()
+        """a core message was received (argument: hardware millis timestamp)"""
 
         self.log = logging.getLogger('rosys.robot_brain')
 
@@ -209,6 +211,7 @@ class RobotBrain:
             hardware_time: float | None = None
             if first == 'core':
                 millis = float(words.pop(0))
+                self.CORE_MESSAGE_RECEIVED.emit(millis)
                 if self.clock_offset is None:
                     continue
                 hardware_time = millis / 1000 + self.clock_offset

--- a/rosys/hardware/wheels.py
+++ b/rosys/hardware/wheels.py
@@ -23,6 +23,9 @@ class Wheels(Module, abc.ABC):
         self.VELOCITY_MEASURED = Event[list[Velocity]]()
         """the wheel velocities have been measured (argument: list of ``Velocity`` objects)"""
 
+        self.VELOCITY_COMMANDED = Event[Velocity]()
+        """a drive command has been issued (argument: ``Velocity`` with commanded linear/angular speeds)"""
+
         self.linear_target_speed: float = 0.0
         self.angular_target_speed: float = 0.0
 
@@ -32,6 +35,7 @@ class Wheels(Module, abc.ABC):
     async def drive(self, linear: float, angular: float) -> None:
         self.linear_target_speed = linear
         self.angular_target_speed = angular
+        self.VELOCITY_COMMANDED.emit(Velocity(linear=linear, angular=angular, time=rosys.time()))
 
     async def stop(self) -> None:
         await self.drive(0.0, 0.0)


### PR DESCRIPTION
### Motivation

The MCAP sensor data logger lives in the [feldfreund](https://github.com/zauberzeug/feldfreund) repo, not in RoSys. To record commanded velocities and align messages with the microcontroller clock, that logger needs two events that RoSys does not currently expose. This PR adds only those events, keeping RoSys changes minimal; all MCAP recording logic stays in feldfreund.

### Implementation

- New `VELOCITY_COMMANDED` event on `Wheels`, emitted in `drive()` with the commanded `Velocity` (linear/angular speeds).
- New `CORE_MESSAGE_RECEIVED` event on `RobotBrain`, emitted in `read_lines()` with the hardware millis timestamp of each `core` message.

Net change: +7 lines across `rosys/hardware/wheels.py` and `rosys/hardware/robot_brain.py`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
