### PR TITLE
Use ui.timer instead of on_repeat in AxesObject

### DIFF
--- a/rosys/geometry/pose3d.py
+++ b/rosys/geometry/pose3d.py
@@ -136,7 +136,7 @@ class AxesObject(ui.scene.group):
                     ui.scene.cylinder(0.00 * length, 0.05 * length, 0.2 * length).move(y=0.9 * length).material(color)
             if name:
                 ui.scene.text(name).move(z=-0.03)
-        rosys.on_repeat(self.update, rosys.config.ui_update_interval)
+        ui.timer(rosys.config.ui_update_interval, self.update)
 
     def update(self) -> None:
         resolved_pose = self.frame.resolve()


### PR DESCRIPTION
### Motivation

Creating an `AxesObject` in a ui context (as intended) would leak it via `on_repeat`.

### Implementation

Replace the `on_repeat` timer with a ui timer.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
