### PR TITLE
Use a spawn context for the path planner instead of a global spawn requirement

### DIFF
--- a/rosys/pathplanning/path_planner.py
+++ b/rosys/pathplanning/path_planner.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import time
 from copy import copy
-from multiprocessing import Pipe
 from typing import Any
 
 from nicegui import Event
@@ -13,6 +12,7 @@ from ..geometry import Point, Pose, Prism, Spline
 from .area import Area
 from .obstacle import Obstacle
 from .planner_process import (
+    SPAWN_CONTEXT,
     PlannerCommand,
     PlannerGrowMapCommand,
     PlannerObstacleDistanceCommand,
@@ -35,7 +35,7 @@ class PathPlanner(persistence.Persistable):
 
         self.log = logging.getLogger('rosys.path_planner')
 
-        self.connection, process_connection = Pipe()
+        self.connection, process_connection = SPAWN_CONTEXT.Pipe()
         self.process = PlannerProcess(process_connection, robot_shape.outline)
         self.responses: dict[str, Any] = {}
 

--- a/rosys/pathplanning/planner_process.py
+++ b/rosys/pathplanning/planner_process.py
@@ -1,15 +1,19 @@
 import abc
 import logging
+import multiprocessing
 import uuid
 from dataclasses import dataclass, field
-from multiprocessing import Process
 from multiprocessing.connection import Connection
+from multiprocessing.context import SpawnProcess
 from typing import Any
 
 from ..geometry import Point, Pose, Spline
 from .area import Area
 from .delaunay_planner import DelaunayPlanner
 from .obstacle_map import Obstacle
+
+# spawn, not fork (which is broken for Python), regardless of the global start method (#19)
+SPAWN_CONTEXT = multiprocessing.get_context('spawn')
 
 
 @dataclass
@@ -57,7 +61,7 @@ class PlannerResponse:
     content: Any
 
 
-class PlannerProcess(Process):
+class PlannerProcess(SpawnProcess):  # always spawn (#19)
 
     def __init__(self, connection: Connection, robot_outline: list[tuple[float, float]]) -> None:
         super().__init__()

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -1,7 +1,6 @@
 import asyncio
 import gc
 import logging
-import multiprocessing
 import os
 import signal
 import threading
@@ -28,10 +27,6 @@ log = logging.getLogger('rosys.core')
 translator: Any | None = None
 
 core.is_test = is_test = helpers.is_test()
-
-# POSIX standard to create processes is "fork", which is inherently broken for python (see https://pythonspeed.com/articles/python-multiprocessing/)
-if __name__ == '__main__':
-    multiprocessing.set_start_method('spawn')
 
 
 @dataclass(slots=True, kw_only=True)
@@ -232,9 +227,6 @@ def on_shutdown(handler: Callable) -> None:
 async def startup() -> None:
     if _state.startup_finished:
         raise RuntimeError('should be only executed once')
-    if multiprocessing.get_start_method() != 'spawn':
-        raise RuntimeError(
-            'multiprocessing start method must be "spawn"; see https://pythonspeed.com/articles/python-multiprocessing/')
 
     _state.startup_finished = True
 

--- a/rosys/testing/fixtures.py
+++ b/rosys/testing/fixtures.py
@@ -1,6 +1,5 @@
 # pylint: disable=redefined-outer-name,unused-argument
 import asyncio
-import multiprocessing
 from collections.abc import AsyncGenerator
 
 import pytest
@@ -71,10 +70,8 @@ async def kpi_logger(rosys_integration: None) -> KpiLogger:
 
 
 @pytest.fixture(scope='session', autouse=True)
-def enforce_spawn_process() -> None:
-    if multiprocessing.get_start_method() != 'spawn':
-        multiprocessing.set_start_method('spawn', force=True)
-    run.setup()  # Some tests need the CPU pool
+def setup_run_pool() -> None:
+    run.setup()  # Some tests need the CPU pool (the path planner now spawns via its own context, see #19)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Motivation

`import rosys` + `ui.run(reload=False)` raises `RuntimeError: multiprocessing start method must be "spawn"` on Linux/Docker (#19). `startup()` asserts the **global** start method is `spawn`, but rosys never reliably set it — the `set_start_method('spawn')` in `rosys.py` was dead code under `if __name__ == '__main__'` in an imported module. It only happened to work when NiceGUI/uvicorn's reloader flipped the global default (`reload=True`); with `reload=False` on Linux the default stays `fork` and the assertion fires.

### Implementation

Route the planner subprocess through its own spawn context instead of requiring a global precondition (the supported pattern — mirrors `nicegui.native`'s `SPAWN_CONTEXT`):

- `planner_process.py`: module-level `SPAWN_CONTEXT = multiprocessing.get_context('spawn')`; `PlannerProcess(SpawnProcess)` — spawn-based regardless of the OS default.
- `path_planner.py`: `SPAWN_CONTEXT.Pipe()`.
- `rosys.py`: removed the dead `set_start_method` block and the `startup()` spawn assertion.
- `testing/fixtures.py`: dropped the `enforce_spawn_process` global override (no longer needed); renamed to `setup_run_pool`.

> **Behavior note (Linux):** removing the global assertion means `run.cpu_bound` (which delegates to NiceGUI's pool) now follows the global start method — `fork` on Linux/`reload=False` — until zauberzeug/nicegui#6117 ships a spawn-context pool and the `nicegui` pin is bumped. The planner itself is unaffected (own context), and adopting the NiceGUI fix needs no rosys code change.

<details>
<summary><b>Minimal repro (this is #19)</b></summary>

```python
import rosys
from nicegui import ui

rosys.on_startup(lambda: print('rosys started'))
ui.run(reload=False)
```

On Linux: **before** this PR → `RuntimeError: multiprocessing start method must be "spawn"` at startup; **after** → starts normally. (macOS is unaffected — its default is already `spawn`.)
</details>

<details>
<summary><b>Verification (real Linux box, genuine <code>fork</code> default, Python 3.12.3)</b></summary>

- `mypy` clean · `pylint` 9.93 (only a pre-existing `unused 'robot'` arg) · `ruff` clean.
- `pytest tests/test_path_planning.py` → **7 passed** (each spawns a real `PlannerProcess`).
- Reproduced #19's condition: the removed assertion raises under `fork`; the PR-branch `startup()` returns cleanly; a `SPAWN_CONTEXT` process launches and exits 0 under the fork-global.
</details>

<details>
<summary><b>On "rosys does more spawning than NiceGUI"</b></summary>

The only *raw* multiprocessing site in rosys is the path planner (`Process` + `Pipe`), fixed here. The one *indirect* site is `run.cpu_bound` → NiceGUI's `ProcessPoolExecutor`, which has no spawn context (checked nicegui 3.13.0 + `main`) and so follows the global method. On a real Linux/`fork` run, `test_record_images` (which calls `cpu_bound`) passes but emits CPython's `DeprecationWarning: ...fork() may lead to deadlocks`. zauberzeug/nicegui#6117 fixes that pool; rosys adopts it by a version bump, no code change.
</details>

### Progress

- [x] Meaningful title ("If applied, this PR will use a spawn context for the path planner instead of a global spawn requirement").
- [x] Labels — maintainer's discretion.
- [x] The implementation is complete.
- [x] Pytests are not necessary — the 7 existing `test_path_planning.py` tests already spawn a real `PlannerProcess`.
- [x] Documentation is not necessary (bug fix).
