### PR TITLE
Add `scope` parameter to `on_repeat` and `Repeater`

### DIFF
--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -13,7 +13,6 @@ from typing import Any, ClassVar, Literal
 import numpy as np
 import psutil
 from nicegui import Client, Event, app, background_tasks, context, ui
-from nicegui import core as nicegui_core
 from nicegui.slot import Slot
 
 from . import core, helpers, run
@@ -145,28 +144,23 @@ def _run_handler(handler: Callable) -> None:
         log.exception('error while starting handler "%s"', handler.__qualname__)
 
 
-def _resolve_scope(scope: Literal['app', 'client', 'auto'], handler: Callable) -> Client | None:
+def _resolve_scope(scope: Literal['app', 'client'], handler: Callable) -> Client | None:
     """Return the client whose deletion should end the handler's lifetime (None for app lifetime)."""
     if scope == 'app':
         return None
     # NOTE: check the stack first, because accessing `context.client` outside a UI context would enter script mode
     if Slot.get_stack():
-        client = context.client
-        # NOTE: with 'auto' we must not bind to the script-mode client, which is deleted before startup;
-        # with 'client' binding to it is correct: the pre-flight repeater dies with it,
+        # NOTE: this may be the script-mode client, which is deleted before startup;
+        # binding to it is correct: the pre-flight repeater dies with it,
         # while each per-connection re-execution binds to its own client
-        if scope == 'client' or client is not nicegui_core.script_client:
-            return client
-        return None
-    if scope == 'client':
-        raise RuntimeError(f'cannot bind repeater for {handler} to a client outside of a UI context')
-    return None
+        return context.client
+    raise RuntimeError(f'cannot bind repeater for {handler} to a client outside of a UI context')
 
 
 class Repeater:
     tasks: ClassVar[set[asyncio.Task]] = set()
 
-    def __init__(self, handler: Callable, interval: float, *, scope: Literal['app', 'client', 'auto'] = 'app') -> None:
+    def __init__(self, handler: Callable, interval: float, *, scope: Literal['app', 'client'] = 'app') -> None:
         self.handler: Callable | None = handler
         self.interval = interval
         self._task: asyncio.Task | None = None
@@ -244,12 +238,11 @@ class Repeater:
             repeater.cancel()
 
 
-def on_repeat(handler: Callable, interval: float, *, scope: Literal['app', 'client', 'auto'] = 'app') -> Repeater:
+def on_repeat(handler: Callable, interval: float, *, scope: Literal['app', 'client'] = 'app') -> Repeater:
     """Repeatedly call a handler with a given interval.
 
     With ``scope='app'`` the repeater runs for the lifetime of the app.
     With ``scope='client'`` it must be created within a UI context and stops when that client is deleted.
-    With ``scope='auto'`` it binds to the client if created within a UI context and to the app otherwise.
     """
     repeater = Repeater(handler, interval, scope=scope)
     repeater.start()

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -144,31 +144,19 @@ def _run_handler(handler: Callable) -> None:
         log.exception('error while starting handler "%s"', handler.__qualname__)
 
 
-def _resolve_scope(scope: Literal['app', 'client'], handler: Callable) -> Client | None:
-    """Return the client whose deletion should end the handler's lifetime (None for app lifetime)."""
-    if scope == 'app':
-        return None
-    # NOTE: check the stack first, because accessing `context.client` outside a UI context would enter script mode
-    if Slot.get_stack():
-        # NOTE: this may be the script-mode client, which is deleted before startup;
-        # binding to it is correct: the pre-flight repeater dies with it,
-        # while each per-connection re-execution binds to its own client
-        return context.client
-    raise RuntimeError(f'cannot bind repeater for {handler} to a client outside of a UI context')
-
-
 class Repeater:
     tasks: ClassVar[set[asyncio.Task]] = set()
 
-    def __init__(self, handler: Callable, interval: float, *, scope: Literal['app', 'client'] = 'app') -> None:
+    def __init__(self, handler: Callable, interval: float, *, client_scoped: bool = False) -> None:
         self.handler: Callable | None = handler
         self.interval = interval
         self._task: asyncio.Task | None = None
         self._client_deleted = False
-        client = _resolve_scope(scope, handler)
-        if client is not None:
+        if client_scoped:
+            if not Slot.get_stack():  # NOTE: check the stack; accessing `context.client` would enter script mode
+                raise RuntimeError(f'cannot bind repeater for {handler} to a client outside of a UI context')
             # NOTE: not storing the client avoids a reference cycle that would outlive its deletion
-            client.on_delete(self._handle_client_delete)
+            context.client.on_delete(self._handle_client_delete)
 
     def _handle_client_delete(self) -> None:
         self._client_deleted = True
@@ -238,13 +226,12 @@ class Repeater:
             repeater.cancel()
 
 
-def on_repeat(handler: Callable, interval: float, *, scope: Literal['app', 'client'] = 'app') -> Repeater:
+def on_repeat(handler: Callable, interval: float, *, client_scoped: bool = False) -> Repeater:
     """Repeatedly call a handler with a given interval.
 
-    With ``scope='app'`` the repeater runs for the lifetime of the app.
-    With ``scope='client'`` it must be created within a UI context and stops when that client is deleted.
+    A client-scoped repeater must be created within a UI context and stops when that client is deleted.
     """
-    repeater = Repeater(handler, interval, scope=scope)
+    repeater = Repeater(handler, interval, client_scoped=client_scoped)
     repeater.start()
     return repeater
 

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -13,6 +13,7 @@ from typing import Any, ClassVar, Literal
 import numpy as np
 import psutil
 from nicegui import Client, Event, app, background_tasks, context, ui
