### PR TITLE
Use the camera's capture timestamp for MJPEG frames

### DIFF
--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -11,6 +11,26 @@ from ..image_processing import remove_exif
 from .vendors import mac_to_url
 
 
+def parse_capture_timestamp(part_header: bytes) -> float | None:
+    """Extract the absolute capture instant (Unix epoch seconds) from the ``X-Timestamp``
+    field of an MJPEG multipart part header.
+
+    Cameras that stamp each frame at capture time emit an ``X-Timestamp: <sec>.<usec>``
+    line in the part header preceding the JPEG. Returns ``None`` when the field is absent
+    or unparsable, so the caller can fall back to the receive time.
+    """
+    marker = b'x-timestamp:'
+    index = part_header.lower().rfind(marker)
+    if index == -1:
+        return None
+    line_end = part_header.find(b'\r\n', index)
+    raw = part_header[index + len(marker):] if line_end == -1 else part_header[index + len(marker):line_end]
+    try:
+        return float(raw.strip())
+    except ValueError:
+        return None
+
+
 class MjpegDevice:
 
     def __init__(self, mac: str, ip: str, *,
@@ -50,7 +70,7 @@ class MjpegDevice:
     async def run_capture_task(self) -> None:
         self.log.debug('Starting capture task for %s', self._url)
 
-        async def stream() -> AsyncGenerator[bytes, None]:
+        async def stream() -> AsyncGenerator[tuple[bytes, float | None], None]:
             async with httpx.AsyncClient() as client:
                 assert self._url is not None
                 try:
@@ -84,8 +104,10 @@ class MjpegDevice:
                                 if start == -1:
                                     continue
 
+                                # the bytes before the SOI marker are this frame's multipart part header
+                                capture_time = parse_capture_timestamp(bytes(buffer_view[:start]))
                                 end += 2
-                                yield buffer_view[start:end]
+                                yield bytes(buffer_view[start:end]), capture_time
                                 buffer_view[:buffer_end - end] = buffer_view[end:buffer_end]
                                 buffer_end -= end
 
@@ -96,11 +118,11 @@ class MjpegDevice:
                     self.log.warning('Connection to %s failed. Was something disconnected?\n%s', self._url, e)
                     raise e
 
-        async for image in stream():
+        async for image, capture_time in stream():
             if not image:
                 continue
             try:
-                timestamp = rosys.time()
+                timestamp = capture_time if capture_time is not None else rosys.time()
                 result = self._on_new_image_data(remove_exif(image), timestamp)
                 if isinstance(result, Awaitable):
                     await result

--- a/tests/test_mjpeg_device.py
+++ b/tests/test_mjpeg_device.py
@@ -1,0 +1,26 @@
+from rosys.vision.mjpeg_camera.mjpeg_device import parse_capture_timestamp
+
+
+def test_parses_x_timestamp():
+    header = b'\r\n--boundary\r\nContent-Type: image/jpeg\r\nContent-Length: 1234\r\nX-Timestamp: 1718900000.123456\r\n\r\n'
+    assert parse_capture_timestamp(header) == 1718900000.123456
+
+
+def test_parses_x_timestamp_case_insensitively():
+    header = b'--boundary\r\nx-timestamp:1718900000.5\r\n\r\n'
+    assert parse_capture_timestamp(header) == 1718900000.5
+
+
+def test_returns_none_without_header():
+    header = b'\r\n--boundary\r\nContent-Type: image/jpeg\r\nContent-Length: 1234\r\n\r\n'
+    assert parse_capture_timestamp(header) is None
+
+
+def test_returns_none_for_unparsable_value():
+    header = b'X-Timestamp: not-a-number\r\n\r\n'
+    assert parse_capture_timestamp(header) is None
+
+
+def test_uses_last_header_when_multiple_present():
+    header = b'X-Timestamp: 1.0\r\n\r\n<jpeg>\r\n--boundary\r\nX-Timestamp: 2.0\r\n\r\n'
+    assert parse_capture_timestamp(header) == 2.0


### PR DESCRIPTION
### Motivation

MJPEG `Image.time` is currently set to the client *receive* time (`rosys.time()`), which includes network and buffering delay and drifts from when the frame was actually captured. Cameras that stamp each frame at capture time expose that instant in the multipart part header, so we can report the true capture time instead — important for latency-sensitive and time-synchronised use.

### Implementation

- Add `parse_capture_timestamp()` to read the `X-Timestamp: <sec>.<usec>` field (absolute Unix epoch) from the MJPEG multipart part header that precedes each JPEG (the bytes before the `\xff\xd8` SOI marker).
- Use the parsed capture time as the image `timestamp`, falling back to `rosys.time()` when the field is absent or unparsable — so cameras without the header behave exactly as before.
- Yield the JPEG as `bytes` instead of a `memoryview` into the shared receive buffer. This also removes a latent aliasing hazard: the buffer is compacted in place on the next loop iteration while the consumer may still hold the view across an `await`.
- Add unit tests for the header parser (present, case-insensitive, absent, unparsable, last-wins).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8[1m]