### PR TITLE
Verify Lizard startup checksum when the ESP connects

### DIFF
--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -108,7 +108,7 @@ class LizardFirmware:
             self.log.error('Could not read startup checksum from Core. Robot Brain is not ready.')
             return
         deadline = rosys.time() + 5.0
-        while rosys.time() < deadline:
+        while rosys.time() < deadline and self.robot_brain.is_ready:
             if response := await self.robot_brain.send_and_await('core.startup_checksum()', 'checksum:', timeout=1):
                 self.core_checksum = response.split()[-1]
                 self.log.info('core checksum: %s', self.core_checksum)

--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -96,6 +96,7 @@ class LizardFirmware:
         self.log.info('local checksum: %s', self.local_checksum)
 
     async def read_core_checksum(self) -> None:
+        self.core_checksum = None
         if not self.robot_brain.is_ready:
             self.log.error('Could not read startup checksum from Core. Robot Brain is not ready.')
             return

--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -38,8 +38,8 @@ class LizardFirmware:
 
     @property
     def checksums_match(self) -> bool | None:
-        """Whether the local and core startup checksums match, or ``None`` if the core checksum is unknown."""
-        if self.core_checksum is None:
+        """Whether the local and core startup checksums match, or ``None`` if either checksum is unknown."""
+        if self.local_checksum is None or self.core_checksum is None:
             return None
         return self.local_checksum == self.core_checksum
 

--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -36,6 +36,13 @@ class LizardFirmware:
         self._p0_flash_last_complete: float = 0.0
         self.robot_brain.FLASH_P0_COMPLETE.subscribe(lambda: setattr(self, '_p0_flash_last_complete', rosys.time()))
 
+    @property
+    def checksums_match(self) -> bool | None:
+        """Whether the local and core startup checksums match, or ``None`` if the core checksum is unknown."""
+        if self.core_checksum is None:
+            return None
+        return self.local_checksum == self.core_checksum
+
     async def read_all(self) -> None:
         await self.read_online_version()
         self.read_local_version()

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -46,6 +46,7 @@ class RobotBrain:
         self.communication = communication
         self.lizard_code = ''
         self.lizard_firmware = LizardFirmware(self)
+        self.ESP_CONNECTED.subscribe(self._check_lizard_code)
 
         self.waiting_list: dict[str, str | None] = {}
         self._clock_offset: float | None = None
@@ -229,6 +230,18 @@ class RobotBrain:
         if millis is not None:
             self._handle_clock_offset(rosys.time() - millis / 1000)
         return lines
+
+    async def _check_lizard_code(self) -> None:
+        if not self.lizard_code:
+            return
+        self.lizard_firmware.read_local_checksum()
+        await self.lizard_firmware.read_core_checksum()
+        if self.lizard_firmware.core_checksum is None:
+            self.log.warning('Could not verify Lizard startup code (no checksum received)')
+            return
+        if self.lizard_firmware.local_checksum != self.lizard_firmware.core_checksum:
+            rosys.notify('The Lizard startup code on the microcontroller differs from the expected configuration. '
+                         'Please configure the microcontroller.', 'negative', log_level=logging.WARNING)
 
     def _handle_clock_offset(self, offset: float) -> None:
         if self._clock_offset is not None and abs(offset - self._clock_offset) > 0.1:

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -122,8 +122,7 @@ class RobotBrain:
             local_update_button.visible = \
                 self.lizard_firmware.local_version != self.lizard_firmware.core_version or \
                 self.lizard_firmware.local_version != self.lizard_firmware.p0_version
-            configure_button.visible = \
-                self.lizard_firmware.local_checksum != self.lizard_firmware.core_checksum
+            configure_button.visible = self.lizard_firmware.checksums_match is False
         ui.timer(1.0, update_visibility)
 
         with ui.row().classes('items-center'):

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -236,9 +236,7 @@ class RobotBrain:
             return
         self.lizard_firmware.read_local_checksum()
         await self.lizard_firmware.read_core_checksum()
-        if self.lizard_firmware.checksums_match is None:
-            self.log.warning('Could not verify Lizard startup code (no checksum received)')
-        elif not self.lizard_firmware.checksums_match:
+        if self.lizard_firmware.checksums_match is False:
             rosys.notify('Lizard startup code is outdated. Please configure.', 'negative', log_level=logging.WARNING)
 
     def _handle_clock_offset(self, offset: float) -> None:

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -186,12 +186,12 @@ class RobotBrain:
 
     async def restart(self) -> None:
         await self.send('core.restart()', force=True)
-        try:
-            await self.LINE_RECEIVED.emitted(timeout=1.0)  # NOTE: we have to wait for the last core message to be sent
-        except TimeoutError:
-            pass
-        finally:
-            self._hardware_time = None
+        # NOTE: wait until core messages cease; otherwise buffered messages would re-establish the hardware time
+        # and emit ESP_CONNECTED again before the ESP has actually restarted
+        deadline = rosys.time() + 5.0
+        while rosys.time() < deadline and self._hardware_time is not None and rosys.time() - self._hardware_time < 0.5:
+            await rosys.sleep(0.1)
+        self._hardware_time = None
 
     async def read_lines(self) -> list[tuple[float, str]]:
         lines: list[tuple[float, str]] = []