+from nicegui import core as nicegui_core
 from nicegui.slot import Slot
 
 from . import core, helpers, run
@@ -148,8 +149,11 @@ def _resolve_scope(scope: Literal['app', 'client', 'auto'], handler: Callable) -
     """Return the client whose deletion should end the handler's lifetime (None for app lifetime)."""
     if scope == 'app':
         return None
-    if Slot.get_stack():  # NOTE: check the stack first; accessing `context.client` outside a UI context would enter script mode
-        return context.client
+    # NOTE: check the stack first, because accessing `context.client` outside a UI context would enter script mode
+    if Slot.get_stack():
+        client = context.client
+        if client is not nicegui_core.script_client:  # NOTE: the script-mode client is deleted before startup
+            return client
     if scope == 'client':
         raise RuntimeError(f'cannot bind repeater for {handler} to a client outside of a UI context')
     return None
@@ -162,24 +166,25 @@ class Repeater:
         self.handler = handler
         self.interval = interval
         self._task: asyncio.Task | None = None
-        self._client = _resolve_scope(scope, handler)
-        if self._client is not None:
-            self._client.on_delete(self.stop)
+        self._client_deleted = False
+        client = _resolve_scope(scope, handler)
+        if client is not None:
+            # NOTE: not storing the client avoids a reference cycle that would outlive its deletion
+            client.on_delete(self._handle_client_delete)
+
+    def _handle_client_delete(self) -> None:
+        self._client_deleted = True
+        self.stop()
 
     def start(self) -> None:
-        if self.running:
+        if self.running or self._client_deleted:  # a client-scoped repeater must not outlive its client
             return
         if _state.startup_finished:
             self._task = background_tasks.create(self._repeat())
             self.tasks.add(self._task)
-            self._task.add_done_callback(self._handle_task_done)
+            self._task.add_done_callback(self.tasks.discard)
         elif self.start not in startup_handlers:
             startup_handlers.append(self.start)
-
-    def _handle_task_done(self, task: asyncio.Task) -> None:
-        self.tasks.discard(task)
-        if self._task is task:  # not a stale callback from a task replaced by a restart
-            self._task = None
 
     async def _repeat(self) -> None:
         await sleep(self.interval)  # NOTE delaying first execution so not all actors rush in at the same time
@@ -259,7 +264,7 @@ async def startup() -> None:
 
     _state.startup_finished = True
 
-    for handler in startup_handlers:
+    for handler in list(startup_handlers):  # NOTE: snapshot, because a handler can mutate the list via Repeater.stop()
         _run_handler(handler)
 
 

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -265,7 +265,8 @@ async def startup() -> None:
     _state.startup_finished = True
 
     for handler in list(startup_handlers):  # NOTE: snapshot, because a handler can mutate the list via Repeater.stop()
-        _run_handler(handler)
+        if handler in startup_handlers:  # NOTE: a previous handler may have removed this one via Repeater.stop()
+            _run_handler(handler)
 
 
 async def _garbage_collection() -> None:

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -152,8 +152,12 @@ def _resolve_scope(scope: Literal['app', 'client', 'auto'], handler: Callable) -
     # NOTE: check the stack first, because accessing `context.client` outside a UI context would enter script mode
     if Slot.get_stack():
         client = context.client
-        if client is not nicegui_core.script_client:  # NOTE: the script-mode client is deleted before startup
+        # NOTE: with 'auto' we must not bind to the script-mode client, which is deleted before startup;
+        # with 'client' binding to it is correct: the pre-flight repeater dies with it,
+        # while each per-connection re-execution binds to its own client
+        if scope == 'client' or client is not nicegui_core.script_client:
             return client
+        return None
     if scope == 'client':
         raise RuntimeError(f'cannot bind repeater for {handler} to a client outside of a UI context')
     return None
@@ -163,7 +167,7 @@ class Repeater:
     tasks: ClassVar[set[asyncio.Task]] = set()
 
     def __init__(self, handler: Callable, interval: float, *, scope: Literal['app', 'client', 'auto'] = 'app') -> None:
-        self.handler = handler
+        self.handler: Callable | None = handler
         self.interval = interval
         self._task: asyncio.Task | None = None
         self._client_deleted = False
@@ -175,6 +179,9 @@ class Repeater:
     def _handle_client_delete(self) -> None:
         self._client_deleted = True
         self.stop()
+        # NOTE: the client never clears its delete handlers, so release the handler to not pin its owner;
+        # this is safe because stop() has cancelled the task and _client_deleted blocks any restart
+        self.handler = None
 
     def start(self) -> None:
         if self.running or self._client_deleted:  # a client-scoped repeater must not outlive its client
@@ -187,24 +194,26 @@ class Repeater:
             startup_handlers.append(self.start)
 
     async def _repeat(self) -> None:
+        handler = self.handler
+        assert handler is not None  # NOTE: the handler is only released after the task has been cancelled
         await sleep(self.interval)  # NOTE delaying first execution so not all actors rush in at the same time
         while True:
             start = time()
             try:
                 if is_stopping():
-                    log.info('%s must be stopped', self.handler)
+                    log.info('%s must be stopped', handler)
                     break
-                await invoke(self.handler)
+                await invoke(handler)
                 dt = time() - start
             except (asyncio.CancelledError, GeneratorExit):
                 return
             except Exception:
                 dt = time() - start
