### PR TITLE
Make mjpeg transfer faster

### DIFF
--- a/rosys/vision/__init__.py
+++ b/rosys/vision/__init__.py
@@ -10,7 +10,7 @@ from .detections import BoxDetection, Detection, Detections, PointDetection
 from .detector import Autoupload, Detector
 from .detector_hardware import DetectorHardware
 from .detector_simulation import DetectorSimulation, SimulatedObject
-from .image import BytesImage, Image, ImageArray, ImageSize, MemfdImage
+from .image import Image, ImageArray, ImageSize, MemfdImage
 from .image_rotation import ImageRotation
 from .mjpeg_camera import MjpegCamera, MjpegCameraProvider
 from .multi_camera_provider import MultiCameraProvider
@@ -25,7 +25,6 @@ __all__ = [
     'Autoupload',
     'BoxAnnotation',
     'BoxDetection',
-    'BytesImage',
     'CalibratableCamera',
     'CalibratableCameraProvider',
     'Calibration',

--- a/rosys/vision/__init__.py
+++ b/rosys/vision/__init__.py
@@ -10,7 +10,7 @@ from .detections import BoxDetection, Detection, Detections, PointDetection
 from .detector import Autoupload, Detector
 from .detector_hardware import DetectorHardware
 from .detector_simulation import DetectorSimulation, SimulatedObject
-from .image import Image, ImageArray, ImageSize
+from .image import BytesImage, Image, ImageArray, ImageSize
 from .image_rotation import ImageRotation
 from .mjpeg_camera import MjpegCamera, MjpegCameraProvider
 from .multi_camera_provider import MultiCameraProvider
@@ -25,6 +25,7 @@ __all__ = [
     'Autoupload',
     'BoxAnnotation',
     'BoxDetection',
+    'BytesImage',
     'CalibratableCamera',
     'CalibratableCameraProvider',
     'Calibration',

--- a/rosys/vision/__init__.py
+++ b/rosys/vision/__init__.py
@@ -10,7 +10,7 @@ from .detections import BoxDetection, Detection, Detections, PointDetection
 from .detector import Autoupload, Detector
 from .detector_hardware import DetectorHardware
 from .detector_simulation import DetectorSimulation, SimulatedObject
-from .image import BytesImage, Image, ImageArray, ImageSize
+from .image import BytesImage, Image, ImageArray, ImageSize, MemfdImage
 from .image_rotation import ImageRotation
 from .mjpeg_camera import MjpegCamera, MjpegCameraProvider
 from .multi_camera_provider import MultiCameraProvider
@@ -46,6 +46,7 @@ __all__ = [
     'ImageRotation',
     'ImageSize',
     'Intrinsics',
+    'MemfdImage',
     'MjpegCamera',
     'MjpegCameraProvider',
     'MultiCameraProvider',

--- a/rosys/vision/image.py
+++ b/rosys/vision/image.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import mmap
+import os
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Self
 
@@ -152,4 +154,50 @@ class BytesImage:
 
     def to_image(self) -> Image:
         array = np.frombuffer(self.data, dtype=np.uint8).reshape(self.size.height, self.size.width, 3)
+        return Image.from_array(array, camera_id=self.camera_id, time=self.time, metadata=self.metadata)
+
+
+@dataclass(slots=True, kw_only=True)
+class MemfdImage:
+    """A frame shared with another process via a Linux ``memfd`` file descriptor.
+
+    The pixels are written once into an anonymous in-memory file; only the (cheap) file descriptor crosses
+    the process boundary, and the receiver maps it with a zero-copy ``np.frombuffer``. The reconstructed
+    :class:`Image` keeps the mapping alive until it is garbage-collected.
+
+    Linux-only (requires ``os.memfd_create``); use :class:`BytesImage` elsewhere. Both share the
+    ``from_array`` / ``to_image`` interface so the receiver does not need to know which one it got.
+    """
+    fd: Any  # multiprocessing.reduction.DupFd, picklable across the process boundary
+    nbytes: int
+    size: ImageSize
+    camera_id: str
+    time: float
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_array(cls, array: ImageArray, *,
+                   camera_id: str, time: float, metadata: dict[str, Any] | None = None) -> MemfdImage:
+        # imported lazily: DupFd is POSIX-only (absent on Windows), this path runs only where memfd exists
+        from multiprocessing.reduction import DupFd  # noqa: PLC0415 # pylint: disable=import-outside-toplevel
+        height, width = array.shape[:2]
+        nbytes = int(array.nbytes)
+        fd = os.memfd_create(f'rosys-image-{camera_id}')
+        try:
+            os.ftruncate(fd, nbytes)
+            with mmap.mmap(fd, nbytes) as buffer:
+                np.frombuffer(buffer, dtype=np.uint8).reshape(height, width, 3)[:] = array
+            dup_fd = DupFd(fd)  # an independent dup that survives closing our fd, sent across the boundary
+        finally:
+            os.close(fd)
+        return cls(fd=dup_fd, nbytes=nbytes, size=ImageSize(width=width, height=height),
+                   camera_id=camera_id, time=time, metadata=metadata or {})
+
+    def to_image(self) -> Image:
+        fd = self.fd.detach()
+        try:
+            buffer = mmap.mmap(fd, self.nbytes)  # keeps the mapping alive after the fd is closed
+        finally:
+            os.close(fd)
+        array = np.frombuffer(buffer, dtype=np.uint8).reshape(self.size.height, self.size.width, 3)
         return Image.from_array(array, camera_id=self.camera_id, time=self.time, metadata=self.metadata)

--- a/rosys/vision/image.py
+++ b/rosys/vision/image.py
@@ -128,36 +128,6 @@ class Image:
 
 
 @dataclass(slots=True, kw_only=True)
-class BytesImage:
-    """An image as raw, uncompressed RGB pixel bytes.
-
-    A lightweight carrier for cheap transfer (e.g. across a process boundary): it pickles as a plain
-    ``bytes`` blob and reconstructs via a zero-copy ``np.frombuffer`` view, avoiding the heavier pickling
-    of a full :class:`Image` (numpy reconstruction plus detections/metadata).
-    """
-    data: bytes
-    size: ImageSize
-    camera_id: str
-    time: float
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-    @classmethod
-    def from_image(cls, image: Image) -> BytesImage:
-        return cls(data=image.array.tobytes(), size=image.size,
-                   camera_id=image.camera_id, time=image.time, metadata=image.metadata)
-
-    @classmethod
-    def from_array(cls, array: ImageArray, *,
-                   camera_id: str, time: float, metadata: dict[str, Any] | None = None) -> BytesImage:
-        return cls(data=array.tobytes(), size=ImageSize(width=array.shape[1], height=array.shape[0]),
-                   camera_id=camera_id, time=time, metadata=metadata or {})
-
-    def to_image(self) -> Image:
-        array = np.frombuffer(self.data, dtype=np.uint8).reshape(self.size.height, self.size.width, 3)
-        return Image.from_array(array, camera_id=self.camera_id, time=self.time, metadata=self.metadata)
-
-
-@dataclass(slots=True, kw_only=True)
 class MemfdImage:
     """A frame shared with another process via a Linux ``memfd`` file descriptor.
 
@@ -165,8 +135,8 @@ class MemfdImage:
     the process boundary, and the receiver maps it with a zero-copy ``np.frombuffer``. The reconstructed
     :class:`Image` keeps the mapping alive until it is garbage-collected.
 
-    Linux-only (requires ``os.memfd_create``); use :class:`BytesImage` elsewhere. Both share the
-    ``from_array`` / ``to_image`` interface so the receiver does not need to know which one it got.
+    Linux-only (requires ``os.memfd_create``); where it is unavailable, senders fall back to shipping the
+    :class:`Image` itself across the boundary.
     """
     fd: Any  # multiprocessing.reduction.DupFd, picklable across the process boundary
     nbytes: int
@@ -182,7 +152,7 @@ class MemfdImage:
         from multiprocessing.reduction import DupFd  # noqa: PLC0415 # pylint: disable=import-outside-toplevel
         height, width = array.shape[:2]
         nbytes = int(array.nbytes)
-        fd = os.memfd_create(f'rosys-image-{camera_id}')
+        fd = os.memfd_create(f'rosys-image-{camera_id}')  # pylint: disable=no-member  # Linux-only, guarded by caller
         try:
             os.ftruncate(fd, nbytes)
             with mmap.mmap(fd, nbytes) as buffer:

--- a/rosys/vision/image.py
+++ b/rosys/vision/image.py
@@ -123,3 +123,33 @@ class Image:
     def byte_size(self) -> int:
         """Compute the size of the stored image representation in bytes."""
         return self.array.size
+
+
+@dataclass(slots=True, kw_only=True)
+class BytesImage:
+    """An image as raw, uncompressed RGB pixel bytes.
+
+    A lightweight carrier for cheap transfer (e.g. across a process boundary): it pickles as a plain
+    ``bytes`` blob and reconstructs via a zero-copy ``np.frombuffer`` view, avoiding the heavier pickling
+    of a full :class:`Image` (numpy reconstruction plus detections/metadata).
+    """
+    data: bytes
+    size: ImageSize
+    camera_id: str
+    time: float
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_image(cls, image: Image) -> BytesImage:
+        return cls(data=image.array.tobytes(), size=image.size,
+                   camera_id=image.camera_id, time=image.time, metadata=image.metadata)
+
+    @classmethod
+    def from_array(cls, array: ImageArray, *,
+                   camera_id: str, time: float, metadata: dict[str, Any] | None = None) -> BytesImage:
+        return cls(data=array.tobytes(), size=ImageSize(width=array.shape[1], height=array.shape[0]),
+                   camera_id=camera_id, time=time, metadata=metadata or {})
+
+    def to_image(self) -> Image:
+        array = np.frombuffer(self.data, dtype=np.uint8).reshape(self.size.height, self.size.width, 3)
+        return Image.from_array(array, camera_id=self.camera_id, time=self.time, metadata=self.metadata)

--- a/rosys/vision/mjpeg_camera/arkvision_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/arkvision_mjpeg_device.py
@@ -1,7 +1,6 @@
-from collections.abc import Awaitable, Callable
 
 from .arkvision_settings_interface import ArkVisionSettingsInterface
-from .mjpeg_device import MjpegDevice
+from .mjpeg_device import ImageDataHandler, MjpegDevice
 from .vendors import VendorType, mac_to_vendor
 
 
@@ -12,7 +11,7 @@ class ArkVisionMjpegDevice(MjpegDevice):
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
+                 on_new_image_data: ImageDataHandler) -> None:
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.ARKVISION:
             raise ValueError(

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -1,8 +1,7 @@
 import re
-from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
-from .mjpeg_device import MjpegDevice
+from .mjpeg_device import ImageDataHandler, MjpegDevice
 from .vendors import VendorType, mac_to_vendor
 
 
@@ -26,7 +25,7 @@ class AxisMjpegDevice(MjpegDevice):
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
+                 on_new_image_data: ImageDataHandler) -> None:
         super().__init__(mac, ip, index=index, username=username, password=password, on_new_image_data=on_new_image_data)
 
         self.axis_settings = AxisSettings(fps=6, resolution=(640, 480), mirrored=False)

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -1,13 +1,10 @@
+import asyncio
 import logging
 from typing import Any
 
-from ... import rosys
 from ..camera import ConfigurableCamera, TransformableCamera
-from ..image import Image
-from ..image_processing import process_jpeg_image
-from ..image_rotation import ImageRotation
-from .mjpeg_device import MjpegDevice
-from .mjpeg_device_factory import MjpegDeviceFactory
+from .mjpeg_capture import MjpegCapture
+from .vendors import VendorType, mac_to_vendor
 
 
 class MjpegCamera(TransformableCamera, ConfigurableCamera):
@@ -40,7 +37,8 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
             self.index = int(parts[1])
 
         self.mac = parts[0]
-        self.device: MjpegDevice | None = None
+
+        self._capture: MjpegCapture | None = None
 
         self._register_parameter('fps', self._get_fps, self._set_fps, default_value=fps)
         self._register_parameter('resolution', self._get_resolution, self._set_resolution, default_value=resolution)
@@ -57,7 +55,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
 
     @property
     def is_connected(self) -> bool:
-        return (self.device is not None) and self.device.is_connected
+        return self._capture is not None and self._capture.is_running
 
     async def connect(self) -> None:
         if self.is_connected:
@@ -67,59 +65,39 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
             self.log.error('No IP address provided')
             return
 
-        try:
-            self.device = MjpegDeviceFactory.create(self.mac, self.ip, index=self.index, username=self.username,
-                                                    password=self.password, on_new_image_data=self._handle_new_image_data)
-        except ValueError as error:
-            self.log.error('Could not connect to device: %s', error)
+        if mac_to_vendor(self.mac) == VendorType.OTHER:
+            self.log.error('Could not connect to device: unknown vendor for mac="%s"', self.mac)
             return
 
-        await self._apply_all_parameters()
+        self._capture = MjpegCapture(camera_id=self.id, mac=self.mac, ip=self.ip, index=self.index,
+                                     username=self.username, password=self.password,
+                                     rotation=self.rotation, crop=self.crop, parameters=self.parameters,
+                                     loop=asyncio.get_running_loop(), on_image=self._add_image)
+        self._capture.start()
 
     async def disconnect(self) -> None:
-        if self.device is None:
+        if self._capture is None:
             return
-
-        self.device.shutdown()
-        self.device = None
-
-    async def _handle_new_image_data(self, image_bytes: bytes, timestamp: float) -> None:
-        image: Image | None = None
-        if self.crop or self.rotation != ImageRotation.NONE:
-            image_array = await rosys.run.cpu_bound(process_jpeg_image, image_bytes, self.rotation, self.crop)
-            if image_array is not None:
-                image = Image.from_array(image_array, camera_id=self.id, time=timestamp)
-        else:
-            image = await rosys.run.cpu_bound(Image.from_jpeg_bytes, image_bytes, camera_id=self.id, time=timestamp)
-
-        if image is not None:
-            self._add_image(image)
+        await self._capture.shutdown()
+        self._capture = None
 
     async def _set_fps(self, fps: int) -> None:
-        assert self.device is not None
-        await self.device.set_fps(fps)
+        if self._capture is not None:
+            await self._capture.call('set_fps', fps)
 
     async def _get_fps(self) -> int | None:
-        assert self.device is not None
-
-        return await self.device.get_fps()
+        return await self._capture.call('get_fps') if self._capture is not None else None
 
     async def _set_resolution(self, resolution: tuple[int, int]) -> None:
-        assert self.device is not None
-
-        await self.device.set_resolution(*resolution)
+        if self._capture is not None:
+            await self._capture.call('set_resolution', *resolution)
 
     async def _get_resolution(self) -> tuple[int, int] | None:
-        assert self.device is not None
-
-        return await self.device.get_resolution()
+        return await self._capture.call('get_resolution') if self._capture is not None else None
 
     async def _set_mirrored(self, mirrored: bool) -> None:
-        assert self.device is not None
-
-        await self.device.set_mirrored(mirrored)
+        if self._capture is not None:
+            await self._capture.call('set_mirrored', mirrored)
 
     async def _get_mirrored(self) -> bool | None:
-        assert self.device is not None
-
-        return await self.device.get_mirrored()
+        return await self._capture.call('get_mirrored') if self._capture is not None else None

--- a/rosys/vision/mjpeg_camera/mjpeg_capture.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_capture.py
@@ -9,7 +9,7 @@ from multiprocessing.context import SpawnProcess
 from typing import Any
 
 from ...geometry import Rectangle
-from ..image import BytesImage, Image, ImageArray, MemfdImage
+from ..image import Image, ImageArray, MemfdImage
 from ..image_rotation import ImageRotation
 from .mjpeg_device import MjpegDevice
 from .mjpeg_device_factory import MjpegDeviceFactory
@@ -18,8 +18,8 @@ from .mjpeg_device_factory import MjpegDeviceFactory
 SPAWN_CONTEXT = multiprocessing.get_context('spawn')
 
 # memfd hands the frame to the main process as a file descriptor instead of copying the pixels through the
-# pipe (the main-process bottleneck). Linux-only; elsewhere we fall back to copying via BytesImage.
-ImageCarrier = MemfdImage if hasattr(os, 'memfd_create') else BytesImage
+# pipe (the main-process bottleneck). Linux-only; elsewhere we ship the Image itself (no gain, but correct).
+USE_MEMFD = hasattr(os, 'memfd_create')
 
 
 class MjpegCaptureProcess(SpawnProcess):  # always spawn
@@ -82,9 +82,10 @@ class MjpegCaptureProcess(SpawnProcess):  # always spawn
             self._stop.set()
 
     def _handle_image_data(self, image_array: ImageArray, timestamp: float) -> None:
-        carrier = ImageCarrier.from_array(image_array, camera_id=self._camera_id, time=timestamp)
+        factory = MemfdImage.from_array if USE_MEMFD else Image.from_array
+        payload = factory(image_array, camera_id=self._camera_id, time=timestamp)
         try:
-            self._image_writer.send(carrier)
+            self._image_writer.send(payload)
         except (BrokenPipeError, OSError):
             self._request_stop()
 
@@ -166,10 +167,11 @@ class MjpegCapture:
     def _read_images(self) -> None:
         while True:
             try:
-                carrier: BytesImage | MemfdImage = self._image_reader.recv()
+                payload: MemfdImage | Image = self._image_reader.recv()
             except (EOFError, OSError):
                 break
-            self._loop.call_soon_threadsafe(self._on_image, carrier.to_image())
+            image = payload.to_image() if isinstance(payload, MemfdImage) else payload
+            self._loop.call_soon_threadsafe(self._on_image, image)
 
     async def call(self, method: str, *args: Any) -> Any:
         """Run a device method in the subprocess and return its result (re-raising any exception)."""

--- a/rosys/vision/mjpeg_camera/mjpeg_capture.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_capture.py
@@ -8,8 +8,7 @@ from multiprocessing.context import SpawnProcess
 from typing import Any
 
 from ...geometry import Rectangle
-from ..image import Image
-from ..image_processing import process_jpeg_image
+from ..image import Image, ImageArray
 from ..image_rotation import ImageRotation
 from .mjpeg_device import MjpegDevice
 from .mjpeg_device_factory import MjpegDeviceFactory
@@ -61,6 +60,9 @@ class MjpegCaptureProcess(SpawnProcess):  # always spawn
         self._device = MjpegDeviceFactory.create(self._mac, self._ip, index=self._index,
                                                  username=self._username, password=self._password,
                                                  on_new_image_data=self._handle_image_data)
+        # set before the first await, so the capture task picks them up on its first frame
+        self._device.rotation = self._rotation
+        self._device.crop = self._crop
         for name, value in self._parameters.items():
             args = value if isinstance(value, tuple) else (value,)
             await self._call_device(f'set_{name}', args)
@@ -74,17 +76,12 @@ class MjpegCaptureProcess(SpawnProcess):  # always spawn
         if self._stop is not None:
             self._stop.set()
 
-    def _handle_image_data(self, image_bytes: bytes, timestamp: float) -> None:
-        if self._crop is not None or self._rotation != ImageRotation.NONE:
-            array = process_jpeg_image(image_bytes, self._rotation, self._crop)
-            image = None if array is None else Image.from_array(array, camera_id=self._camera_id, time=timestamp)
-        else:
-            image = Image.from_jpeg_bytes(image_bytes, camera_id=self._camera_id, time=timestamp)
-        if image is not None:
-            try:
-                self._image_writer.send(image)
-            except (BrokenPipeError, OSError):
-                self._request_stop()
+    def _handle_image_data(self, image_array: ImageArray, timestamp: float) -> None:
+        image = Image.from_array(image_array, camera_id=self._camera_id, time=timestamp)
+        try:
+            self._image_writer.send(image)
+        except (BrokenPipeError, OSError):
+            self._request_stop()
 
     def _on_control_readable(self) -> None:
         try:

--- a/rosys/vision/mjpeg_camera/mjpeg_capture.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_capture.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import multiprocessing
+import os
 import threading
 from collections.abc import Awaitable, Callable
 from multiprocessing.connection import Connection
@@ -8,13 +9,17 @@ from multiprocessing.context import SpawnProcess
 from typing import Any
 
 from ...geometry import Rectangle
-from ..image import BytesImage, Image, ImageArray
+from ..image import BytesImage, Image, ImageArray, MemfdImage
 from ..image_rotation import ImageRotation
 from .mjpeg_device import MjpegDevice
 from .mjpeg_device_factory import MjpegDeviceFactory
 
 # spawn, not fork (which is broken for Python), regardless of the global start method (see path planning, #19)
 SPAWN_CONTEXT = multiprocessing.get_context('spawn')
+
+# memfd hands the frame to the main process as a file descriptor instead of copying the pixels through the
+# pipe (the main-process bottleneck). Linux-only; elsewhere we fall back to copying via BytesImage.
+ImageCarrier = MemfdImage if hasattr(os, 'memfd_create') else BytesImage
 
 
 class MjpegCaptureProcess(SpawnProcess):  # always spawn
@@ -77,9 +82,9 @@ class MjpegCaptureProcess(SpawnProcess):  # always spawn
             self._stop.set()
 
     def _handle_image_data(self, image_array: ImageArray, timestamp: float) -> None:
-        bytes_image = BytesImage.from_array(image_array, camera_id=self._camera_id, time=timestamp)
+        carrier = ImageCarrier.from_array(image_array, camera_id=self._camera_id, time=timestamp)
         try:
-            self._image_writer.send(bytes_image)
+            self._image_writer.send(carrier)
         except (BrokenPipeError, OSError):
             self._request_stop()
 
@@ -161,10 +166,10 @@ class MjpegCapture:
     def _read_images(self) -> None:
         while True:
             try:
-                bytes_image: BytesImage = self._image_reader.recv()
+                carrier: BytesImage | MemfdImage = self._image_reader.recv()
             except (EOFError, OSError):
                 break
-            self._loop.call_soon_threadsafe(self._on_image, bytes_image.to_image())
+            self._loop.call_soon_threadsafe(self._on_image, carrier.to_image())
 
     async def call(self, method: str, *args: Any) -> Any:
         """Run a device method in the subprocess and return its result (re-raising any exception)."""

--- a/rosys/vision/mjpeg_camera/mjpeg_capture.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_capture.py
@@ -8,7 +8,7 @@ from multiprocessing.context import SpawnProcess
 from typing import Any
 
 from ...geometry import Rectangle
-from ..image import Image, ImageArray
+from ..image import BytesImage, Image, ImageArray
 from ..image_rotation import ImageRotation
 from .mjpeg_device import MjpegDevice
 from .mjpeg_device_factory import MjpegDeviceFactory
@@ -77,9 +77,9 @@ class MjpegCaptureProcess(SpawnProcess):  # always spawn
             self._stop.set()
 
     def _handle_image_data(self, image_array: ImageArray, timestamp: float) -> None:
-        image = Image.from_array(image_array, camera_id=self._camera_id, time=timestamp)
+        bytes_image = BytesImage.from_array(image_array, camera_id=self._camera_id, time=timestamp)
         try:
-            self._image_writer.send(image)
+            self._image_writer.send(bytes_image)
         except (BrokenPipeError, OSError):
             self._request_stop()
 
@@ -161,10 +161,10 @@ class MjpegCapture:
     def _read_images(self) -> None:
         while True:
             try:
-                image = self._image_reader.recv()
+                bytes_image: BytesImage = self._image_reader.recv()
             except (EOFError, OSError):
                 break
-            self._loop.call_soon_threadsafe(self._on_image, image)
+            self._loop.call_soon_threadsafe(self._on_image, bytes_image.to_image())
 
     async def call(self, method: str, *args: Any) -> Any:
         """Run a device method in the subprocess and return its result (re-raising any exception)."""

--- a/rosys/vision/mjpeg_camera/mjpeg_capture.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_capture.py
@@ -1,0 +1,195 @@
+import asyncio
+import logging
+import multiprocessing
+import threading
+from collections.abc import Awaitable, Callable
+from multiprocessing.connection import Connection
+from multiprocessing.context import SpawnProcess
+from typing import Any
+
+from ...geometry import Rectangle
+from ..image import Image
+from ..image_processing import process_jpeg_image
+from ..image_rotation import ImageRotation
+from .mjpeg_device import MjpegDevice
+from .mjpeg_device_factory import MjpegDeviceFactory
+
+# spawn, not fork (which is broken for Python), regardless of the global start method (see path planning, #19)
+SPAWN_CONTEXT = multiprocessing.get_context('spawn')
+
+
+class MjpegCaptureProcess(SpawnProcess):  # always spawn
+    """Subprocess that owns the MJPEG stream, decodes frames and ships ready ``Image`` objects."""
+
+    def __init__(self, *,
+                 camera_id: str,
+                 mac: str,
+                 ip: str,
+                 index: int | None,
+                 username: str | None,
+                 password: str | None,
+                 rotation: ImageRotation,
+                 crop: Rectangle | None,
+                 parameters: dict[str, Any],
+                 image_writer: Connection,
+                 control_connection: Connection) -> None:
+        super().__init__()
+        self._camera_id = camera_id
+        self._mac = mac
+        self._ip = ip
+        self._index = index
+        self._username = username
+        self._password = password
+        self._rotation = rotation
+        self._crop = crop
+        self._parameters = parameters
+        self._image_writer = image_writer
+        self._control_connection = control_connection
+        self.log = logging.getLogger(f'rosys.vision.mjpeg_camera.{camera_id}.process')
+        self._device: MjpegDevice | None = None
+        self._stop: asyncio.Event | None = None
+        self._tasks: set[asyncio.Task] = set()
+
+    def run(self) -> None:
+        try:
+            asyncio.run(self._main())
+        except (KeyboardInterrupt, EOFError):
+            pass
+
+    async def _main(self) -> None:
+        # constructing the device starts its capture task on this loop (see MjpegDevice.start_capture_task)
+        self._device = MjpegDeviceFactory.create(self._mac, self._ip, index=self._index,
+                                                 username=self._username, password=self._password,
+                                                 on_new_image_data=self._handle_image_data)
+        for name, value in self._parameters.items():
+            args = value if isinstance(value, tuple) else (value,)
+            await self._call_device(f'set_{name}', args)
+
+        self._stop = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        loop.add_reader(self._control_connection.fileno(), self._on_control_readable)
+        await self._stop.wait()
+
+    def _request_stop(self) -> None:
+        if self._stop is not None:
+            self._stop.set()
+
+    def _handle_image_data(self, image_bytes: bytes, timestamp: float) -> None:
+        if self._crop is not None or self._rotation != ImageRotation.NONE:
+            array = process_jpeg_image(image_bytes, self._rotation, self._crop)
+            image = None if array is None else Image.from_array(array, camera_id=self._camera_id, time=timestamp)
+        else:
+            image = Image.from_jpeg_bytes(image_bytes, camera_id=self._camera_id, time=timestamp)
+        if image is not None:
+            try:
+                self._image_writer.send(image)
+            except (BrokenPipeError, OSError):
+                self._request_stop()
+
+    def _on_control_readable(self) -> None:
+        try:
+            command = self._control_connection.recv()
+        except EOFError:
+            self._request_stop()
+            return
+        if command is None:  # shutdown sentinel
+            self._request_stop()
+            return
+        task = asyncio.create_task(self._handle_command(command))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _handle_command(self, command: tuple[str, tuple]) -> None:
+        method, args = command
+        result = await self._call_device(method, args)
+        try:
+            self._control_connection.send(result)
+        except (BrokenPipeError, OSError):
+            self._request_stop()
+
+    async def _call_device(self, method: str, args: tuple) -> Any:
+        assert self._device is not None
+        try:
+            result = getattr(self._device, method)(*args)
+            if isinstance(result, Awaitable):
+                result = await result
+            return result
+        except Exception as e:  # forwarded to the caller, which re-raises
+            self.log.exception('command %s%s failed', method, args)
+            return e
+
+
+class MjpegCapture:
+    """Parent-side handle for an :class:`MjpegCaptureProcess`.
+
+    Owns the process boundary: it creates both pipes, spawns the process with the child ends, and keeps the
+    parent ends. Decoded images arrive on a reader thread and are delivered onto ``loop`` via ``on_image``;
+    ``set_*`` / ``get_*`` requests are forwarded over the control pipe by :meth:`call`.
+    """
+
+    def __init__(self, *,
+                 camera_id: str,
+                 mac: str,
+                 ip: str,
+                 index: int | None,
+                 username: str | None,
+                 password: str | None,
+                 rotation: ImageRotation,
+                 crop: Rectangle | None,
+                 parameters: dict[str, Any],
+                 loop: asyncio.AbstractEventLoop,
+                 on_image: Callable[[Image], None]) -> None:
+        self._loop = loop
+        self._on_image = on_image
+        self._control_lock = threading.Lock()
+
+        self._image_reader, self._image_writer = SPAWN_CONTEXT.Pipe(duplex=False)
+        self._control_parent, control_child = SPAWN_CONTEXT.Pipe()
+        self._control_connection = control_child
+        self._process = MjpegCaptureProcess(camera_id=camera_id, mac=mac, ip=ip, index=index,
+                                            username=username, password=password,
+                                            rotation=rotation, crop=crop, parameters=parameters,
+                                            image_writer=self._image_writer, control_connection=control_child)
+
+    @property
+    def is_running(self) -> bool:
+        return self._process.is_alive()
+
+    def start(self) -> None:
+        self._process.start()
+        self._image_writer.close()  # the child holds the only writing end now, so the reader sees EOF on exit
+        self._control_connection.close()
+        threading.Thread(target=self._read_images, daemon=True).start()
+
+    def _read_images(self) -> None:
+        while True:
+            try:
+                image = self._image_reader.recv()
+            except (EOFError, OSError):
+                break
+            self._loop.call_soon_threadsafe(self._on_image, image)
+
+    async def call(self, method: str, *args: Any) -> Any:
+        """Run a device method in the subprocess and return its result (re-raising any exception)."""
+        if not self._process.is_alive():
+            return None
+        return await self._loop.run_in_executor(None, self._call_sync, method, args)
+
+    def _call_sync(self, method: str, args: tuple) -> Any:
+        with self._control_lock:
+            self._control_parent.send((method, args))
+            result = self._control_parent.recv()
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    async def shutdown(self) -> None:
+        try:
+            self._control_parent.send(None)  # shutdown sentinel
+        except (BrokenPipeError, OSError):
+            pass
+        await self._loop.run_in_executor(None, self._process.join, 5.0)
+        if self._process.is_alive():
+            self._process.terminate()
+        self._image_reader.close()
+        self._control_parent.close()

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -7,11 +7,17 @@ from contextlib import asynccontextmanager
 import httpx
 
 from ... import rosys
+from ...geometry import Rectangle
 from ...rosys import on_startup
-from ..image_processing import remove_exif
+from ..image import ImageArray
+from ..image_processing import process_jpeg_image, remove_exif
+from ..image_rotation import ImageRotation
 from .vendors import mac_to_url
 
 log = logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device')
+
+ImageDataHandler = Callable[[ImageArray, float], Awaitable | None]
+"""Receives a decoded, cropped and rotated frame together with its capture timestamp."""
 
 
 def parse_capture_timestamp(part_header: bytes) -> float | None:
@@ -40,12 +46,14 @@ class MjpegDevice:
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
+                 on_new_image_data: ImageDataHandler) -> None:
         self._mac = mac
         self._ip = ip
         self.log = logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device.' + self._mac)
 
         self._on_new_image_data = on_new_image_data
+        self.rotation: ImageRotation = ImageRotation.NONE
+        self.crop: Rectangle | None = None
         self._capture_task: Task | None = None
         self._username = username
         self._password = password
@@ -133,7 +141,10 @@ class MjpegDevice:
                                 continue
                             try:
                                 timestamp = capture_time if capture_time is not None else rosys.time()
-                                result = self._on_new_image_data(remove_exif(image), timestamp)
+                                array = process_jpeg_image(remove_exif(image), self.rotation, self.crop)
+                                if array is None:
+                                    continue
+                                result = self._on_new_image_data(array, timestamp)
                                 if isinstance(result, Awaitable):
                                     await result
                             except Exception as e:

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -64,7 +64,12 @@ class MjpegDevice:
         def create_capture_task() -> None:
             loop = asyncio.get_event_loop()
             self._capture_task = loop.create_task(self.run_capture_task())
-        on_startup(create_capture_task)
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            on_startup(create_capture_task)  # no loop yet (e.g. constructed at import time): defer to startup
+        else:
+            create_capture_task()  # a loop is already running (e.g. inside the capture subprocess)
 
     def restart_capture(self) -> None:
         self.log.debug('Restarting capture task')

--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -1,8 +1,6 @@
-from collections.abc import Awaitable, Callable
-
 from .arkvision_mjpeg_device import ArkVisionMjpegDevice
 from .axis_mjpeg_device import AxisMjpegDevice
-from .mjpeg_device import MjpegDevice
+from .mjpeg_device import ImageDataHandler, MjpegDevice
 from .motec_mjpeg_device import MotecMjpegDevice
 from .openipc_zauberzeug_mjpeg_device import OpenIpcZauberzeugMjpegDevice
 from .vendors import VendorType, mac_to_vendor
@@ -15,7 +13,7 @@ class MjpegDeviceFactory:
                username: str | None = None,
                password: str | None = None,
                control_port: int | None = None,
-               on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> MjpegDevice:
+               on_new_image_data: ImageDataHandler) -> MjpegDevice:
 
         vendor = mac_to_vendor(mac)
 

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -1,6 +1,5 @@
-from collections.abc import Awaitable, Callable
 