@@ -236,12 +236,10 @@ class RobotBrain:
             return
         self.lizard_firmware.read_local_checksum()
         await self.lizard_firmware.read_core_checksum()
-        if self.lizard_firmware.core_checksum is None:
+        if self.lizard_firmware.checksums_match is None:
             self.log.warning('Could not verify Lizard startup code (no checksum received)')
-            return
-        if self.lizard_firmware.local_checksum != self.lizard_firmware.core_checksum:
-            rosys.notify('The Lizard startup code on the microcontroller differs from the expected configuration. '
-                         'Please configure the microcontroller.', 'negative', log_level=logging.WARNING)
+        elif not self.lizard_firmware.checksums_match:
+            rosys.notify('Lizard startup code is outdated. Please configure.', 'negative', log_level=logging.WARNING)
 
     def _handle_clock_offset(self, offset: float) -> None:
         if self._clock_offset is not None and abs(offset - self._clock_offset) > 0.1:

--- a/tests/test_robot_brain.py
+++ b/tests/test_robot_brain.py
@@ -34,6 +34,10 @@ class CommunicationSimulation(Communication):
         return augment(self.incoming.popleft()) if self.incoming else None
 
 
+def matching_checksum(robot_brain: RobotBrain) -> str:
+    return f'{sum(ord(c) for c in robot_brain.lizard_code) % 0x10000:04x}'
+
+
 async def connect(communication: CommunicationSimulation) -> None:
     for millis in (100, 200):  # NOTE: the first core message only establishes the clock offset
         communication.incoming.append(f'core {millis}')
@@ -53,8 +57,7 @@ async def test_no_warning_when_lizard_code_matches(robot_brain: RobotBrain) -> N
     rosys.NEW_NOTIFICATION.subscribe(notifications.append)
     communication = robot_brain.communication
     assert isinstance(communication, CommunicationSimulation)
-    checksum = sum(ord(c) for c in robot_brain.lizard_code) % 0x10000
-    communication.startup_checksum = f'{checksum:04x}'
+    communication.startup_checksum = matching_checksum(robot_brain)
     await connect(communication)
     assert 'core.startup_checksum()' in communication.sent
     assert not any(MISMATCH_MESSAGE in message for message in notifications)
@@ -83,8 +86,7 @@ async def test_check_runs_again_after_configuring(robot_brain: RobotBrain) -> No
     await connect(communication)
     assert robot_brain.lizard_firmware.checksums_match is False
 
-    checksum = sum(ord(c) for c in robot_brain.lizard_code) % 0x10000
-    communication.startup_checksum = f'{checksum:04x}'
+    communication.startup_checksum = matching_checksum(robot_brain)
     configure_task = background_tasks.create(robot_brain.configure(), name='configure')
     communication.incoming.append('core 5000')  # NOTE: buffered message arriving after ``core.restart()``
     await forward(seconds=2.0)

--- a/tests/test_robot_brain.py
+++ b/tests/test_robot_brain.py
@@ -1,6 +1,7 @@
 from collections import deque
 
 import pytest
+from nicegui import background_tasks
 
 import rosys
 from rosys.hardware import RobotBrain, RobotHardware
@@ -8,7 +9,7 @@ from rosys.hardware.communication import Communication
 from rosys.hardware.robot_brain import augment
 from rosys.testing import forward
 
-MISMATCH_MESSAGE = 'differs from the expected configuration'
+MISMATCH_MESSAGE = 'Lizard startup code is outdated'
 
 
 class CommunicationSimulation(Communication):
@@ -67,3 +68,30 @@ async def test_warning_when_lizard_code_differs(robot_brain: RobotBrain) -> None
     communication.startup_checksum = 'ffff'
     await connect(communication)
     assert any(MISMATCH_MESSAGE in message for message in notifications)
+
+
+async def test_check_runs_again_after_configuring(robot_brain: RobotBrain) -> None:
+    connect_count = 0
+
+    def count_connect() -> None:
+        nonlocal connect_count
+        connect_count += 1
+    robot_brain.ESP_CONNECTED.subscribe(count_connect)
+    communication = robot_brain.communication
+    assert isinstance(communication, CommunicationSimulation)
+    communication.startup_checksum = 'ffff'
+    await connect(communication)
+    assert robot_brain.lizard_firmware.checksums_match is False
+
+    checksum = sum(ord(c) for c in robot_brain.lizard_code) % 0x10000
+    communication.startup_checksum = f'{checksum:04x}'
+    configure_task = background_tasks.create(robot_brain.configure(), name='configure')
+    communication.incoming.append('core 5000')  # NOTE: buffered message arriving after ``core.restart()``
+    await forward(seconds=2.0)
+    assert configure_task.done()
+    assert not robot_brain.is_ready, 'buffered messages should not re-establish the connection'
+    assert connect_count == 1
+
+    await connect(communication)
+    assert connect_count == 2
+    assert robot_brain.lizard_firmware.checksums_match is True