-                log.exception('error in "%s"', self.handler.__qualname__)
+                log.exception('error in "%s"', handler.__qualname__)
                 if self.interval == 0 and dt < 0.1:
                     delay = 0.1 - dt
                     log.warning(
-                        f'"{self.handler.__qualname__}" would be called to frequently ' +
+                        f'"{handler.__qualname__}" would be called to frequently ' +
                         f'because it only took {dt*1000:.0f} ms; ' +
                         f'delaying this step for {delay*1000:.0f} ms')
                     await sleep(delay)

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -12,7 +12,8 @@ from typing import Any, ClassVar, Literal
 
 import numpy as np
 import psutil
-from nicegui import Client, Event, app, background_tasks, ui
+from nicegui import Client, Event, app, background_tasks, context, ui
+from nicegui.slot import Slot
 
 from . import core, helpers, run
 from .config import Config
@@ -143,13 +144,27 @@ def _run_handler(handler: Callable) -> None:
         log.exception('error while starting handler "%s"', handler.__qualname__)
 
 
+def _resolve_scope(scope: Literal['app', 'client', 'auto'], handler: Callable) -> Client | None:
+    """Return the client whose deletion should end the handler's lifetime (None for app lifetime)."""
+    if scope == 'app':
+        return None
+    if Slot.get_stack():  # NOTE: check the stack first; accessing `context.client` outside a UI context would enter script mode
+        return context.client
+    if scope == 'client':
+        raise RuntimeError(f'cannot bind repeater for {handler} to a client outside of a UI context')
+    return None
+
+
 class Repeater:
     tasks: ClassVar[set[asyncio.Task]] = set()
 
-    def __init__(self, handler: Callable, interval: float) -> None:
+    def __init__(self, handler: Callable, interval: float, *, scope: Literal['app', 'client', 'auto'] = 'app') -> None:
         self.handler = handler
         self.interval = interval
         self._task: asyncio.Task | None = None
+        self._client = _resolve_scope(scope, handler)
+        if self._client is not None:
+            self._client.on_delete(self.stop)
 
     def start(self) -> None:
         if self.running:
@@ -157,8 +172,14 @@ class Repeater:
         if _state.startup_finished:
             self._task = background_tasks.create(self._repeat())
             self.tasks.add(self._task)
+            self._task.add_done_callback(self._handle_task_done)
         elif self.start not in startup_handlers:
             startup_handlers.append(self.start)
+
+    def _handle_task_done(self, task: asyncio.Task) -> None:
+        self.tasks.discard(task)
+        if self._task is task:  # not a stale callback from a task replaced by a restart
+            self._task = None
 
     async def _repeat(self) -> None:
         await sleep(self.interval)  # NOTE delaying first execution so not all actors rush in at the same time
@@ -188,13 +209,15 @@ class Repeater:
                 return
 
     def stop(self) -> None:
+        if self.start in startup_handlers:  # a deferred start must not revive the repeater at startup
+            startup_handlers.remove(self.start)
         if not self._task:
             return
 
         if not self._task.done():
             self._task.cancel()
 
-        self.tasks.remove(self._task)
+        self.tasks.discard(self._task)
         self._task = None
 
     @property
@@ -207,8 +230,14 @@ class Repeater:
             repeater.cancel()
 
 
-def on_repeat(handler: Callable, interval: float) -> Repeater:
-    repeater = Repeater(handler, interval)
+def on_repeat(handler: Callable, interval: float, *, scope: Literal['app', 'client', 'auto'] = 'app') -> Repeater:
+    """Repeatedly call a handler with a given interval.
+
+    With ``scope='app'`` the repeater runs for the lifetime of the app.
+    With ``scope='client'`` it must be created within a UI context and stops when that client is deleted.
+    With ``scope='auto'`` it binds to the client if created within a UI context and to the app otherwise.
+    """
+    repeater = Repeater(handler, interval, scope=scope)
     repeater.start()
     return repeater
 

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 
@@ -23,16 +24,20 @@ class CameraProjector:
 
     It is mainly used for visualization purposes.
 
-    The update loop uses ``scope='auto'``: constructed within a UI context it stops when that client is deleted,
-    so construct shared instances outside of a UI context to keep them running for the app lifetime.
+    The ``scope`` parameter controls the lifetime of the update loop (see ``rosys.on_repeat``).
+    The default ``'app'`` keeps the projector running independently of where it was constructed;
+    pass ``'client'`` for a page-local projector that should stop when its client is deleted.
     """
 
-    def __init__(self, camera_provider: CalibratableCameraProvider, *, interval: float = 1.0) -> None:
+    def __init__(self,
+                 camera_provider: CalibratableCameraProvider, *,
+                 interval: float = 1.0,
+                 scope: Literal['app', 'client', 'auto'] = 'app') -> None:
         self.camera_provider = camera_provider
 
         self.projections: dict[str, Projection] = {}
 
-        rosys.on_repeat(self.step, interval, scope='auto')
+        rosys.on_repeat(self.step, interval, scope=scope)
 
     async def step(self) -> None:
         for id_ in list(self.projections):

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -32,7 +32,7 @@ class CameraProjector:
     def __init__(self,
                  camera_provider: CalibratableCameraProvider, *,
                  interval: float = 1.0,
-                 scope: Literal['app', 'client', 'auto'] = 'app') -> None:
+                 scope: Literal['app', 'client'] = 'app') -> None:
         self.camera_provider = camera_provider
 
         self.projections: dict[str, Projection] = {}

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -29,7 +29,7 @@ class CameraProjector:
 
         self.projections: dict[str, Projection] = {}
 
-        rosys.on_repeat(self.step, interval)
+        rosys.on_repeat(self.step, interval, scope='auto')
 
     async def step(self) -> None:
         for id_ in list(self.projections):

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -22,6 +22,9 @@ class CameraProjector:
     """The camera projector computes a grid of projected image points on the ground plane.
 
     It is mainly used for visualization purposes.
