### PR TITLE
Use the camera's capture timestamp for RTSP frames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,8 @@ follow_imports = "skip"
 module = [
     "cairosvg",
     "coloredlogs",
+    "gi",
+    "gi.*",
     "imgsize",
     "networkx",
     "objgraph",

--- a/rosys/vision/rtsp_camera/capture_time.py
+++ b/rosys/vision/rtsp_camera/capture_time.py
@@ -1,0 +1,46 @@
+"""Recover the absolute capture instant of a frame from an RTP header extension.
+
+Cameras that stamp frames at capture time carry the instant in the WebRTC
+"Absolute Capture Time" RTP header extension: a 64-bit Q32.32 NTP timestamp
+(seconds since 1900-01-01, big-endian) on the first packet of each frame.
+Unlike the RTP timestamp it is self-anchored -- each frame carries a freshly
+clock-corrected absolute time -- so it needs neither an RTCP Sender Report
+anchor nor extrapolation, while the RTP timestamp stays a clean media clock.
+
+See http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+ABS_CAPTURE_TIME_URI = 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time'
+
+# Seconds between the 1900 (NTP) and 1970 (Unix) epochs.
+_NTP_UNIX_EPOCH_OFFSET = 2_208_988_800
+
+# Default one-byte header-extension id for abs-capture-time. The id is properly negotiated
+# via the SDP `a=extmap` line; until that is parsed the extension is read at this fixed id.
+DEFAULT_ABS_CAPTURE_TIME_EXT_ID = 10
+
+
+def decode_abs_capture_time(payload: bytes) -> float:
+    """Decode the extension payload (>=8 bytes; trailing optional fields ignored) to Unix epoch seconds."""
+    return int.from_bytes(payload[:8], 'big') / (1 << 32) - _NTP_UNIX_EPOCH_OFFSET
+
+
+def encode_abs_capture_time(epoch: float) -> bytes:
+    """Encode a Unix epoch (seconds) as the extension's 8-byte Q32.32 NTP payload (inverse of decode)."""
+    q32_32 = round((epoch + _NTP_UNIX_EPOCH_OFFSET) * (1 << 32)) & ((1 << 64) - 1)
+    return q32_32.to_bytes(8, 'big')
+
+
+def read_abs_capture_time(rtp_buffer: Any, ext_id: int = DEFAULT_ABS_CAPTURE_TIME_EXT_ID) -> float | None:
+    """Read the abs-capture-time epoch (s) from a mapped ``GstRtp.RTPBuffer`` one-byte header extension.
+
+    Returns ``None`` when the extension is absent, so the caller can fall back to the receive time.
+    ``rtp_buffer`` is kept untyped to avoid importing the GStreamer bindings at module import time.
+    """
+    ok, data = rtp_buffer.get_extension_onebyte_header(ext_id, 0)
+    if not ok or not data:
+        return None
+    return decode_abs_capture_time(bytes(data))

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -1,25 +1,41 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
-import re
-import shlex
-import signal
-import struct
-import subprocess
-from asyncio.subprocess import Process
-from collections.abc import AsyncGenerator, Awaitable, Callable
-from dataclasses import dataclass
-from enum import Enum
-from typing import Literal
+import threading
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
 
 import numpy as np
 from nicegui import background_tasks
 
 from ... import rosys
 from ...vision.image import ImageArray
+from .capture_time import DEFAULT_ABS_CAPTURE_TIME_EXT_ID, read_abs_capture_time
 from .jovision_rtsp_interface import JovisionInterface
 from .vendors import VendorType, mac_to_url, mac_to_vendor
+
+
+@functools.lru_cache(maxsize=1)
+def _load_gstreamer() -> Any:
+    """Import and initialize the GStreamer Python bindings (PyGObject with ``Gst`` and ``GstRtp``).
+
+    Returns the ``(Gst, GstRtp)`` modules, or ``None`` if the bindings are missing. The result is
+    cached, so a deployment without them does not re-run the import or log the error on every
+    reconnect attempt; it is reported once.
+    """
+    try:
+        import gi  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+        gi.require_version('Gst', '1.0')
+        gi.require_version('GstRtp', '1.0')
+        from gi.repository import Gst, GstRtp  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+        Gst.init(None)
+        return (Gst, GstRtp)
+    except (ImportError, ValueError) as e:
+        logging.getLogger('rosys.vision.rtsp_camera.rtsp_device').error(
+            'RTSP capture requires the GStreamer Python bindings (PyGObject with Gst and GstRtp): %s', e)
+        return None
 
 
 class RtspDevice:
@@ -35,9 +51,11 @@ class RtspDevice:
         self._substream = substream
         self._on_new_image_data = on_new_image_data
         self._avdec = avdec
+        self._ext_id = DEFAULT_ABS_CAPTURE_TIME_EXT_ID
 
         self._capture_task: asyncio.Task | None = None
-        self._capture_process: Process | None = None
+        self._pipeline: Any = None
+        self._gst: Any = None
         self._authorized: bool = True
 
         vendor_type = mac_to_vendor(mac)
@@ -68,30 +86,20 @@ class RtspDevice:
         return url
 
     async def shutdown(self) -> None:
-        if self._capture_process is not None:
-            self.log.debug('[%s] Terminating gstreamer process', self._mac)
-            self._capture_process.terminate()
-            try:
-                await asyncio.wait_for(self._capture_process.wait(), timeout=5)
-            except TimeoutError:
-                self.log.warning('[%s] Timeout while waiting for gstreamer process to terminate', self._mac)
-            else:
-                self.log.debug('[%s] Successfully shut down process (code %s)',
-                               self._mac, self._capture_process.returncode if self._capture_process.returncode is not None else 'None')
-                self._capture_process = None
+        if self._pipeline is not None and self._gst is not None:
+            self.log.debug('[%s] Stopping gstreamer pipeline', self._mac)
+            self._pipeline.set_state(self._gst.State.NULL)
+            self._pipeline = None
         if self._capture_task is not None and not self._capture_task.done():
-            self.log.debug('[%s] Cancelling gstreamer task', self._mac)
+            self.log.debug('[%s] Cancelling capture task', self._mac)
             self._capture_task.cancel()
             try:
                 await asyncio.wait_for(self._capture_task, timeout=5)
-            except TimeoutError:
-                self.log.warning('[%s] Timeout while waiting for capture task to cancel', self._mac)
-                return
             except asyncio.CancelledError:
                 self.log.debug('[%s] Task was successfully cancelled', self._mac)
-            else:
-                self.log.debug('[%s] Task finished', self._mac)
-            self._capture_task = None
+            except TimeoutError:
+                self.log.warning('[%s] Timeout while waiting for capture task to cancel', self._mac)
+        self._capture_task = None
 
     def _start_gstreamer_task(self) -> None:
         self.log.debug('[%s] Starting gstreamer task', self._mac)
@@ -105,84 +113,117 @@ class RtspDevice:
         self._start_gstreamer_task()
 
     async def _run_gstreamer(self) -> None:
-        if self._capture_process is not None and self._capture_process.returncode is None:
-            self.log.warning('[%s] capture process already running', self._mac)
+        if self._pipeline is not None:
+            self.log.warning('[%s] pipeline already running', self._mac)
             return
 
-        async def stream() -> AsyncGenerator[ImageArray, None]:
-            url = self.url
-            self.log.debug('[%s] Starting gstreamer pipeline for %s', self._mac, url)
-            # to try: replace avdec_h264 with nvh264dec ! nvvidconv (!videoconvert)
-            command = f'gst-launch-1.0 --quiet rtspsrc location="{url}" latency=0 protocols=tcp ! rtp{self._avdec}depay ! avdec_{self._avdec} ! videoconvert ! video/x-raw,format=RGB ! queue max-size-buffers=1 leaky=downstream ! gdppay ! fdsink sync=false'
-            self.log.debug('[%s] Running command: %s', self._mac, command)
-            process = await asyncio.create_subprocess_exec(
-                *shlex.split(command),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            assert process.stdout is not None
-            assert process.stderr is not None
-            self._capture_process = process
+        gstreamer = _load_gstreamer()
+        if gstreamer is None:
+            self._capture_task = None
+            return
+        Gst, GstRtp = gstreamer
+        self._gst = Gst
 
-            width = None
-            height = None
-            while process.returncode is None:
-                assert process.stdout is not None
+        url = self.url
+        # latency=0 + sync=false: emit frames as they arrive without client-side buffering
+        # (the project values low delay over smoothing); the leaky queue keeps only the newest.
+        # An appsink (rather than gdppay ! fdsink) lets us read the RTP header in a pad probe.
+        pipeline_description = (
+            f'rtspsrc location="{url}" protocols=tcp latency=0 name=src '
+            f'! rtp{self._avdec}depay name=depay '
+            f'! avdec_{self._avdec} '
+            f'! videoconvert ! video/x-raw,format=RGB '
+            f'! queue max-size-buffers=1 leaky=downstream '
+            f'! appsink name=sink sync=false max-buffers=1 drop=true'
+        )
+        self.log.debug('[%s] Starting gstreamer pipeline for %s', self._mac, url)
 
-                try:
-                    packet = await GDPPacket.read(process.stdout)
-                except asyncio.exceptions.IncompleteReadError:
+        # capture_by_pts: GStreamer buffer PTS (ns) -> absolute capture epoch (s). Filled by the
+        # RTP pad probe (runs on a streaming thread), read by the pull loop (runs in an executor
+        # thread) -- so guard it with a lock. Bounded so it cannot grow without limit.
+        capture_by_pts: dict[int, float] = {}
+        pts_lock = threading.Lock()
+
+        def on_rtp(_pad, info):
+            buffer = info.get_buffer()
+            if buffer is None or buffer.pts == Gst.CLOCK_TIME_NONE:
+                return Gst.PadProbeReturn.OK
+            ok, rtp = GstRtp.RTPBuffer.map(buffer, Gst.MapFlags.READ)
+            if ok:
+                capture_time = read_abs_capture_time(rtp, self._ext_id)
+                rtp.unmap()
+                # The extension rides only the first packet of each access unit, but every packet
+                # of the unit shares this buffer PTS, so the first packet's value covers the unit.
+                if capture_time is not None:
+                    with pts_lock:
+                        capture_by_pts[buffer.pts] = capture_time
+                        if len(capture_by_pts) > 512:     # keep the newest ~256 entries
+                            for old in list(capture_by_pts)[:256]:
+                                del capture_by_pts[old]
+            return Gst.PadProbeReturn.OK
+
+        def to_array(sample) -> ImageArray | None:
+            structure = sample.get_caps().get_structure(0)
+            ok_w, width = structure.get_int('width')
+            ok_h, height = structure.get_int('height')
+            if not (ok_w and ok_h):
+                return None
+            buffer = sample.get_buffer()
+            ok, info = buffer.map(Gst.MapFlags.READ)
+            if not ok:
+                return None
+            try:
+                if info.size != width * height * 3:
+                    return None
+                return np.frombuffer(info.data, dtype=np.uint8).reshape(height, width, 3).copy()
+            finally:
+                buffer.unmap(info)
+
+        pipeline = Gst.parse_launch(pipeline_description)
+        self._pipeline = pipeline
+        pipeline.get_by_name('depay').get_static_pad('sink').add_probe(Gst.PadProbeType.BUFFER, on_rtp)
+        sink = pipeline.get_by_name('sink')
+        bus = pipeline.get_bus()
+
+        if pipeline.set_state(Gst.State.PLAYING) == Gst.StateChangeReturn.FAILURE:
+            self.log.error('[%s] failed to start gstreamer pipeline', self._mac)
+            pipeline.set_state(Gst.State.NULL)
+            self._pipeline = None
+            self._capture_task = None
+            return
+
+        loop = asyncio.get_event_loop()
+        try:
+            while True:
+                sample = await loop.run_in_executor(None, sink.try_pull_sample, Gst.SECOND)
+                if sample is None:
+                    message = bus.pop_filtered(Gst.MessageType.ERROR | Gst.MessageType.EOS)
+                    if message is None:
+                        continue   # pull timed out without a frame -- keep waiting
+                    if message.type == Gst.MessageType.ERROR:
+                        error, _ = message.parse_error()
+                        self.log.error('[%s] gstreamer error: %s', self._mac, error.message)
+                        if 'Unauthorized' in error.message:
+                            self._authorized = False
+                    else:
+                        self.log.debug('[%s] end of stream', self._mac)
                     break
 
-                if packet.payload_type == GDPPayloadType.CAPS:
-                    cap_text = packet.payload.decode('utf-8', 'ignore')
-
-                    w = GDP_CAPS_WIDTH_REGEX.search(cap_text)
-                    h = GDP_CAPS_HEIGHT_REGEX.search(cap_text)
-
-                    assert w is not None and h is not None
-                    assert len(w.groups()) == 1
-                    assert len(h.groups()) == 1
-
-                    width = int(w.group(1))
-                    height = int(h.group(1))
-
-                elif packet.payload_type == GDPPayloadType.BUFFER:
-                    assert width is not None and height is not None
-
-                    assert width * height * 3 == len(packet.payload)
-                    frame = np.frombuffer(packet.payload, dtype=np.uint8).reshape(height, width, 3)
-
-                    yield frame
-
-            try:
-                await asyncio.wait_for(process.wait(), timeout=5)
-            except TimeoutError:
-                self.log.warning(
-                    '[%s] Stream ended. Timeout while waiting for gstreamer process to terminate', self._mac)
-                return
-
-            return_code = process.returncode
-            if return_code == -1 * signal.SIGTERM:
-                self.log.debug('gstreamer process %s was terminated using SIGTERM', process.pid)
-            else:
-                error = await process.stderr.read()
-                error_message = error.decode()
-                self.log.error('gstreamer process %s exited with code %s.\nstderr: %s',
-                               process.pid, return_code, error_message)
-
-                if 'Unauthorized' in error_message:
-                    self._authorized = False
-
-        async for image in stream():
-            timestamp = rosys.time()
-            result = self._on_new_image_data(image, timestamp)
-            if isinstance(result, Awaitable):
-                await result
+                frame = to_array(sample)
+                if frame is None:
+                    continue
+                with pts_lock:
+                    capture_time = capture_by_pts.get(sample.get_buffer().pts)
+                timestamp = capture_time if capture_time is not None else rosys.time()
+                result = self._on_new_image_data(frame, timestamp)
+                if isinstance(result, Awaitable):
+                    await result
+        finally:
+            pipeline.set_state(Gst.State.NULL)
+            self._pipeline = None
+            self._capture_task = None
 
         self.log.info('[%s] stream ended', self._mac)
-
-        self._capture_task = None
 
     async def set_fps(self, fps: int) -> None:
         self._fps = fps
@@ -215,32 +256,3 @@ class RtspDevice:
 
     def set_avdec(self, avdec: Literal['h264', 'h265']) -> None:
         self._avdec = avdec
-
-
-class GDPPayloadType(Enum):
-    NONE = 0
-    BUFFER = 1
-    CAPS = 2
-    EVENT_NONE = 3
-
-
-# See https://maemo.org/api_refs/5.0/5.0-final/gstreamer-libs-0.10/gstreamer-libs-gstdataprotocol.html for header format
-GDPPACKET_FORMAT = struct.Struct('>HcxHIQQQQH14sHH')
-GDP_CAPS_WIDTH_REGEX = re.compile(r'width=\(int\)\s*(\d+)')
-GDP_CAPS_HEIGHT_REGEX = re.compile(r'height=\(int\)\s*(\d+)')
-GDP_HEADER_SIZE = 62
-
-
-@dataclass(slots=True, kw_only=True)
-class GDPPacket:
-    payload_type: GDPPayloadType
-    payload: bytes
-
-    @staticmethod
-    async def read(stream: asyncio.StreamReader) -> GDPPacket:
-        header_bytes = await stream.readexactly(GDP_HEADER_SIZE)
-        _version, _flags, gdp_type, length, *_ = GDPPACKET_FORMAT.unpack(header_bytes)
-        return GDPPacket(
-            payload_type=GDPPayloadType(gdp_type) if gdp_type < 3 else GDPPayloadType.EVENT_NONE,
-            payload=await stream.readexactly(length),
-        )

--- a/tests/test_capture_time.py
+++ b/tests/test_capture_time.py
@@ -1,0 +1,41 @@
+from rosys.vision.rtsp_camera.capture_time import (
+    decode_abs_capture_time,
+    encode_abs_capture_time,
+    read_abs_capture_time,
+)
+
+
+def test_decode_known_vector():
+    # 1900-01-01 + _NTP_UNIX_EPOCH_OFFSET seconds == Unix epoch 0, fraction 0.
+    payload = (2_208_988_800 << 32).to_bytes(8, 'big')
+    assert decode_abs_capture_time(payload) == 0.0
+
+
+def test_encode_decode_roundtrip():
+    epoch = 1718900000.123456
+    decoded = decode_abs_capture_time(encode_abs_capture_time(epoch))
+    assert abs(decoded - epoch) < 1e-6
+
+
+def test_decode_ignores_trailing_optional_fields():
+    payload = encode_abs_capture_time(1718900000.0) + b'\x00\x00\x00\x00'
+    assert abs(decode_abs_capture_time(payload) - 1718900000.0) < 1e-6
+
+
+class _FakeRtpBuffer:
+    def __init__(self, ext: dict[int, bytes]) -> None:
+        self._ext = ext
+
+    def get_extension_onebyte_header(self, ext_id: int, _index: int):
+        data = self._ext.get(ext_id)
+        return (data is not None, data)
+
+
+def test_read_returns_epoch_when_extension_present():
+    payload = encode_abs_capture_time(1718900000.5)
+    rtp = _FakeRtpBuffer({10: payload})
+    assert abs(read_abs_capture_time(rtp, 10) - 1718900000.5) < 1e-6
+
+
+def test_read_returns_none_when_extension_absent():
+    assert read_abs_capture_time(_FakeRtpBuffer({}), 10) is None


### PR DESCRIPTION
### Motivation

RTSP `Image.time` is currently set to the client *receive* time (`rosys.time()`), which includes network and decode delay and drifts from when the frame was actually captured. Cameras that timestamp frames at capture time carry that instant per frame in the WebRTC "Absolute Capture Time" RTP header extension, so we can report the true capture time — important for latency-sensitive and time-synchronised use.

### Implementation

- Add `capture_time.py` with the WebRTC abs-capture-time codec (Q32.32 NTP ↔ Unix epoch) and `read_abs_capture_time()` to read the one-byte RTP header extension from a mapped `GstRtp.RTPBuffer`.
- Read the per-frame capture instant in `RtspDevice` and use it as the image `timestamp`, falling back to `rosys.time()` when the extension is absent — cameras without it behave exactly as before.
- The absolute capture time only exists at the RTP layer (lost after depay), so replace the `gst-launch-1.0 ... ! gdppay ! fdsink` subprocess with an **in-process** GStreamer pipeline: a pad probe on the depayloader sink pad reads the extension and maps it by GStreamer buffer PTS; the `appsink`'s decoded RGB frames are pulled in an asyncio executor and matched to their capture time by PTS.
- Load the GStreamer Python bindings (PyGObject `Gst`/`GstRtp`) lazily and cache the result, so the bindings are only required for RTSP and a deployment without them reports the missing dependency once rather than on every reconnect.
- Preserve the full public surface of `RtspDevice` (`url`, `shutdown`, `restart_gstreamer`, `set/get_fps`, `set/get_substream`, `set/get_bitrate`, `get/set_avdec`, `is_connected`, `authorized`).
- Add `gi` to mypy's `ignore_missing_imports`; add unit tests for the abs-capture-time codec and extension reader.

### New runtime requirement

RTSP capture now needs the **GStreamer Python bindings** (PyGObject with `Gst` and `GstRtp` typelibs) in-process, where it previously only needed the `gst-launch-1.0` binary. The import is lazy and cached, so non-RTSP users are unaffected.

### Work In Progress

- Not yet verified against a physical camera + GStreamer (no hardware in this environment). The codec and parsing are unit-tested; the pipeline/threading/lifecycle logic has been reviewed but needs a live RTSP smoke test (frame flow, capture-time vs. fallback, reconnect, shutdown) before marking ready.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).

---
⬛ claude-opus-4-8[1m]