### PR TITLE
Mirror hardware GNSS latency in the simulation

### DIFF
--- a/rosys/hardware/gnss/gnss_simulation.py
+++ b/rosys/hardware/gnss/gnss_simulation.py
@@ -62,18 +62,20 @@ class GnssSimulation(Gnss):
         noise_point = geo_pose.point.polar(noise_magnitude, noise_direction)
         noise_heading = np.random.normal(geo_pose.heading, math.radians(self._heading_std_dev))
         noise_pose = GeoPose(lat=noise_point.lat, lon=noise_point.lon, heading=noise_heading)
-        timestamp = rosys.time()
+        fix_time = rosys.time()  # the measurement reflects the pose at this epoch
+        if self._latency:
+            await rosys.sleep(self._latency)
+        # mirror the hardware: ``time`` is the arrival epoch (now), ``gnss_time`` the fix epoch,
+        # so ``measurement.age`` carries the latency just as it does on a real receiver
         self.last_measurement = GnssMeasurement(
-            time=timestamp,
-            gnss_time=timestamp,
+            time=rosys.time(),
+            gnss_time=fix_time,
             pose=noise_pose,
             latitude_std_dev=self._lat_std_dev,
             longitude_std_dev=self._lon_std_dev,
             heading_std_dev=self._heading_std_dev,
             gps_quality=self._gps_quality,
         )
-        if self._latency:
-            await rosys.sleep(self._latency)
         self.NEW_MEASUREMENT.emit(self.last_measurement)
 
     def developer_ui(self) -> None:


### PR DESCRIPTION
### Motivation

`GnssSimulation` stamped both `time` and `gnss_time` at the same instant (before the latency sleep), so `GnssMeasurement.age` was always ~0. Simulated GNSS therefore never modelled the receiver's transmission latency, and latency-aware consumers (e.g. out-of-sequence GNSS fusion) plus their tests could not be exercised faithfully in simulation.

### Implementation

- Sample the fix epoch *before* the latency sleep and stamp `gnss_time` with it.
- Stamp `time` at emission (*after* the sleep) — the arrival epoch — mirroring `GnssHardware._parse_measurement`.
- Net effect: `measurement.age` (= `gnss_time − now`) now carries the configured `_latency`, exactly as on real hardware.
- Risk: any simulation consumer relying on `measurement.time` being the pre-latency timestamp now sees the arrival time instead.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8[1m]