+
+    The update loop uses ``scope='auto'``: constructed within a UI context it stops when that client is deleted,
+    so construct shared instances outside of a UI context to keep them running for the app lifetime.
     """
 
     def __init__(self, camera_provider: CalibratableCameraProvider, *, interval: float = 1.0) -> None:

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Literal
 
 import numpy as np
 
@@ -23,21 +22,17 @@ class CameraProjector:
     """The camera projector computes a grid of projected image points on the ground plane.
 
     It is mainly used for visualization purposes.
-
-    The ``scope`` parameter controls the lifetime of the update loop (see ``rosys.on_repeat``).
-    The default ``'app'`` keeps the projector running independently of where it was constructed;
-    pass ``'client'`` for a page-local projector that should stop when its client is deleted.
     """
 
     def __init__(self,
                  camera_provider: CalibratableCameraProvider, *,
                  interval: float = 1.0,
-                 scope: Literal['app', 'client'] = 'app') -> None:
+                 client_scoped: bool = False) -> None:
         self.camera_provider = camera_provider
 
         self.projections: dict[str, Projection] = {}
 
-        rosys.on_repeat(self.step, interval, scope=scope)
+        rosys.on_repeat(self.step, interval, client_scoped=client_scoped)
 
     async def step(self) -> None:
         for id_ in list(self.projections):

--- a/tests/test_camera_projector.py
+++ b/tests/test_camera_projector.py
@@ -11,7 +11,7 @@ from rosys.vision import CalibratableCamera, CameraProjector, SimulatedCameraPro
 @pytest.mark.usefixtures('rosys_integration')
 async def test_projector_created_in_ui_context_keeps_running_by_default():
     # NOTE: a shared projector may be constructed lazily inside a page handler;
-    # the default scope='app' must keep it running when that client is deleted.
+    # by default it must keep running when that client is deleted.
     steps: list[float] = []
 
     class CountingProjector(CameraProjector):

--- a/tests/test_camera_projector.py
+++ b/tests/test_camera_projector.py
@@ -1,6 +1,32 @@
 import numpy as np
+import pytest
+from nicegui import Client
+from nicegui.page import page
 
-from rosys.vision import CalibratableCamera, CameraProjector
+import rosys
+from rosys.testing import forward
+from rosys.vision import CalibratableCamera, CameraProjector, SimulatedCameraProvider
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_projector_created_in_ui_context_keeps_running_by_default():
+    # NOTE: a shared projector may be constructed lazily inside a page handler;
+    # the default scope='app' must keep it running when that client is deleted.
+    steps: list[float] = []
+
+    class CountingProjector(CameraProjector):
+
+        async def step(self) -> None:
+            await super().step()
+            steps.append(rosys.time())
+
+    client = Client(page('/projector-test'), request=None)
+    with client:
+        CountingProjector(SimulatedCameraProvider(), interval=0.1)
+    client.delete()
+
+    await forward(0.35)
+    assert steps  # still ticking after the constructing client is gone
 
 
 def test_projection():

--- a/tests/test_repeater.py
+++ b/tests/test_repeater.py
@@ -41,137 +41,102 @@ async def test_repeater_can_restart_after_stop():
 
 
 @pytest.mark.usefixtures('rosys_integration')
-async def test_app_scoped_repeater_ignores_ui_context():
-    ticker = Ticker()
-    client = Client(page('/app-scope-test'), request=None)
-    with client:
-        repeater = rosys.on_repeat(ticker.step, 0.1)
-
-    client.delete()
-    await forward(0.35)
-    assert repeater.running  # the default scope is not affected by client deletion
-
-
-@pytest.mark.usefixtures('rosys_integration')
 async def test_client_scoped_repeater_stops_when_client_is_deleted():
-    ticker = Ticker()
-    client = Client(page('/client-scope-test'), request=None)
+    app_ticker = Ticker()
+    client_ticker = Ticker()
+    client = Client(page('/scope-test'), request=None)
     with client:
-        repeater = rosys.on_repeat(ticker.step, 0.1, scope='client')
+        app_repeater = rosys.on_repeat(app_ticker.step, 0.1)
+        client_repeater = rosys.on_repeat(client_ticker.step, 0.1, client_scoped=True)
 
     await forward(0.35)
-    assert repeater.running
-    calls_while_alive = len(ticker.calls)
+    assert client_repeater.running
+    calls_while_alive = len(client_ticker.calls)
     assert calls_while_alive >= 1  # the repeater was actually ticking
 
     client.delete()
-    assert not repeater.running  # the client teardown stopped the repeater
-    assert repeater.handler is None  # the handler is released so the deleted client does not pin its owner
-    repeater.start()
-    assert not repeater.running  # a client-scoped repeater cannot be revived after its client is deleted
+    assert app_repeater.running  # the default is not affected by client deletion
+    assert not client_repeater.running  # the client teardown stopped the client-scoped repeater
+    assert client_repeater.handler is None  # the handler is released so the deleted client does not pin its owner
+    client_repeater.start()
+    assert not client_repeater.running  # a client-scoped repeater cannot be revived after its client is deleted
     await forward(0.5)
-    assert len(ticker.calls) == calls_while_alive  # no more ticks after deletion
+    assert len(client_ticker.calls) == calls_while_alive  # no more ticks after deletion
 
 
 @pytest.mark.usefixtures('rosys_integration')
-async def test_client_scope_outside_ui_context_raises():
+async def test_client_scoped_repeater_outside_ui_context_raises():
     ticker = Ticker()
     with pytest.raises(RuntimeError):
-        rosys.on_repeat(ticker.step, 0.1, scope='client')
+        rosys.on_repeat(ticker.step, 0.1, client_scoped=True)
 
 
-@pytest.mark.usefixtures('rosys_integration')
-async def test_client_scope_binds_to_script_mode_client():
-    # NOTE: NiceGUI deletes the script-mode client before startup;
-    # a client-scoped repeater binds to it and dies with it, like with any other client.
-    ticker = Ticker()
-    client = Client(page('/script-mode-test'), request=None)
-    core.script_client = client
-    try:
-        with client:
-            repeater = rosys.on_repeat(ticker.step, 0.1, scope='client')
-        client.delete()
-    finally:
-        core.script_client = None
-
-    assert not repeater.running  # died with the script-mode client
+@pytest.fixture
+async def pre_startup():
+    """Set up a rosys test environment without running startup, so tests can exercise deferred starts."""
+    core.loop = asyncio.get_event_loop()
+    rosys.reset_before_test()
+    yield
+    if _state.startup_finished:
+        await rosys.shutdown()
+    rosys.reset_after_test()
 
 
+@pytest.mark.usefixtures('pre_startup')
 async def test_stop_before_startup_prevents_deferred_start():
     # NOTE: a repeater created pre-startup defers its start; stopping it before startup
     # must remove the deferred start so the repeater is not revived when startup replays the handlers.
-    core.loop = asyncio.get_event_loop()
-    rosys.reset_before_test()
-    try:
-        assert not _state.startup_finished
+    ticker = Ticker()
+    repeater = rosys.on_repeat(ticker.step, 0.01)
+    assert not repeater.running  # start was deferred, not launched
+    assert repeater.start in startup_handlers
 
-        ticker = Ticker()
-        repeater = rosys.on_repeat(ticker.step, 0.01)
-        assert not repeater.running  # start was deferred, not launched
-        assert repeater.start in startup_handlers
+    repeater.stop()
+    assert repeater.start not in startup_handlers
 
-        repeater.stop()
-        assert repeater.start not in startup_handlers
+    await rosys.startup()  # replays the deferred start handlers
 
-        await rosys.startup()  # replays the deferred start handlers
-
-        assert not repeater.running  # the stopped repeater was not revived
-
-        await rosys.shutdown()
-    finally:
-        rosys.reset_after_test()
+    assert not repeater.running  # the stopped repeater was not revived
 
 
+@pytest.mark.usefixtures('pre_startup')
 async def test_stopping_repeater_during_startup_does_not_skip_other_handlers():
     # NOTE: Repeater.stop() removes a deferred start from startup_handlers;
     # startup() must iterate a snapshot so this mutation does not skip the following handler.
-    core.loop = asyncio.get_event_loop()
-    rosys.reset_before_test()
-    try:
-        ticker = Ticker()
-        repeater = rosys.on_repeat(ticker.step, 0.01)
-        events: list[str] = []
+    ticker = Ticker()
+    repeater = rosys.on_repeat(ticker.step, 0.01)
+    events: list[str] = []
 
-        def stopper() -> None:
-            repeater.stop()
-            events.append('stopper')
+    def stopper() -> None:
+        repeater.stop()
+        events.append('stopper')
 
-        def victim() -> None:
-            events.append('victim')
+    def victim() -> None:
+        events.append('victim')
 
-        rosys.on_startup(stopper)
-        rosys.on_startup(victim)
+    rosys.on_startup(stopper)
+    rosys.on_startup(victim)
 
-        await rosys.startup()
+    await rosys.startup()
 
-        assert events == ['stopper', 'victim']  # the mutation must not skip the next startup handler
-        assert not repeater.running
-
-        await rosys.shutdown()
-    finally:
-        rosys.reset_after_test()
+    assert events == ['stopper', 'victim']  # the mutation must not skip the next startup handler
+    assert not repeater.running
 
 
+@pytest.mark.usefixtures('pre_startup')
 async def test_stopping_repeater_during_startup_does_not_revive_it():
     # NOTE: flipped ordering of the test above: when the stopping handler precedes the deferred start,
     # startup() must not invoke the stale snapshot entry and revive the stopped repeater.
-    core.loop = asyncio.get_event_loop()
-    rosys.reset_before_test()
-    try:
-        ticker = Ticker()
-        repeaters: list[Repeater] = []
+    ticker = Ticker()
+    repeaters: list[Repeater] = []
 
-        def stopper() -> None:
-            repeaters[0].stop()
+    def stopper() -> None:
+        repeaters[0].stop()
 
-        rosys.on_startup(stopper)  # registered before the repeater, so its deferred start comes later
-        repeaters.append(rosys.on_repeat(ticker.step, 0.01))
-        assert startup_handlers.index(stopper) < startup_handlers.index(repeaters[0].start)
+    rosys.on_startup(stopper)  # registered before the repeater, so its deferred start comes later
+    repeaters.append(rosys.on_repeat(ticker.step, 0.01))
+    assert startup_handlers.index(stopper) < startup_handlers.index(repeaters[0].start)
 
-        await rosys.startup()
+    await rosys.startup()
 
-        assert not repeaters[0].running  # the stopped repeater was not revived by the snapshot
-
-        await rosys.shutdown()
-    finally:
-        rosys.reset_after_test()
+    assert not repeaters[0].running  # the stopped repeater was not revived by the snapshot

--- a/tests/test_repeater.py
+++ b/tests/test_repeater.py
@@ -1,0 +1,111 @@
+import asyncio
+
+import pytest
+from nicegui import Client, core
+from nicegui.page import page
+
+import rosys
+from rosys.rosys import _state, startup_handlers
+from rosys.testing import forward
+
+
+class Ticker:
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    def step(self) -> None:
+        self.calls.append(rosys.time())
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_repeater_can_restart_after_stop():
+    ticker = Ticker()
+    repeater = rosys.on_repeat(ticker.step, 0.1)
+
+    await forward(0.35)
+    assert repeater.running
+    assert len(ticker.calls) >= 1
+
+    repeater.stop()
+    assert not repeater.running
+    calls_after_stop = len(ticker.calls)
+    await forward(0.5)
+    assert len(ticker.calls) == calls_after_stop  # stopped: no more ticks
+
+    repeater.start()
+    assert repeater.running  # a plain stop() must not permanently disable restart
+    await forward(0.35)
+    assert len(ticker.calls) > calls_after_stop  # restarted: ticking again
+    assert repeater.running  # the old task's done-callback must not clear the new task
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_app_scoped_repeater_ignores_ui_context():
+    ticker = Ticker()
+    client = Client(page('/app-scope-test'), request=None)
+    with client:
+        repeater = rosys.on_repeat(ticker.step, 0.1)
+    assert repeater._client is None  # pylint: disable=protected-access
+
+    client.delete()
+    await forward(0.35)
+    assert repeater.running  # the default scope is not affected by client deletion
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_client_scoped_repeater_stops_when_client_is_deleted():
+    ticker = Ticker()
+    client = Client(page('/client-scope-test'), request=None)
+    with client:
+        repeater = rosys.on_repeat(ticker.step, 0.1, scope='auto')
+    assert repeater._client is client  # pylint: disable=protected-access
+
+    await forward(0.35)
+    assert repeater.running
+    calls_while_alive = len(ticker.calls)
+    assert calls_while_alive >= 1  # the repeater was actually ticking
+
+    client.delete()
+    assert not repeater.running  # the client teardown stopped the repeater
+    await forward(0.5)
+    assert len(ticker.calls) == calls_while_alive  # no more ticks after deletion
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_auto_scope_outside_ui_context_falls_back_to_app_scope():
+    ticker = Ticker()
+    repeater = rosys.on_repeat(ticker.step, 0.1, scope='auto')
+    assert repeater._client is None  # pylint: disable=protected-access
+    await forward(0.25)
+    assert repeater.running
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_client_scope_outside_ui_context_raises():
+    ticker = Ticker()
+    with pytest.raises(RuntimeError):
+        rosys.on_repeat(ticker.step, 0.1, scope='client')
+
+
+async def test_stop_before_startup_prevents_deferred_start():
+    # NOTE: a repeater created pre-startup defers its start; stopping it before startup
+    # must remove the deferred start so the repeater is not revived when startup replays the handlers.
+    core.loop = asyncio.get_event_loop()
+    rosys.reset_before_test()
+    assert not _state.startup_finished
+
+    ticker = Ticker()
+    repeater = rosys.on_repeat(ticker.step, 0.01)
+    assert not repeater.running  # start was deferred, not launched
+    assert repeater.start in startup_handlers
+
+    repeater.stop()
+    assert repeater.start not in startup_handlers
+
+    await rosys.startup()  # replays the deferred start handlers
+
+    assert not repeater.running  # the stopped repeater was not revived
+
+    await rosys.shutdown()
+    rosys.reset_after_test()

--- a/tests/test_repeater.py
+++ b/tests/test_repeater.py
@@ -5,7 +5,7 @@ from nicegui import Client, core
 from nicegui.page import page
 
 import rosys
-from rosys.rosys import _state, startup_handlers
+from rosys.rosys import Repeater, _state, startup_handlers
 from rosys.testing import forward
 
 
@@ -57,7 +57,7 @@ async def test_client_scoped_repeater_stops_when_client_is_deleted():
     ticker = Ticker()
     client = Client(page('/client-scope-test'), request=None)
     with client:
-        repeater = rosys.on_repeat(ticker.step, 0.1, scope='auto')
+        repeater = rosys.on_repeat(ticker.step, 0.1, scope='client')
 
     await forward(0.35)
     assert repeater.running
@@ -74,14 +74,6 @@ async def test_client_scoped_repeater_stops_when_client_is_deleted():
 
 
 @pytest.mark.usefixtures('rosys_integration')
-async def test_auto_scope_outside_ui_context_falls_back_to_app_scope():
-    ticker = Ticker()
-    repeater = rosys.on_repeat(ticker.step, 0.1, scope='auto')
-    await forward(0.25)
-    assert repeater.running
-
-
-@pytest.mark.usefixtures('rosys_integration')
 async def test_client_scope_outside_ui_context_raises():
     ticker = Ticker()
     with pytest.raises(RuntimeError):
@@ -89,23 +81,20 @@ async def test_client_scope_outside_ui_context_raises():
 
 
 @pytest.mark.usefixtures('rosys_integration')
-async def test_scopes_handle_script_mode_client():
+async def test_client_scope_binds_to_script_mode_client():
     # NOTE: NiceGUI deletes the script-mode client before startup;
-    # 'auto' must fall back to app scope, while 'client' binds to it and dies with it.
+    # a client-scoped repeater binds to it and dies with it, like with any other client.
     ticker = Ticker()
     client = Client(page('/script-mode-test'), request=None)
     core.script_client = client
     try:
         with client:
-            auto_repeater = rosys.on_repeat(ticker.step, 0.1, scope='auto')
-            client_repeater = rosys.on_repeat(ticker.step, 0.1, scope='client')
+            repeater = rosys.on_repeat(ticker.step, 0.1, scope='client')
         client.delete()
     finally:
         core.script_client = None
 
-    assert not client_repeater.running  # died with the script-mode client
-    await forward(0.35)
-    assert auto_repeater.running  # fell back to app scope, unaffected by the deletion
+    assert not repeater.running  # died with the script-mode client
 
 
 async def test_stop_before_startup_prevents_deferred_start():
@@ -170,7 +159,7 @@ async def test_stopping_repeater_during_startup_does_not_revive_it():
     rosys.reset_before_test()
     try:
         ticker = Ticker()
-        repeaters: list[rosys.Repeater] = []
+        repeaters: list[Repeater] = []
 
         def stopper() -> None:
             repeaters[0].stop()

--- a/tests/test_repeater.py
+++ b/tests/test_repeater.py
@@ -140,3 +140,28 @@ async def test_stopping_repeater_during_startup_does_not_skip_other_handlers():
         await rosys.shutdown()
     finally:
         rosys.reset_after_test()
+
+
+async def test_stopping_repeater_during_startup_does_not_revive_it():
+    # NOTE: flipped ordering of the test above: when the stopping handler precedes the deferred start,
+    # startup() must not invoke the stale snapshot entry and revive the stopped repeater.
+    core.loop = asyncio.get_event_loop()
+    rosys.reset_before_test()
+    try:
+        ticker = Ticker()
+        repeaters: list[rosys.Repeater] = []
+
+        def stopper() -> None:
+            repeaters[0].stop()
+
+        rosys.on_startup(stopper)  # registered before the repeater, so its deferred start comes later
+        repeaters.append(rosys.on_repeat(ticker.step, 0.01))
+        assert startup_handlers.index(stopper) < startup_handlers.index(repeaters[0].start)
+
+        await rosys.startup()
+
+        assert not repeaters[0].running  # the stopped repeater was not revived by the snapshot
+
+        await rosys.shutdown()
+    finally:
+        rosys.reset_after_test()

--- a/tests/test_repeater.py
+++ b/tests/test_repeater.py
@@ -46,7 +46,6 @@ async def test_app_scoped_repeater_ignores_ui_context():
     client = Client(page('/app-scope-test'), request=None)
     with client:
         repeater = rosys.on_repeat(ticker.step, 0.1)
-    assert repeater._client is None  # pylint: disable=protected-access
 
     client.delete()
     await forward(0.35)
@@ -59,7 +58,6 @@ async def test_client_scoped_repeater_stops_when_client_is_deleted():
     client = Client(page('/client-scope-test'), request=None)
     with client:
         repeater = rosys.on_repeat(ticker.step, 0.1, scope='auto')
-    assert repeater._client is client  # pylint: disable=protected-access
 
     await forward(0.35)
     assert repeater.running
@@ -68,6 +66,8 @@ async def test_client_scoped_repeater_stops_when_client_is_deleted():
 
     client.delete()
     assert not repeater.running  # the client teardown stopped the repeater
+    repeater.start()
+    assert not repeater.running  # a client-scoped repeater cannot be revived after its client is deleted
     await forward(0.5)
     assert len(ticker.calls) == calls_while_alive  # no more ticks after deletion
 
@@ -76,7 +76,6 @@ async def test_client_scoped_repeater_stops_when_client_is_deleted():
 async def test_auto_scope_outside_ui_context_falls_back_to_app_scope():
     ticker = Ticker()
     repeater = rosys.on_repeat(ticker.step, 0.1, scope='auto')
-    assert repeater._client is None  # pylint: disable=protected-access
     await forward(0.25)
     assert repeater.running
 
@@ -93,19 +92,51 @@ async def test_stop_before_startup_prevents_deferred_start():
     # must remove the deferred start so the repeater is not revived when startup replays the handlers.
     core.loop = asyncio.get_event_loop()
     rosys.reset_before_test()
-    assert not _state.startup_finished
+    try:
+        assert not _state.startup_finished
 
-    ticker = Ticker()
-    repeater = rosys.on_repeat(ticker.step, 0.01)
-    assert not repeater.running  # start was deferred, not launched
-    assert repeater.start in startup_handlers
+        ticker = Ticker()
+        repeater = rosys.on_repeat(ticker.step, 0.01)
+        assert not repeater.running  # start was deferred, not launched
+        assert repeater.start in startup_handlers
 
-    repeater.stop()
-    assert repeater.start not in startup_handlers
+        repeater.stop()
+        assert repeater.start not in startup_handlers
 
-    await rosys.startup()  # replays the deferred start handlers
+        await rosys.startup()  # replays the deferred start handlers
 
-    assert not repeater.running  # the stopped repeater was not revived
+        assert not repeater.running  # the stopped repeater was not revived
 
-    await rosys.shutdown()
-    rosys.reset_after_test()
+        await rosys.shutdown()
+    finally:
+        rosys.reset_after_test()
+
+
+async def test_stopping_repeater_during_startup_does_not_skip_other_handlers():
+    # NOTE: Repeater.stop() removes a deferred start from startup_handlers;
+    # startup() must iterate a snapshot so this mutation does not skip the following handler.
+    core.loop = asyncio.get_event_loop()
+    rosys.reset_before_test()
+    try:
+        ticker = Ticker()
+        repeater = rosys.on_repeat(ticker.step, 0.01)
+        events: list[str] = []
+
+        def stopper() -> None:
+            repeater.stop()
+            events.append('stopper')
+
+        def victim() -> None:
+            events.append('victim')
+
+        rosys.on_startup(stopper)
+        rosys.on_startup(victim)
+
+        await rosys.startup()
+
+        assert events == ['stopper', 'victim']  # the mutation must not skip the next startup handler
+        assert not repeater.running
+
+        await rosys.shutdown()
+    finally:
+        rosys.reset_after_test()

--- a/tests/test_repeater.py
+++ b/tests/test_repeater.py
@@ -66,6 +66,7 @@ async def test_client_scoped_repeater_stops_when_client_is_deleted():
 
     client.delete()
     assert not repeater.running  # the client teardown stopped the repeater
+    assert repeater.handler is None  # the handler is released so the deleted client does not pin its owner
     repeater.start()
     assert not repeater.running  # a client-scoped repeater cannot be revived after its client is deleted
     await forward(0.5)
@@ -85,6 +86,26 @@ async def test_client_scope_outside_ui_context_raises():
     ticker = Ticker()
     with pytest.raises(RuntimeError):
         rosys.on_repeat(ticker.step, 0.1, scope='client')
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_scopes_handle_script_mode_client():
+    # NOTE: NiceGUI deletes the script-mode client before startup;
+    # 'auto' must fall back to app scope, while 'client' binds to it and dies with it.
+    ticker = Ticker()
+    client = Client(page('/script-mode-test'), request=None)
+    core.script_client = client
+    try:
+        with client:
+            auto_repeater = rosys.on_repeat(ticker.step, 0.1, scope='auto')
+            client_repeater = rosys.on_repeat(ticker.step, 0.1, scope='client')
+        client.delete()
+    finally:
+        core.script_client = None
+
+    assert not client_repeater.running  # died with the script-mode client
+    await forward(0.35)
+    assert auto_repeater.running  # fell back to app scope, unaffected by the deletion
 
 
 async def test_stop_before_startup_prevents_deferred_start():


### PR DESCRIPTION
### Motivation

Alternative to #427, solving the same problem with deterministic lifetimes instead of weak references.

`rosys.on_repeat` keeps its handler's object alive forever via the reference stored in the task — for page-owned objects this leaks one repeater per page load. `ui.timer` is not a substitute because repeaters run on RoSys time (simulated/accelerated), not wall clock. With client scoping, page-owned objects die with their client:

```python
class PageWidget:
    def __init__(self) -> None:
        rosys.on_repeat(self.update, 1.0, client_scoped=True)  # stops when the page's client is deleted

    def update(self) -> None:
        pass
```

Compared to the weak-reference approach in #427, scoping is deterministic and robust in ways weak references cannot be in this codebase:

- RoSys runs with `gc.disable()`, so weak-ref cleanup only happens when pure refcounting reaches zero — any accidental reference cycle (bound-method callbacks are the classic case, see `SimulatedCamera` ↔ `SimulatedDevice`) silently defeats it forever. Client scoping stops the repeater at a well-defined moment regardless of reference graphs. (To be precise: what is deterministic is tearing down the *behavior*; a cyclic object graph may still wait for a pressure-triggered collection. To keep deleted clients from pinning their owners, the repeater releases its handler on client deletion — thanks @evnchn for the analysis.)
- Weak references silently kill fire-and-forget modules whose only anchor was the repeater (`BackupSchedule()`, `NetworkMonitor()`). With client scoping being opt-in, every existing call site keeps today's behavior; nothing needs converting.
- No special handling for non-weakenable handlers (plain functions, partials, slots classes) — any callable works.

### Implementation

- `rosys.on_repeat(handler, interval, client_scoped=False)`:
  - default: process lifetime, exactly as before.
  - `client_scoped=True`: must be created within a UI context; the repeater stops when that client is deleted (raises `RuntimeError` outside a UI context). In NiceGUI script mode this includes the pre-flight client: the pre-flight repeater dies with it, while each per-connection re-execution binds to its own client.
- Context detection mirrors NiceGUI's own `Event.subscribe` idiom (`Slot.get_stack()` check before `context.client`, so no accidental script-mode entry). Teardown uses `client.on_delete(...)` without storing the client on the repeater (no reference cycle) and releases the handler on deletion.
- `CameraProjector` exposes the flag (`client_scoped=False` by default) instead of hardcoding a lifetime.
- Includes the uncontroversial lifecycle fixes from #427: finished tasks are pruned from `Repeater.tasks` via a done-callback and `stop()` uses `discard`. Additionally, `stop()` before or during startup removes the deferred start so a stopped repeater is not revived when startup replays its handlers.

### Design history: why there is no `'auto'`

Earlier revisions had a three-value `scope` parameter including `'auto'` (bind to the client if constructed in a UI context, app lifetime otherwise), and `CameraProjector` hardcoded it. @ftilde's demo in the discussion showed why that is a trap: a shared projector constructed lazily inside a page handler silently became client-scoped and froze app-wide after a page refresh. The general lesson: only the caller knows an object's intended lifetime, so a class must not infer it from where it happens to be constructed — and `'auto'` was exactly that inference, offered as a feature. It is gone; the lifetime is always an explicit choice, which also deleted the script-mode special case that existed only to keep `'auto'` from binding to the doomed pre-flight client. With only two lifetimes left, the parameter then shrank to a single `client_scoped` flag. Thanks @ftilde for the pushback.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels.
- [x] The implementation is complete.
- [x] Pytests have been added.
- [x] Documentation is not necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
