### PR TITLE
Release a camera's image routes when the camera is collected

### DIFF
--- a/rosys/vision/image_route.py
+++ b/rosys/vision/image_route.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 log = logging.getLogger('rosys.image_route')
 
+_route_owners: dict[str, weakref.ref] = {}
+
 
 def create_image_route(camera: Camera) -> None:
     placeholder_url = '/' + camera.base_path + '/placeholder'
@@ -33,6 +35,9 @@ def create_image_route(camera: Camera) -> None:
     app.remove_route(undistorted_url)
 
     camera_ref = weakref.ref(camera)
+    urls = (placeholder_url, timestamp_url, undistorted_url)
+    for url in urls:
+        _route_owners[url] = camera_ref  # NOTE: claim the urls before adding, so a pending finalizer cannot remove them
 
     async def get_camera_image(timestamp: str,
                                shrink: float = 1.0,
@@ -94,6 +99,15 @@ def create_image_route(camera: Camera) -> None:
     app.add_api_route(placeholder_url, _get_placeholder)
     app.add_api_route(timestamp_url, get_camera_image)
     app.add_api_route(undistorted_url, get_camera_image_undistorted)
+
+    weakref.finalize(camera, _remove_image_routes, camera_ref, urls)
+
+
+def _remove_image_routes(camera_ref: weakref.ref, urls: tuple[str, ...]) -> None:
+    for url in urls:
+        if _route_owners.get(url) is camera_ref:  # NOTE: a newer camera with the same id may own them by now
+            app.remove_route(url)
+            del _route_owners[url]
 
 
 def _create_placeholder(shrink: int) -> bytes:

--- a/rosys/vision/image_route.py
+++ b/rosys/vision/image_route.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 log = logging.getLogger('rosys.image_route')
 
-_route_owners: dict[str, weakref.ref] = {}
+_route_owners: dict[str, weakref.ref[Camera]] = {}
 
 
 def create_image_route(camera: Camera) -> None:
@@ -103,7 +103,7 @@ def create_image_route(camera: Camera) -> None:
     weakref.finalize(camera, _remove_image_routes, camera_ref, urls)
 
 
-def _remove_image_routes(camera_ref: weakref.ref, urls: tuple[str, ...]) -> None:
+def _remove_image_routes(camera_ref: weakref.ref[Camera], urls: tuple[str, ...]) -> None:
     for url in urls:
         if _route_owners.get(url) is camera_ref:  # NOTE: a newer camera with the same id may own them by now
             app.remove_route(url)

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -7,7 +7,6 @@ from nicegui import app
 
 from rosys.testing import forward
 from rosys.vision import RtspCamera, RtspCameraProvider, SimulatedCamera, UsbCamera, UsbCameraProvider
-from rosys.vision.image_route import _remove_image_routes, _route_owners
 
 
 async def test_simulated_camera(rosys_integration):
@@ -81,23 +80,18 @@ async def test_a_collected_camera_keeps_the_routes_of_its_successor(rosys_integr
 
 async def test_a_pending_finalizer_cannot_remove_the_routes_of_a_reused_id(rosys_integration, monkeypatch):
     """The old camera's finalizer may fire while its successor is still registering its routes."""
-    old_camera = SimulatedCamera(id='reused_cam', connect_after_init=False)
-    stale_ref = _route_owners['/images/reused_cam/placeholder']
-    urls = tuple(url for url in _route_owners if url.startswith('/images/reused_cam/'))
+    old_camera: SimulatedCamera | None = SimulatedCamera(id='raced_cam', connect_after_init=False)
     original_add_api_route = app.add_api_route
-    fired = False
 
     def add_api_route(*args, **kwargs):
-        nonlocal fired
+        nonlocal old_camera
         result = original_add_api_route(*args, **kwargs)
-        if not fired:  # NOTE: fire once the successor has registered its first route, not before
-            fired = True
-            _remove_image_routes(stale_ref, urls)
+        old_camera = None  # NOTE: collect the old camera once the successor has registered its first route
+        gc.collect()
         return result
     monkeypatch.setattr(app, 'add_api_route', add_api_route)
 
-    new_camera = SimulatedCamera(id='reused_cam', connect_after_init=False)
+    new_camera = SimulatedCamera(id='raced_cam', connect_after_init=False)
 
-    monkeypatch.undo()
-    assert _image_route_count('reused_cam') == 3
-    assert new_camera.base_path == old_camera.base_path
+    assert _image_route_count('raced_cam') == 3
+    assert new_camera.base_path == 'images/raced_cam'

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -1,10 +1,13 @@
 import asyncio
+import gc
 import platform
 
 import pytest
+from nicegui import app
 
 from rosys.testing import forward
 from rosys.vision import RtspCamera, RtspCameraProvider, SimulatedCamera, UsbCamera, UsbCameraProvider
+from rosys.vision.image_route import _remove_image_routes, _route_owners
 
 
 async def test_simulated_camera(rosys_integration):
@@ -49,3 +52,52 @@ async def test_rtsp_camera(rosys_integration):
         await asyncio.sleep(0.2)
     assert camera.is_connected
     assert len(camera.images) >= 1
+
+
+def _image_route_count(camera_id: str) -> int:
+    return len([route for route in app.routes if getattr(route, 'path', '').startswith(f'/images/{camera_id}/')])
+
+
+async def test_image_routes_are_released_with_the_camera(rosys_integration):
+    camera = SimulatedCamera(id='fleeting_cam', connect_after_init=False)
+    assert _image_route_count('fleeting_cam') == 3
+
+    del camera
+    gc.collect()
+
+    assert _image_route_count('fleeting_cam') == 0
+
+
+async def test_a_collected_camera_keeps_the_routes_of_its_successor(rosys_integration):
+    old_camera = SimulatedCamera(id='reused_cam', connect_after_init=False)
+    new_camera = SimulatedCamera(id='reused_cam', connect_after_init=False)  # same id: replaces the routes
+
+    del old_camera
+    gc.collect()
+
+    assert _image_route_count('reused_cam') == 3
+    assert new_camera.base_path == 'images/reused_cam'
+
+
+async def test_a_pending_finalizer_cannot_remove_the_routes_of_a_reused_id(rosys_integration, monkeypatch):
+    """The old camera's finalizer may fire while its successor is still registering its routes."""
+    old_camera = SimulatedCamera(id='reused_cam', connect_after_init=False)
+    stale_ref = _route_owners['/images/reused_cam/placeholder']
+    urls = tuple(url for url in _route_owners if url.startswith('/images/reused_cam/'))
+    original_add_api_route = app.add_api_route
+    fired = False
+
+    def add_api_route(*args, **kwargs):
+        nonlocal fired
+        result = original_add_api_route(*args, **kwargs)
+        if not fired:  # NOTE: fire once the successor has registered its first route, not before
+            fired = True
+            _remove_image_routes(stale_ref, urls)
+        return result
+    monkeypatch.setattr(app, 'add_api_route', add_api_route)
+
+    new_camera = SimulatedCamera(id='reused_cam', connect_after_init=False)
+
+    monkeypatch.undo()
+    assert _image_route_count('reused_cam') == 3
+    assert new_camera.base_path == old_camera.base_path


### PR DESCRIPTION
**TL;DR:** The three `/images/<id>/…` routes were registered for every camera and never removed, so a per-request camera with a per-request id grew `app.routes` without bound — measured **90 route entries for 30 per-page cameras**. They are now released when the camera is collected, which takes it to **0**. This is the last open item of #436.

The camera *object* was already safe (the handlers hold `weakref.ref(camera)`), so this is purely about the route table.

```python
     camera_ref = weakref.ref(camera)
+    urls = (placeholder_url, timestamp_url, undistorted_url)
+    for url in urls:
+        _route_owners[url] = camera_ref  # NOTE: claim the urls before adding, so a pending finalizer cannot remove them
     ...
     app.add_api_route(undistorted_url, get_camera_image_undistorted)
+
+    weakref.finalize(camera, _remove_image_routes, camera_ref, urls)
+
+
+def _remove_image_routes(camera_ref: weakref.ref, urls: tuple[str, ...]) -> None:
+    for url in urls:
+        if _route_owners.get(url) is camera_ref:  # NOTE: a newer camera with the same id may own them by now
+            app.remove_route(url)
+            del _route_owners[url]
```

A finalizer rather than an explicit teardown method, to stay with the "object lifetime defines resource lifetime" direction of #427.

**Reusing a camera id is the tricky case, and it needs both the ownership check and the ordering.** `create_image_route` already calls `app.remove_route` for its own three paths at the top, so reconstructing a camera under the same id is a supported case.

- Without the identity check, *A(id=x) → B(id=x) → collect A* would have A's finalizer delete **B's** routes.
- Claiming the urls **before** `add_api_route` matters too: a finalizer still pending for A can fire *between* B's route registrations. If ownership were transferred afterwards, A's finalizer would remove routes B had just added, leaving `_route_owners` claiming routes that no longer exist. Both orderings are covered by tests below.

`_route_owners` is keyed by url and cleaned in the finalizer, so it holds at most one entry per live camera path — if a camera is never collected its route is not removed either, so this adds no new class of growth.

<details>
<summary><b>Tests — and how I checked they aren't hollow</b></summary>

Three tests in `tests/test_cameras.py`. Two of them guard bugs *the fix itself* could introduce, so they pass before and after — I checked each is load-bearing by breaking the specific line it guards:

| test | proof it is not decorative |
|---|---|
| `test_image_routes_are_released_with_the_camera` | fails without the fix: `AssertionError: assert 3 == 0` |
| `test_a_collected_camera_keeps_the_routes_of_its_successor` | delete the `is camera_ref` check → `assert 0 == 3` |
| `test_a_pending_finalizer_cannot_remove_the_routes_of_a_reused_id` | move the ownership claim back after `add_api_route` → `assert 2 == 3` |

The third test injects the stale finalizer *after* the successor's first route registration, which is the interleaving that actually reproduces the bug — firing it before the first registration does not, because the finalizer clears its own ownership entries on the way through.

End-to-end, 30 cameras built one per page-view, clients then deleted: `routes_added=90` before, `routes_added=0` after.

Gates: `pytest` 340 passed / 7 skipped (skips are the `arp-scan` and Linux-only camera tests), `mypy` clean on 217 files, `pylint` 10.00/10, `pre-commit` clean.
</details>

<details>
<summary><b>Where this sits relative to #436</b></summary>

With #427 merged, the repeater half of #436 is closed — I re-measured it and the residual "leak" I originally reported for `RobotSimulation`/`Steerer`/`Odometer` turned out to be a ~2 second collection lag, not a leak. `Odometer`'s `VELOCITY_MEASURED` subscription is already released by NiceGUI's auto-unsubscribe for callbacks made inside a UI context.

That left two genuine vectors, and this PR is the second of them:

1. `rosys.on_shutdown` holding handlers strongly, pinning every per-request module → #443.
2. the route-table growth fixed here.

Deliberately kept as three separate PRs (with #437 for the pre-startup `stop()` gap) so each stays reviewable on its own.
</details>

<details>
<summary><b>Second-lineage review</b></summary>

Reviewed adversarially by Codex (different model lineage). It found the ordering bug described above — my first version transferred ownership *after* registering the routes, leaving a window where a pending finalizer for a same-id predecessor would delete the successor's routes — which is now fixed and covered by the third test. It refuted three things I asked it to attack: the finalizer does not pin the camera (it holds a weakref and a tuple of strings, no closure over `camera`), `_route_owners` is not a new unbounded leak, and mutating `app.routes` from a finalizer is not a new hazard class since `create_image_route` already calls `app.remove_route` synchronously and CPython list mutation during iteration does not raise. Off-loop finalizer execution remains theoretically possible if the last camera reference is dropped from another thread; neither of us found a RoSys path that does that, so I left it alone rather than adding speculative locking — happy to revisit if you know of one.
</details>

_Disclaimer: measurements, implementation and this description by Claude (Opus 5), reviewed against a second model lineage._
