### PR TITLE
Suspend on child futures in parallelize instead of busy-polling the event loop

### DIFF
--- a/rosys/automation/automation.py
+++ b/rosys/automation/automation.py
@@ -85,8 +85,8 @@ class Automation:
         return await self
 
     def __await__(self) -> Generator[Any, None, Any | None]:
-        token = _CURRENT_AUTOMATION.set(self)  # bind this Automation instance into the task context
         coro_iter = self.coro.__await__()
+        token = _CURRENT_AUTOMATION.set(self)  # bind this Automation instance into the task context
         try:
             self._is_waited = True
             iter_send, iter_throw = coro_iter.send, coro_iter.throw

--- a/rosys/automation/automation.py
+++ b/rosys/automation/automation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
-from collections.abc import Callable, Coroutine, Generator
+from collections.abc import Awaitable, Callable, Generator
 from contextvars import ContextVar
 from typing import Any
 
@@ -48,7 +48,7 @@ class Automation:
     """
 
     def __init__(self,
-                 coro: Coroutine,
+                 coro: Awaitable,
                  exception_handler: Callable | None = None,
                  on_complete: Callable | None = None) -> None:
         self.log = logging.getLogger('rosys.automation')
@@ -86,9 +86,9 @@ class Automation:
 
     def __await__(self) -> Generator[Any, None, Any | None]:
         token = _CURRENT_AUTOMATION.set(self)  # bind this Automation instance into the task context
+        coro_iter = self.coro.__await__()
         try:
             self._is_waited = True
-            coro_iter = self.coro.__await__()
             iter_send, iter_throw = coro_iter.send, coro_iter.throw
             send: Callable = iter_send
             message: Any = None
@@ -128,7 +128,7 @@ class Automation:
         finally:
             self._is_waited = False
             _CURRENT_AUTOMATION.reset(token)
-            self.coro.close()
+            coro_iter.close()  # close the iterator, not self.coro: awaitables like parallelize are not coroutines
         return None
 
     def pause(self) -> None:

--- a/rosys/automation/parallelize.py
+++ b/rosys/automation/parallelize.py
@@ -79,12 +79,15 @@ class parallelize:
                             cancel_unfinished(e, propagate=True)
 
                 if all(waiting[i] is not None or completed[i] for i in active_coros):
-                    try:
-                        yield  # allow the event loop to process other tasks while all coroutines are waiting
-                    except GeneratorExit:
-                        raise
-                    except BaseException as e:
-                        cancel_unfinished(e, propagate=True)
+                    pending = [w for w in (waiting[i] for i in active_coros) if w is not None]
+                    if pending:
+                        try:
+                            # suspend until any coroutine can make progress instead of busy-polling the event loop
+                            yield from asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED).__await__()
+                        except GeneratorExit:
+                            raise
+                        except BaseException as e:
+                            cancel_unfinished(e, propagate=True)
 
             if exception_to_reraise:
                 # re-raise the external stop now that every coroutine has cleaned up

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import Literal
 
 import numpy as np
@@ -6,6 +7,7 @@ import pytest
 
 import rosys
 from rosys.automation import Automator
+from rosys.automation.automation import Automation
 from rosys.driving import Driver
 from rosys.geometry import Pose, Spline
 from rosys.hardware import Robot
@@ -255,6 +257,44 @@ async def test_parallelize_exception(automator: Automator):
     automator.start(run())
     await forward(seconds=10)
     assert failures == ['an exception occurred in an automation: i is 3']
+
+
+async def test_parallelize_suspends_while_all_coroutines_are_parked_on_futures():
+    """``parallelize`` must wait on the coroutines' futures instead of busy-polling the event loop (regression).
+
+    This runs on real time because test-mode ``rosys.sleep`` never parks on a future.
+    """
+    events: list[str] = []
+
+    async def fast() -> None:
+        await asyncio.sleep(0.1)
+        events.append('fast done')
+
+    async def slow() -> None:
+        try:
+            await asyncio.sleep(5.0)
+            events.append('slow done')
+        finally:
+            events.append('slow cleanup')
+
+    cpu_start = time.process_time()
+    wall_start = time.monotonic()
+    await rosys.automation.parallelize(slow(), fast(), return_when_first_completed=True)
+    assert time.monotonic() - wall_start < 1.0, 'should return as soon as the fast coroutine completes'
+    assert time.process_time() - cpu_start < 0.05, 'should suspend instead of burning CPU while waiting'
+    assert events == ['fast done', 'slow cleanup']
+
+
+async def test_automation_can_wrap_a_non_coroutine_awaitable():
+    """``Automation`` must also close awaitables like ``parallelize`` which are not coroutines (regression)."""
+    events: list[str] = []
+
+    async def worker() -> None:
+        await asyncio.sleep(0.01)
+        events.append('done')
+
+    assert await Automation(rosys.automation.parallelize(worker())).run() is None
+    assert events == ['done']
 
 
 @pytest.mark.parametrize('method', ['pause', 'stop'])


### PR DESCRIPTION
### Motivation

`rosys.automation.parallelize` hogs a full CPU core whenever all of its coroutines are waiting: it parks the children's futures and busy-polls them with a bare `yield`, which makes asyncio reschedule the automation task on every event loop iteration.

### Implementation

- Replace the bare `yield` in `parallelize.__await__` with `yield from asyncio.wait(pending, return_when=FIRST_COMPLETED).__await__()`, suspending the automation task on the children's actual futures (select-like).
- Fix `Automation.__await__` closing `self.coro` in its `finally`, which raised `AttributeError` for non-coroutine awaitables like `parallelize` (introduced in #403/#413); it now closes the `__await__` iterator instead, which is equivalent for real coroutines. Widen the `coro` parameter type from `Coroutine` to `Awaitable` accordingly. Discovered accidentally when adding tests.
- Add regression tests

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5
