### PR TITLE
Add Hikvision and HI3510 vendors for RTSP camera discovery

### DIFF
--- a/rosys/vision/rtsp_camera/vendors.py
+++ b/rosys/vision/rtsp_camera/vendors.py
@@ -11,6 +11,8 @@ class VendorType(Enum):
     OPENIPC_ZAUBERZEUG = 7
     GOODCAM = 8
     ARKVISION = 9
+    HIKVISION = 10
+    HI3510 = 11
     OTHER = -1
 
 
@@ -28,6 +30,8 @@ mac_prefix_to_vendor: dict[str, VendorType] = {
     '7a:7a:21': VendorType.OPENIPC_ZAUBERZEUG,
     '2c:6f:51': VendorType.GOODCAM,
     '18:fd:cb': VendorType.ARKVISION,  # NOTE: prefix observed on a single ArkCam Basic+ mini; may need expanding
+    '28:57:be': VendorType.HIKVISION,  # Hangzhou Hikvision (also OEMs TruVision and many rebrands)
+    '00:af:a5': VendorType.HI3510,  # HiSilicon hi3510 firmware family (EasyN/Wanscam/Sricam/... rebrands)
 }
 
 
@@ -51,6 +55,10 @@ def _vendor_to_url(vendor_type: VendorType, ip: str, substream: int) -> str | No
             return f'rtsp://root:Adminadmin@{ip}{path}'
         case VendorType.ARKVISION:
             return f'rtsp://{ip}:8554/h264'  # no auth; no separate substream
+        case VendorType.HIKVISION:
+            return f'rtsp://admin:Adminadmin@{ip}/Streaming/Channels/10{2 if substream else 1}'
+        case VendorType.HI3510:
+            return f'rtsp://admin:admin@{ip}/1{2 if substream else 1}'
         case VendorType.OTHER:
             return None
     raise AssertionError('unreachable')  # Just for mypy


### PR DESCRIPTION
**TL;DR — adds two RTSP camera vendors to `mac_to_url` discovery, same spirit as #441:**

| Vendor | Enum | MAC prefix | RTSP path (main / sub) |
|---|---|---|---|
| `HIKVISION` | `10` | `28:57:be` | `/Streaming/Channels/101` · `/102` |
| `HI3510` | `11` | `00:af:a5` | `/11` · `/12` |

Both paths were **verified against live cameras** (ffprobe pulled real video through the exact URL the patched `mac_to_url()` emits), not reasoned from a spec.

### The change (`rosys/vision/rtsp_camera/vendors.py`, +8 / -0)
```python
HIKVISION = 10
HI3510 = 11
'28:57:be': VendorType.HIKVISION,  # Hangzhou Hikvision (also OEMs TruVision and many rebrands)
'00:af:a5': VendorType.HI3510,     # HiSilicon hi3510 firmware family (EasyN/Wanscam/Sricam/... rebrands)
case VendorType.HIKVISION:
    return f'rtsp://admin:Adminadmin@{ip}/Streaming/Channels/10{2 if substream else 1}'
case VendorType.HI3510:
    return f'rtsp://admin:admin@{ip}/1{2 if substream else 1}'
```

### Naming `HI3510` — not `EASYN`, not `HISILICON`
The `/11`+`/12` scheme tracks the **firmware family**, not the brand or the silicon vendor:

| Candidate | Verdict |
|---|---|
| `EASYN` | too narrow — same firmware ships as SV3C, Ctronics, Dericam, INSTAR, Wansview, Wanscam, Sricam, … |
| `HISILICON` | too broad / wrong — HiSilicon SoCs under **Xiongmai** firmware use `/user=..&password=..&stream=0.sdp` on port 34567, **not** `/11`,`/12` |
| **`HI3510`** | right altitude — the device's own `/cgi-bin/hi3510/` path and the community name for this firmware family |

<details><summary><b>Evidence — Hikvision (live TruVision TVW-1120)</b></summary>

```
IEEE OUI:   28:57:be -> Hangzhou Hikvision Digital Technology Co.,Ltd.
device:     model=TVW-1120, deviceName=UltraConnect IP Camera, firmware V5.2 FP13
ffprobe:    /Streaming/Channels/101 -> h264 1280x720 @ 25fps (+ mp2 audio)
            /Streaming/Channels/102 -> h264 640x480
DESCRIBE:   SDP carries MEDIAINFO=494D4B48... = ASCII "IMKH" (OEM fingerprint, MAC-independent)
end-to-end: mac_to_vendor('28:57:be:..') = HIKVISION
            substream=0 -> .../101 -> h264,1280,720  LIVE VIDEO OK
            substream=1 -> .../102 -> h264,640,480    LIVE VIDEO OK
```
</details>

<details><summary><b>Evidence — HI3510 (live unit)</b></summary>

```
device:     GET /cgi-bin/hi3510/param.cgi?cmd=getserverinfo -> 200
            model=C6F0SiZ0N0P0L0  soft=V6.4.1.1.1-20160324
RTSP:       Server: Hipcam RealServer/V1.0
IEEE OUI:   00:af:a5 unregistered (common for this OEM class; rosys already maps
            other unregistered prefixes such as ANJOY / OPENIPC)
ffprobe:    /11 -> h264 1920x1080 (+ PCMA audio)
            /12 -> h264 640x352
end-to-end: mac_to_vendor('00:af:a5:..') = HI3510
            substream=0 -> .../11 -> h264,1920,1080  LIVE VIDEO OK
            substream=1 -> .../12 -> h264,640,352      LIVE VIDEO OK
```
External corroboration for the family generalization: hi3510 family → `/11` main, `/12` sub, `/13` mobile (github.com/spagonic/ha-hi3510; smartrtsp.com); Xiongmai → `/user=..&stream=0.sdp` port 34567 (xiongmaitech.com; camlytics.com/camera/hi3518).
</details>

<details><summary><b>Local gates (green) & test note</b></summary>

```
pre-commit (ruff, autopep8, codespell, quotes, ...) .... Passed
mypy ./rosys ........................................... Success: no issues found in 217 source files
pylint vendors.py ...................................... 10.00/10
runtime: enum values unique (10/11), 40:7a:a4 DAHUA mapping intact (regression guard),
         both prefixes resolve, both URLs match the ffprobe-verified paths above
```
No unit test is added: the repo currently has no RTSP-vendor tests to mirror, and this matches the test-free precedent of #441. Happy to add one if preferred.
</details>

<details><summary><b>Caveats for reviewers</b></summary>

- **Credentials are placeholders following repo convention.** Hikvision has **no universal factory default** (activation forces a user-chosen password); `admin:Adminadmin` is the repo's provisioning placeholder (as with DAHUA/REOLINK/etc.). `admin:admin` is the hi3510 family's actual factory default (verified on the unit). Adjust to your provisioning password.
- **WiFi discovery gap (Hikvision).** On WiFi the tested unit presents its **WiFi-module** MAC `20:f4:1b` (Shenzhen Bilian / LB-LINK per IEEE), **not** a Hikvision OUI — so MAC discovery only catches the **wired** leg. `20:f4:1b` is deliberately **not** mapped (generic module OEM → would false-positive).
- **Single-unit prefixes.** Each prefix was observed on one unit; Hikvision owns many OUIs, so both may want expanding over time (same footnote spirit as the ArkVision entry).
</details>

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
