### PR TITLE
Don't run CameraProjector and CameraObjects when invisible

### DIFF
--- a/rosys/vision/camera_objects_.py
+++ b/rosys/vision/camera_objects_.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 import numpy as np
 from nicegui import ui
 from nicegui.elements.scene.scene_object3d import Object3D
@@ -13,6 +15,9 @@ class CameraObjects(Group):
     """This module provides a UI element for displaying cameras in a 3D scene.
 
     It requires a camera provider as a source of cameras as well as a camera projector to show the current images projected on the ground plane.
+    The camera projector can be shared between clients: every visible CameraObjects holds it via acquire()/release(),
+    so it only computes projections while at least one consumer needs them.
+    Hiding this element via ``visible(False)`` also pauses its update timer, so an invisible element causes no load.
     The `px_per_m` argument can be used to scale the camera frustums.
     With `debug=True` camera IDs are shown (default: `False`).
     """
@@ -34,7 +39,34 @@ class CameraObjects(Group):
         self.textures: dict[str, Texture] = {}
         self.image_shrink_factor = 2
 
-        ui.timer(interval, self.update)
+        self._holds_projector = False
+        self._acquire_projector()
+        self._timer = ui.timer(interval, self.update)
+
+    def visible(self, value: bool = True) -> Self:
+        if value:
+            self._acquire_projector()
+            self._timer.activate()
+        else:
+            self._release_projector()
+            self._timer.deactivate()
+        return super().visible(value)
+
+    def __del__(self) -> None:
+        try:
+            self._release_projector()
+        except Exception:
+            pass  # NOTE: finalizers can run during interpreter teardown where anything may be gone already
+
+    def _acquire_projector(self) -> None:
+        if not self._holds_projector:
+            self.camera_projector.acquire()
+            self._holds_projector = True
+
+    def _release_projector(self) -> None:
+        if self._holds_projector:
+            self.camera_projector.release()
+            self._holds_projector = False
 
     @property
     def calibrated_cameras(self) -> dict[str, CalibratableCamera]:

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -26,10 +26,23 @@ class CameraProjector:
 
     def __init__(self, camera_provider: CalibratableCameraProvider, *, interval: float = 1.0) -> None:
         self.camera_provider = camera_provider
+        self._consumer_count = 0
+        self._repeater = rosys.Repeater(self.step, interval)
 
         self.projections: dict[str, Projection] = {}
 
-        rosys.on_repeat(self.step, interval)
+    def acquire(self) -> None:
+        """Register interest in up-to-date projections; the projector only runs while at least one consumer holds it."""
+        self._consumer_count += 1
+        if self._consumer_count == 1:
+            self._repeater.start()
+
+    def release(self) -> None:
+        """Give up interest previously registered with acquire()."""
+        assert self._consumer_count > 0, 'release() without matching acquire()'
+        self._consumer_count -= 1
+        if self._consumer_count == 0:
+            self._repeater.stop()
 
     async def step(self) -> None:
         for id_ in list(self.projections):

--- a/rosys/vision/camera_projector.py
+++ b/rosys/vision/camera_projector.py
@@ -34,8 +34,7 @@ class CameraProjector:
     def acquire(self) -> None:
         """Register interest in up-to-date projections; the projector only runs while at least one consumer holds it."""
         self._consumer_count += 1
-        if self._consumer_count == 1:
-            self._repeater.start()
+        self._repeater.start()  # idempotent: no-op while already running
 
     def release(self) -> None:
         """Give up interest previously registered with acquire()."""

--- a/tests/test_camera_projector.py
+++ b/tests/test_camera_projector.py
@@ -1,6 +1,50 @@
-import numpy as np
+from types import SimpleNamespace
 
+import numpy as np
+import pytest
+
+from rosys.testing import forward
 from rosys.vision import CalibratableCamera, CameraProjector
+
+
+def test_release_without_acquire_raises():
+    projector = CameraProjector(SimpleNamespace(cameras={}))
+    with pytest.raises(AssertionError):
+        projector.release()
+
+
+@pytest.mark.usefixtures('rosys_integration')
+async def test_repeater_only_runs_while_acquired():
+    cam = CalibratableCamera(id='1')
+    cam.set_perfect_calibration(z=3)
+    provider = SimpleNamespace(cameras={'1': cam})
+    projector = CameraProjector(provider, interval=0.1)
+
+    await forward(0.5)
+    assert not projector.projections, 'no consumer -> repeater is not running'
+
+    projector.acquire()
+    projector.acquire()
+    await forward(0.5)
+    assert '1' in projector.projections
+
+    projector.release()
+    cam2 = CalibratableCamera(id='2')
+    cam2.set_perfect_calibration(z=3)
+    provider.cameras['2'] = cam2
+    await forward(0.5)
+    assert '2' in projector.projections, 'one of two consumers released -> repeater keeps running'
+
+    projector.release()
+    cam3 = CalibratableCamera(id='3')
+    cam3.set_perfect_calibration(z=3)
+    provider.cameras['3'] = cam3
+    await forward(0.5)
+    assert '3' not in projector.projections, 'all consumers released -> repeater is stopped'
+
+    projector.acquire()
+    await forward(0.5)
+    assert '3' in projector.projections, 're-acquiring restarts the repeater'
 
 
 def test_projection():


### PR DESCRIPTION
### Motivation

Profiling a robot application showed that the 3D scene's camera visualization dominates CPU usage even when it is not shown: `CameraObjects` is hidden by default in our app (`visible(False)`), but its update timer and the `CameraProjector` keep running for every client — resolving extrinsics, re-projecting ground grids, and updating textures nobody sees.

### Implementation

- Extend `CameraProjector` with `acquire()`/`release()`: a consumer count that starts the repeater on the first acquire and stops it when the last consumer releases, so a projector shared between clients only runs while at least one of them shows it
- Extend `CameraObjects` to hold the projector while visible: acquired on construction and `visible(True)`, released on `visible(False)` and on garbage collection (`__del__`), with an idempotent guard so repeated calls cannot unbalance the count
- Deactivate the `CameraObjects` update timer while the element is hidden
- Add a repeater test using `rosys_integration` and simulated time covering the full acquire/release/re-acquire lifecycle

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5