### PR TITLE
Exclude GPIO0 from the strapping-pin guard when flashing Core or P0

### DIFF
--- a/rosys/hardware/esp_pins.py
+++ b/rosys/hardware/esp_pins.py
@@ -81,12 +81,12 @@ class EspPins:
         await self.robot_brain.send(f'{self.name}.set_pin_level({pin.gpio}, {1 if level else 0})')
 
     async def get_strapping_pins(self, numbers: Sequence[int] = (0, 2, 12)) -> list[bool]:
-"""Get the state of the strapping pins.
+        """Get the state of the strapping pins.
 
-       See https://github.com/zauberzeug/lizard/issues/75 and https://github.com/zauberzeug/lizard/pull/95.
-       
-       :param numbers: GPIO numbers to check (default: strapping pins 0, 2 and 12)
-       """
+        See https://github.com/zauberzeug/lizard/issues/75 and https://github.com/zauberzeug/lizard/pull/95.
+
+        :param numbers: GPIO numbers to check (default: strapping pins 0, 2 and 12)
+        """
         return [await self.get_pin_level(number) for number in numbers]
 
     def developer_ui(self) -> None:

--- a/rosys/hardware/esp_pins.py
+++ b/rosys/hardware/esp_pins.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -79,12 +80,12 @@ class EspPins:
     async def set_pin_level(self, pin: GpioPin, level: bool) -> None:
         await self.robot_brain.send(f'{self.name}.set_pin_level({pin.gpio}, {1 if level else 0})')
 
-    async def get_strapping_pins(self) -> list[bool]:
+    async def get_strapping_pins(self, numbers: Sequence[int] = (0, 2, 12)) -> list[bool]:
         """Get the state of the strapping pins.
 
         See https://github.com/zauberzeug/lizard/issues/75 and https://github.com/zauberzeug/lizard/pull/95.
         """
-        return [await self.get_pin_level(number) for number in [0, 2, 12]]
+        return [await self.get_pin_level(number) for number in numbers]
 
     def developer_ui(self) -> None:
         with ui.column():

--- a/rosys/hardware/esp_pins.py
+++ b/rosys/hardware/esp_pins.py
@@ -81,10 +81,12 @@ class EspPins:
         await self.robot_brain.send(f'{self.name}.set_pin_level({pin.gpio}, {1 if level else 0})')
 
     async def get_strapping_pins(self, numbers: Sequence[int] = (0, 2, 12)) -> list[bool]:
-        """Get the state of the strapping pins.
+"""Get the state of the strapping pins.
 
-        See https://github.com/zauberzeug/lizard/issues/75 and https://github.com/zauberzeug/lizard/pull/95.
-        """
+       See https://github.com/zauberzeug/lizard/issues/75 and https://github.com/zauberzeug/lizard/pull/95.
+       
+       :param numbers: GPIO numbers to check (default: strapping pins 0, 2 and 12)
+       """
         return [await self.get_pin_level(number) for number in numbers]
 
     def developer_ui(self) -> None:

--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -127,7 +127,9 @@ class LizardFirmware:
             return
         assert isinstance(self.robot_brain.communication, SerialCommunication)
         rosys.notify(f'Flashing Lizard firmware {self.local_version} to Core...')
-        if any(await self.robot_brain.esp_pins_core.get_strapping_pins()):
+        # NOTE: GPIO0 idles high in normal operation and is pulled low by Lizard itself during flashing,
+        # so only GPIO2 and GPIO12 can be pre-checked here (https://github.com/zauberzeug/rosys/issues/430)
+        if any(await self.robot_brain.esp_pins_core.get_strapping_pins(numbers=(2, 12))):
             rosys.notify('Flashing Core failed. Check strapping pins.', 'negative')
             return
         self.robot_brain.communication.disconnect()
@@ -143,7 +145,9 @@ class LizardFirmware:
             rosys.notify('Flashing P0 failed. Robot Brain is not ready.', 'negative')
             return
         rosys.notify(f'Flashing Lizard firmware {self.core_version} to P0...')
-        if any(await self.robot_brain.esp_pins_p0.get_strapping_pins()):
+        # NOTE: GPIO0 idles high in normal operation and is pulled low by Lizard itself during flashing,
+        # so only GPIO2 and GPIO12 can be pre-checked here (https://github.com/zauberzeug/rosys/issues/430)
+        if any(await self.robot_brain.esp_pins_p0.get_strapping_pins(numbers=(2, 12))):
             rosys.notify('Flashing P0 failed. Check strapping pins.', 'negative')
             return
         await self.robot_brain.send('p0.flash()')


### PR DESCRIPTION
### Motivation

Clicking **Flash P0** (and likewise flashing the Core) always failed with "Flashing P0 failed. Check strapping pins." because the guard in `LizardFirmware.flash_p0`/`flash_core` checks GPIO **0**, 2 and 12 — but GPIO0 idles **high** in normal operation (internal pull-up), so the `any(...)` guard could never pass. Per zauberzeug/lizard#75 and zauberzeug/lizard#95, Lizard pulls the boot pin (GPIO0) low itself during `flash()`; only GPIO2 (bootloader entry) and GPIO12 (flash voltage) are genuine external preconditions that RoSys can pre-check.

Fixes #430.

### Implementation

`EspPins.get_strapping_pins()` gets a `numbers: Sequence[int] = (0, 2, 12)` parameter, keeping its current behavior for existing callers (e.g. the "Check Strapping Pins" developer menu). The two flash guards in `LizardFirmware` now call it with `numbers=(2, 12)`, with a `NOTE` comment explaining why GPIO0 cannot be pre-checked from the outside. This is option 1 from the issue discussion — the minimal change that keeps the early UI feedback instead of surfacing Lizard's own error after the fact.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary). *(hardware-only module without simulation twin; no existing tests for `EspPins`/`LizardFirmware`)*
- [x] Documentation has been added (or is not necessary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)