-from .mjpeg_device import MjpegDevice
+from .mjpeg_device import ImageDataHandler, MjpegDevice
 from .motec_settings_interface import MotecSettingsInterface
 from .vendors import VendorType, mac_to_vendor
 
@@ -10,7 +9,7 @@ class MotecMjpegDevice(MjpegDevice):
                  username: str | None = '',
                  password: str | None = '',
                  control_port: int | None = 8885,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
+                 on_new_image_data: ImageDataHandler) -> None:
 
         super().__init__(mac, ip, username=username, password=password, on_new_image_data=on_new_image_data)
 

--- a/rosys/vision/mjpeg_camera/openipc_zauberzeug_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/openipc_zauberzeug_mjpeg_device.py
@@ -1,7 +1,5 @@
-from collections.abc import Awaitable, Callable
-
 from ..openipc_zauberzeug_settings_interface import OpenIpcZauberzeugSettingsInterface
-from .mjpeg_device import MjpegDevice
+from .mjpeg_device import ImageDataHandler, MjpegDevice
 from .vendors import VendorType, mac_to_vendor
 
 
@@ -16,7 +14,7 @@ class OpenIpcZauberzeugMjpegDevice(MjpegDevice):
     def __init__(self, mac: str, ip: str, *,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
+                 on_new_image_data: ImageDataHandler) -> None:
         super().__init__(mac, ip, username=username, password=password, on_new_image_data=on_new_image_data)
 
         vendor = mac_to_vendor(mac)


### PR DESCRIPTION
### Motivation

Mjpeg cameras handling is currently still bottlenecked by reading the image from the pipe.

### Implementation

Introduce MemfdImage which stores pixels in a memory-backed anonymous file. This handle can cheaply be sent to another process and be unpacked there without copies.
Disadvantage: This is only supported on Linux and only on python versions with a recent libc.

Depends on #425.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [ ] The implementation is complete.
- [ ] Pytests have been added (or are not necessary).
- [ ] Documentation has been added (or is not necessary).
