### PR TITLE
Add AGENTS.md and CLAUDE.md for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AI Agent Guidelines for RoSys
+
+This file gives AI assistants project-specific behavioral guidance for working on RoSys.
+For human-facing contribution conventions, see [CONTRIBUTING.md](CONTRIBUTING.md).
+For what RoSys is and how the pieces fit together, start with [README.md](README.md) and the [documentation](https://rosys.io/).
+
+## Orient before you touch code
+
+RoSys is a robotics framework, not a typical web app. A few facts shape almost everything:
+
+- **Single asyncio event loop, built on NiceGUI.** Robot logic runs cooperatively on one loop — blocking it stalls the whole robot. Heavy work goes through `rosys.run.cpu_bound`/`io_bound`, and a few subsystems run their own process (e.g. path planning's `PlannerProcess`). Any multiprocessing must use the `spawn` start method: RoSys sets it under `if __name__ == '__main__'` and **asserts** it at startup, so an imported app with the wrong method fails fast rather than being auto-corrected.
+- **Two brains.** Time-critical and safety-critical logic (motor control, E-stop, bump-stop) lives on the microcontroller as [Lizard](https://lizard.dev/) code (the "Robot Brain"); Python orchestrates and reacts. Python requests, the microcontroller decides.
+- **Simulation-first.** Most robot-facing modules have a simulation twin, so you develop and test against simulation with accelerated time and no physical robot. (Pure support modules like `CanHardware`, `SerialHardware` and `ExpanderHardware` are hardware-only — no twin.) Make it work in simulation before you reach for hardware.
+
+## Pair programming
+
+- **Research before guessing.** This codebase is conventions-first — grep for a similar module and copy its shape rather than inventing a new one.
+- **Discuss trade-offs** when the design is unclear instead of silently picking one, and break large changes into reviewable steps.
+
+## RoSys golden rules (easy to get wrong)
+
+- **Time:** for RoSys-time delays use `await rosys.sleep(seconds)` and `rosys.time()` — they honor simulated/accelerated time so tests can fast-forward. Never `time.sleep()`, and don't use `asyncio.sleep()` for robot-time waits. (`asyncio.sleep()` is fine for plain event-loop yielding or wall-clock polling, as RoSys itself does in path planning and automation.) `rosys.set_time()` is tests-only.
+- **Lifecycle:** register with `rosys.on_startup` / `rosys.on_shutdown` / `rosys.on_repeat`, **not** NiceGUI's `app.on_startup`. `rosys.on_startup` runs *after* persisted state is restored (each `Persistable` restores itself when `.persistent()` is called), so configuring through `app.on_startup` lets the restored state overwrite whatever you set (see the README note). Note `on_repeat` waits one interval before its first call — it is not immediate.
+- **Don't block the loop:** wrap CPU-heavy work in `await rosys.run.cpu_bound(...)` and blocking I/O in `await rosys.run.io_bound(...)`. Both return `R | None` — `None` when the app is shutting down or the call is cancelled, so guard the result. `cpu_bound` runs in a *spawned* subprocess, so its callback and arguments must be picklable (module-level functions, no closures or `self`).
+- **Events** are typed `Event[T]` with `.emit()` / `.subscribe()` (imported from `nicegui`, not defined in `rosys` — grepping the `rosys` package for `class Event` finds nothing); event names are `SCREAMING_SNAKE_CASE` (e.g. `VELOCITY_MEASURED`).
+
+## Hardware modules: keep the Hardware/Simulation pair intact
+
+A robot-facing hardware subsystem is usually a triplet — keep the symmetry so simulation and tests keep working:
+
+1. an **abstract base** defining the interface and events,
+2. a **`*Hardware`** class that talks to the Robot Brain (emits Lizard code, parses sensor data in `handle_core_output`), and
+3. a **`*Simulation`** class that updates state in `step(dt)` without any hardware.
+
+Use an existing module such as `rosys/hardware/wheels.py` or `rosys/hardware/bumper.py` as the blueprint, and export all three. Note this is a *convention*, not universal: pure support modules (`Can`, `Serial`, `Expander`) are hardware-only. `RobotSimulation` casts its modules to `ModuleSimulation`, so don't add a hardware-only module to a simulated robot.
+
+## Safety boundary — do not casually cross
+
+- Safety- and timing-critical actuator logic belongs in Lizard on the microcontroller, which continuously enforces the safety conditions and performs the time-critical control. Python may request actions via `robot_brain.send(...)`, but must not bypass the microcontroller or drive hardware directly.
+- The Lizard *startup script* is assembled from each module's `lizard_code` by `RobotHardware.generate_lizard_code()` and uploaded via `robot_brain.configure()`, which restarts the brain to apply it. This is config/startup-script upload, **not** firmware flashing (that is `lizard_firmware.flash_core()` / `flash_p0()`). Don't expect to live-tweak it; changing module composition means regenerating and re-configuring.
+
+## Testing
+
+- pytest with `pytest-asyncio` in `asyncio_mode = "auto"` — tests are plain `async def`, no decorator needed.
+- Develop against the `*Simulation` classes and the helpers in `rosys.testing`: `forward(seconds=...)` to advance accelerated time, or `forward(x=..., y=...)` / `forward(until=...)` to run until the robot arrives or a condition holds, plus `assert_pose(...)` and `approx(...)` (a deep dataclass-equality helper, not `pytest.approx`). See `tests/test_robot.py` and `tests/test_time.py` for the idiom.
+- Add tests for new functionality. Run a single test with `uv run pytest tests/test_<x>.py::test_<y>`.
+
+## Before you call it done
+
+Run the same gates CI runs (`.github/workflows/pytest.yml` is the source of truth):
+
+```bash
+uv run pre-commit run --all-files       # ruff --fix (+ import sort), autopep8 (120 cols), single quotes, codespell, mdformat
+uv run mypy ./rosys                      # not part of pre-commit — run it explicitly
+uv run pylint ./rosys                    # not part of pre-commit — run it explicitly
+uv run pytest
+cd tests && uv run ./test_examples.py    # CI also smoke-runs the examples
+```
+
+CI runs these across Python 3.11, 3.12 and 3.13 — don't rely on syntax or deps available in only one of them.
+
+## House style
+
+- Single quotes and f-strings (mark the rare performance-driven exception with a `# NOTE:` comment), `int | None` over `Optional[int]`, 120-column lines.
+- `@dataclass(slots=True, kw_only=True)` for value types; match the surrounding file's (sparse) docstring and comment density — prefer clear names over comments.
+- In Markdown and docs, write one sentence per line; keep examples in `docs/examples` minimal and focused on a single concept.
+
+## What to avoid
+
+- Blocking the event loop, or `time.sleep` / `asyncio.sleep` in robot code.
+- Overwriting persisted state by configuring through `app.on_startup` instead of `rosys.on_startup`.
+- Breaking the Hardware/Simulation symmetry (a feature that only works on real hardware).
+- Creating new files when editing an existing one suffices; adding unnecessary dependencies.
+
+## Pull requests
+
+Use the repository's [PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md), describe the motivation and implementation, include tests for new features, and make sure the gates above pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,22 +6,38 @@ For what RoSys is and how the pieces fit together, start with [README.md](README
 
 ## Orient before you touch code
 
-RoSys is a robotics framework, not a typical web app. A few facts shape almost everything:
+RoSys is a robotics framework, not a typical web app.
+A few facts shape almost everything:
 
-- **Single asyncio event loop, built on NiceGUI.** Robot logic runs cooperatively on one loop — blocking it stalls the whole robot. Heavy work goes through `rosys.run.cpu_bound`/`io_bound`, and a few subsystems run their own process (e.g. path planning's `PlannerProcess`). Any multiprocessing must use the `spawn` start method: RoSys sets it under `if __name__ == '__main__'` and **asserts** it at startup, so an imported app with the wrong method fails fast rather than being auto-corrected.
-- **Two brains.** Time-critical and safety-critical logic (motor control, E-stop, bump-stop) lives on the microcontroller as [Lizard](https://lizard.dev/) code (the "Robot Brain"); Python orchestrates and reacts. Python requests, the microcontroller decides.
-- **Simulation-first.** Most robot-facing modules have a simulation twin, so you develop and test against simulation with accelerated time and no physical robot. (Pure support modules like `CanHardware`, `SerialHardware` and `ExpanderHardware` are hardware-only — no twin.) Make it work in simulation before you reach for hardware.
+- **Single asyncio event loop, built on NiceGUI.**
+  Robot logic runs cooperatively on one loop — blocking it stalls the whole robot.
+  Heavy work goes through `rosys.run.cpu_bound`/`io_bound`, and a few subsystems run their own process (e.g. path planning's `PlannerProcess`).
+  Any multiprocessing must use the `spawn` start method: RoSys sets it under `if __name__ == '__main__'` and **asserts** it at startup, so an imported app with the wrong method fails fast rather than being auto-corrected.
+- **Two brains.**
+  Time-critical and safety-critical logic (motor control, E-stop, bump-stop) lives on the microcontroller as [Lizard](https://lizard.dev/) code (the "Robot Brain"); Python orchestrates and reacts.
+  Python requests, the microcontroller decides.
+- **Simulation-first.** Most robot-facing modules have a simulation twin, so you develop and test against simulation with accelerated time and no physical robot.
+  (Pure support modules like `CanHardware`, `SerialHardware` and `ExpanderHardware` are hardware-only — no twin.)
+  Make it work in simulation before you reach for hardware.
 
 ## Pair programming
 
-- **Research before guessing.** This codebase is conventions-first — grep for a similar module and copy its shape rather than inventing a new one.
+- **Research before guessing.**
+  This codebase is conventions-first — grep for a similar module and copy its shape rather than inventing a new one.
 - **Discuss trade-offs** when the design is unclear instead of silently picking one, and break large changes into reviewable steps.
 
 ## RoSys golden rules (easy to get wrong)
 
-- **Time:** for RoSys-time delays use `await rosys.sleep(seconds)` and `rosys.time()` — they honor simulated/accelerated time so tests can fast-forward. Never `time.sleep()`, and don't use `asyncio.sleep()` for robot-time waits. (`asyncio.sleep()` is fine for plain event-loop yielding or wall-clock polling, as RoSys itself does in path planning and automation.) `rosys.set_time()` is tests-only.
-- **Lifecycle:** register with `rosys.on_startup` / `rosys.on_shutdown` / `rosys.on_repeat`, **not** NiceGUI's `app.on_startup`. `rosys.on_startup` runs *after* persisted state is restored (each `Persistable` restores itself when `.persistent()` is called), so configuring through `app.on_startup` lets the restored state overwrite whatever you set (see the README note). Note `on_repeat` waits one interval before its first call — it is not immediate.
-- **Don't block the loop:** wrap CPU-heavy work in `await rosys.run.cpu_bound(...)` and blocking I/O in `await rosys.run.io_bound(...)`. Both return `R | None` — `None` when the app is shutting down or the call is cancelled, so guard the result. `cpu_bound` runs in a *spawned* subprocess, so its callback and arguments must be picklable (module-level functions, no closures or `self`).
+- **Time:** for RoSys-time delays use `await rosys.sleep(seconds)` and `rosys.time()` — they honor simulated/accelerated time so tests can fast-forward.
+  Never `time.sleep()`, and don't use `asyncio.sleep()` for robot-time waits.
+  (`asyncio.sleep()` is fine for plain event-loop yielding or wall-clock polling, as RoSys itself does in path planning and automation.)
+  `rosys.set_time()` is tests-only.
+- **Lifecycle:** register with `rosys.on_startup` / `rosys.on_shutdown` / `rosys.on_repeat`, **not** NiceGUI's `app.on_startup`.
+  `rosys.on_startup` runs _after_ persisted state is restored (each `Persistable` restores itself when `.persistent()` is called), so configuring through `app.on_startup` lets the restored state overwrite whatever you set (see the README note).
+  Note `on_repeat` waits one interval before its first call — it is not immediate.
+- **Don't block the loop:** wrap CPU-heavy work in `await rosys.run.cpu_bound(...)` and blocking I/O in `await rosys.run.io_bound(...)`.
+  Both return `R | None` — `None` when the app is shutting down or the call is cancelled, so guard the result.
+  `cpu_bound` runs in a _spawned_ subprocess, so its callback and arguments must be picklable (module-level functions, no closures or `self`).
 - **Events** are typed `Event[T]` with `.emit()` / `.subscribe()` (imported from `nicegui`, not defined in `rosys` — grepping the `rosys` package for `class Event` finds nothing); event names are `SCREAMING_SNAKE_CASE` (e.g. `VELOCITY_MEASURED`).
 
 ## Hardware modules: keep the Hardware/Simulation pair intact
@@ -32,18 +48,25 @@ A robot-facing hardware subsystem is usually a triplet — keep the symmetry so 
 2. a **`*Hardware`** class that talks to the Robot Brain (emits Lizard code, parses sensor data in `handle_core_output`), and
 3. a **`*Simulation`** class that updates state in `step(dt)` without any hardware.
 
-Use an existing module such as `rosys/hardware/wheels.py` or `rosys/hardware/bumper.py` as the blueprint, and export all three. Note this is a *convention*, not universal: pure support modules (`Can`, `Serial`, `Expander`) are hardware-only. `RobotSimulation` casts its modules to `ModuleSimulation`, so don't add a hardware-only module to a simulated robot.
+Use an existing module such as `rosys/hardware/wheels.py` or `rosys/hardware/bumper.py` as the blueprint, and export all three.
+Note this is a _convention_, not universal: pure support modules (`Can`, `Serial`, `Expander`) are hardware-only.
+`RobotSimulation` casts its modules to `ModuleSimulation`, so don't add a hardware-only module to a simulated robot.
 
 ## Safety boundary — do not casually cross
 
-- Safety- and timing-critical actuator logic belongs in Lizard on the microcontroller, which continuously enforces the safety conditions and performs the time-critical control. Python may request actions via `robot_brain.send(...)`, but must not bypass the microcontroller or drive hardware directly.
-- The Lizard *startup script* is assembled from each module's `lizard_code` by `RobotHardware.generate_lizard_code()` and uploaded via `robot_brain.configure()`, which restarts the brain to apply it. This is config/startup-script upload, **not** firmware flashing (that is `lizard_firmware.flash_core()` / `flash_p0()`). Don't expect to live-tweak it; changing module composition means regenerating and re-configuring.
+- Safety- and timing-critical actuator logic belongs in Lizard on the microcontroller, which continuously enforces the safety conditions and performs the time-critical control.
+  Python may request actions via `robot_brain.send(...)`, but must not bypass the microcontroller or drive hardware directly.
+- The Lizard _startup script_ is assembled from each module's `lizard_code` by `RobotHardware.generate_lizard_code()` and uploaded via `robot_brain.configure()`, which restarts the brain to apply it.
+  This is config/startup-script upload, **not** firmware flashing (that is `lizard_firmware.flash_core()` / `flash_p0()`).
+  Don't expect to live-tweak it; changing module composition means regenerating and re-configuring.
 
 ## Testing
 
 - pytest with `pytest-asyncio` in `asyncio_mode = "auto"` — tests are plain `async def`, no decorator needed.
-- Develop against the `*Simulation` classes and the helpers in `rosys.testing`: `forward(seconds=...)` to advance accelerated time, or `forward(x=..., y=...)` / `forward(until=...)` to run until the robot arrives or a condition holds, plus `assert_pose(...)` and `approx(...)` (a deep dataclass-equality helper, not `pytest.approx`). See `tests/test_robot.py` and `tests/test_time.py` for the idiom.
-- Add tests for new functionality. Run a single test with `uv run pytest tests/test_<x>.py::test_<y>`.
+- Develop against the `*Simulation` classes and the helpers in `rosys.testing`: `forward(seconds=...)` to advance accelerated time, or `forward(x=..., y=...)` / `forward(until=...)` to run until the robot arrives or a condition holds, plus `assert_pose(...)` and `approx(...)` (a deep dataclass-equality helper, not `pytest.approx`).
+  See `tests/test_robot.py` and `tests/test_time.py` for the idiom.
+- Add tests for new functionality.
+  Run a single test with `uv run pytest tests/test_<x>.py::test_<y>`.
 
 ## Before you call it done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
*Drafted by Evan (@evnchn) with Claude Code (Opus 4.8). Opened as a **draft** on purpose — see "Why draft" below.*

### Motivation

RoSys has no agent-guidelines file yet — "Add a CLAUDE.md" is a TODO on the [RoSys Wishlist board](https://github.com/orgs/zauberzeug/projects/12). Coding agents (Claude Code, Codex, Cursor, Copilot, …) currently land in RoSys with no orientation and rediscover the framework's non-obvious model every session — single asyncio loop, simulated time, the Hardware/Simulation pairing, the Lizard safety boundary — and frequently get it wrong (`app.on_startup` vs `rosys.on_startup`, `asyncio.sleep` vs `rosys.sleep`, inventing simulation twins for hardware-only modules, etc.).

### Implementation

Adds two files:

- **`AGENTS.md`** — the content. Follows the cross-vendor [AGENTS.md standard](https://agents.md) (now Linux-Foundation–stewarded; read natively by Codex, Cursor, Copilot, Gemini CLI, Aider, Windsurf, Zed).
- **`CLAUDE.md`** — a one-line `@AGENTS.md` import, since Claude Code doesn't read `AGENTS.md` natively. This is the pattern NiceGUI already uses, and it satisfies the board's literal "CLAUDE.md" ask too.

The doc is intentionally RoSys-specific, not generic AI advice: the single-loop runtime model, the `rosys.run.*` offload + `spawn` requirement, `rosys.time`/`rosys.sleep` simulated time, the lifecycle hooks + persistence-restore ordering, the abstract-base + `*Hardware` + `*Simulation` triplet (and the hardware-only exceptions like `Can`/`Serial`/`Expander`), the Lizard / `robot_brain.configure` vs firmware-flash distinction, the testing helpers, and the exact CI gates.

**Every load-bearing claim was fact-checked** against the source, the official docs (rosys.io, lizard.dev), `CONTRIBUTING.md`, and `.github/workflows` — through several independent passes (a code-review agent, a cross-provider review via Codex, and a multi-agent deep-research fact-check). The new files also pass RoSys's own `pre-commit` (codespell / mdformat / EOF / whitespace).

### Why draft

This is a deliberate first pass — my agents and I pulled every trick we have to make it accurate, but **the real test is you running a coding agent against it on an actual RoSys task**. I can't validate "does this make an agent more productive on *your* workflows" from the outside; that needs your hands on it. Keeping it draft until you've kicked the tyres — very happy to cut, reframe, or expand anything.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary). — documentation-only change
- [x] Documentation has been added (or is not necessary).