--- a/tests/test_robot_brain.py
+++ b/tests/test_robot_brain.py
@@ -1,0 +1,69 @@
+from collections import deque
+
+import pytest
+
+import rosys
+from rosys.hardware import RobotBrain, RobotHardware
+from rosys.hardware.communication import Communication
+from rosys.hardware.robot_brain import augment
+from rosys.testing import forward
+
+MISMATCH_MESSAGE = 'differs from the expected configuration'
+
+
+class CommunicationSimulation(Communication):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.incoming: deque[str] = deque()
+        self.sent: list[str] = []
+        self.startup_checksum = ''
+
+    @classmethod
+    def is_possible(cls) -> bool:
+        return True
+
+    async def send(self, msg: str) -> None:
+        line = msg.rsplit('@', 1)[0]
+        self.sent.append(line)
+        if line == 'core.startup_checksum()':
+            self.incoming.append(f'checksum: {self.startup_checksum}')
+
+    async def read(self) -> str | None:
+        return augment(self.incoming.popleft()) if self.incoming else None
+
+
+async def connect(communication: CommunicationSimulation) -> None:
+    for millis in (100, 200):  # NOTE: the first core message only establishes the clock offset
+        communication.incoming.append(f'core {millis}')
+        await forward(seconds=1.0)
+    await forward(seconds=3.0)  # NOTE: let the checksum request and response complete
+
+
+@pytest.fixture
+async def robot_brain(rosys_integration: None) -> RobotBrain:
+    robot_brain = RobotBrain(CommunicationSimulation(), enable_esp_on_startup=False)
+    RobotHardware([], robot_brain)
+    return robot_brain
+
+
+async def test_no_warning_when_lizard_code_matches(robot_brain: RobotBrain) -> None:
+    notifications: list[str] = []
+    rosys.NEW_NOTIFICATION.subscribe(notifications.append)
+    communication = robot_brain.communication
+    assert isinstance(communication, CommunicationSimulation)
+    checksum = sum(ord(c) for c in robot_brain.lizard_code) % 0x10000
+    communication.startup_checksum = f'{checksum:04x}'
+    await connect(communication)
+    assert 'core.startup_checksum()' in communication.sent
+    assert not any(MISMATCH_MESSAGE in message for message in notifications)
+
+
+async def test_warning_when_lizard_code_differs(robot_brain: RobotBrain) -> None:
+    notifications: list[str] = []
+    rosys.NEW_NOTIFICATION.subscribe(notifications.append)
+    communication = robot_brain.communication
+    assert isinstance(communication, CommunicationSimulation)
+    communication.startup_checksum = 'ffff'
+    await connect(communication)
+    assert any(MISMATCH_MESSAGE in message for message in notifications)

--- a/tests/test_robot_brain.py
+++ b/tests/test_robot_brain.py
@@ -39,7 +39,7 @@ def matching_checksum(robot_brain: RobotBrain) -> str:
 
 
 async def connect(communication: CommunicationSimulation) -> None:
-    for millis in (100, 200):  # NOTE: the first core message only establishes the clock offset
+    for millis in (100, 200):  # NOTE: on a first connect, the first core message only establishes the clock offset
         communication.incoming.append(f'core {millis}')
         await forward(seconds=1.0)
     await forward(seconds=3.0)  # NOTE: let the checksum request and response complete


### PR DESCRIPTION
### Motivation

When deploying a robot — during setup, testing or in the field — the only automatic indication that the Lizard startup code on the microcontroller is outdated is the core message field-count check in `RobotHardware.update`. That check misses any change that keeps the number of output fields the same (e.g. changed pins or module parameters). The user should be made aware on startup and after configuring, without interrupting operation.

### Implementation

- Subscribe new `RobotBrain._check_lizard_code` to `ESP_CONNECTED`, which fires both on startup and after `configure()`; on mismatch, show a short negative `rosys.notify` with warning log level — no exception, the robot keeps running
- Reuse `LizardFirmware.read_local_checksum()` and `read_core_checksum()` (`core.startup_checksum()`) for the comparison and expose the result as new `LizardFirmware.checksums_match` property (`True`/`False`/`None` if unknown), so apps can bind UI elements (e.g. a status icon) to it
- Fix premature `ESP_CONNECTED` after `restart()`: waiting for a single line after `core.restart()` was not enough — buffered core messages from the ESP that is about to reboot re-established the hardware time, so `ESP_CONNECTED` fired while the ESP was going down and the checksum check ran into the void; now `restart()` waits until core messages cease before clearing the hardware time
- Reset `core_checksum` to `None` at the beginning of `read_core_checksum()` so a timeout can no longer leave a stale value from a previous read
- Add `tests/test_robot_brain.py` with a `CommunicationSimulation` that establishes an ESP connection and answers `core.startup_checksum()`, covering the matching and mismatching case as well as the configure-restart-reconnect flow with a buffered core message (regression test for the premature `ESP_CONNECTED`)

Tested on real hardware (Field Friend f21): outdated startup code is reported on startup, configuring resolves it and the check runs again after the ESP reconnects.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)