### PR TITLE
Sample a topic's value on the event loop, and only encode it on the writer

### DIFF
--- a/rosys/analysis/recording/converters.py
+++ b/rosys/analysis/recording/converters.py
@@ -1,15 +1,18 @@
 """Registry, topic sources and JSON machinery that feed the MCAP recorder.
 
-A :class:`Converter` bundles a :class:`TopicSchema` with an ``encode`` returning
-JSON bytes (or ``None`` to skip). The registry maps RoSys types to converter
-factories so :func:`add_event_topic` / :func:`add_timer_topic` pick the right
-converter from the value's runtime type, with explicit overrides. App-specific
-topics without a foxglove schema use :func:`custom_message` with a JSON schema.
+A :class:`Converter` bundles a :class:`TopicSchema` with an optional ``sample``
+reducing the payload to the value to record, and an ``encode`` returning JSON
+bytes (or ``None`` to skip). The registry maps RoSys types to converter factories
+so :func:`add_event_topic` / :func:`add_timer_topic` pick the right converter from
+the value's runtime type, with explicit overrides. App-specific topics without a
+foxglove schema use :func:`custom_message` with a JSON schema.
 
 The concrete converters for RoSys/Foxglove data types live in :mod:`.foxglove`;
 this module only holds the machinery that wires values into the recorder. Values
-are enqueued unencoded and :func:`Converter.encode` runs on the recorder's
-background writer, so no JSON/JPEG encoding happens on the event loop.
+are sampled and timestamped on the event loop but enqueued unencoded:
+:func:`Converter.encode` runs on the recorder's background writer, so no
+JSON/JPEG encoding happens on the event loop (see :class:`Converter` for why the
+two cannot be swapped).
 """
 from __future__ import annotations
 
@@ -33,9 +36,29 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class Converter:
-    """A topic's schema plus an ``encode`` returning JSON bytes (or ``None`` to skip)."""
+    """A topic's schema, an optional ``sample`` and an ``encode`` returning JSON bytes.
+
+    The two callables run in different places, which is the whole point of splitting them:
+
+    * ``sample`` reduces the payload to the value that is to be recorded, **on the event loop**, at
+      the moment the topic is written. Anything reading live state belongs here.
+    * ``encode`` turns that value into bytes (``None`` to skip the message) **on the background
+      writer**, off the event loop, because JSON and JPEG encoding are the expensive part.
+
+    Putting a field access into ``encode`` instead silently records the wrong instant: the payload is
+    queued, and by the time the writer encodes it, the object it reads from has moved on. Every
+    message of one flush batch then carries the same value, which turns a live signal into a staircase
+    with the writer's flush period while the timestamps stay perfectly spaced.
+
+    ``sample`` must return an immutable snapshot (a number, or a value object that is replaced rather
+    than mutated, as ``Odometer.pose`` is) — or an explicit copy. Returning a live mutable object only
+    moves the reference onto the queue, so the writer still encodes whatever that object holds later
+    and the staircase remains. The same applies to the payload itself when there is no ``sample``
+    (e.g. ``Odometer.FRAME_UPDATED`` re-emits one in-place-mutated ``Frame3d``).
+    """
     schema: TopicSchema
     encode: Callable[[Any, int], bytes | None]
+    sample: Callable[[Any], Any] | None = None
 
 
 ConverterFactory = Callable[..., Converter]
@@ -116,11 +139,12 @@ def add_timer_topic(recorder: McapRecorder, topic: str, *,
 
 
 class _TopicWriter:
-    """Shared lazy-dispatch + enqueue for a single topic.
+    """Shared sampling + lazy-dispatch + enqueue for a single topic.
 
-    Auto-dispatch and timestamping happen on the event loop (both cheap), but the
-    value is handed to the recorder unencoded together with its ``encode``
-    callable, so the actual JSON/JPEG encoding runs on the background writer.
+    Sampling, auto-dispatch and timestamping happen on the event loop (all cheap),
+    but the sampled value is handed to the recorder unencoded together with its
+    ``encode`` callable, so the actual JSON/JPEG encoding runs on the background
+    writer.
     """
 
     def __init__(self, recorder: McapRecorder, topic: str, converter: Converter | None,
@@ -133,14 +157,21 @@ class _TopicWriter:
 
     def write(self, value: Any) -> None:
         if not self._recorder.accepts(self._topic):
-            return  # not recording or topic deselected -> skip before any (auto-dispatch or encode) work
+            return  # not recording or topic deselected -> skip before any (sample, dispatch, encode) work
         if self._converter is None:
             if value is None:
-                return  # cannot auto-dispatch a None payload
-            self._converter = converter_for(value, **self._overrides)
+                return  # cannot auto-dispatch a None payload (before any timestamp call, which would see None)
+            self._converter = converter_for(value, **self._overrides)  # dispatched on the payload type
             self._recorder.add_topic(self._topic, self._converter.schema)
+        # Taken from the payload, before sampling: the `time` field lives on the payload, and the
+        # sampled value (a float, say) no longer has one — reading it afterwards would silently fall
+        # back to the current time and shift the whole trace.
         timestamp_ns = int(self._timestamp(value) * NANOSECONDS_PER_SECOND) \
             if self._timestamp is not None else _timestamp_ns(value)
+        if self._converter.sample is not None:
+            value = self._converter.sample(value)
+            if value is None:
+                return  # nothing to record at this instant; same meaning as an encode returning None
         self._recorder.log_message(self._topic, value, encode=self._converter.encode, timestamp_ns=timestamp_ns)
 
 
@@ -213,8 +244,14 @@ def _timestamp_ns(value: Any) -> int:
 # --------------------------------------------------------------------------- #
 
 
-def custom_message(schema_name: str, schema: dict, build: Callable[[Any, int], dict | None]) -> Converter:
-    """Converter for an app-specific JSON message; ``build`` returns a dict (or None to skip)."""
+def custom_message(schema_name: str, schema: dict, build: Callable[[Any, int], dict | None], *,
+                   sample: Callable[[Any], Any] | None = None) -> Converter:
+    """Converter for an app-specific JSON message; ``build`` returns a dict (or None to skip).
+
+    ``build`` runs on the background writer, so it must not read anything that moves — pass a
+    ``sample`` for that, which runs on the event loop and reduces the payload to the value ``build``
+    then sees. See :class:`Converter`.
+    """
     topic_schema = TopicSchema(schema_name, json.dumps(schema).encode(), 'jsonschema', 'json')
 
     def encode(value: Any, timestamp_ns: int) -> bytes | None:
@@ -223,7 +260,7 @@ def custom_message(schema_name: str, schema: dict, build: Callable[[Any, int], d
             return None
         return json.dumps(message, default=_json_native).encode()
 
-    return Converter(topic_schema, encode)
+    return Converter(topic_schema, encode, sample)
 
 
 def _json_native(obj: Any) -> Any:
@@ -246,13 +283,17 @@ _SCALAR_SCHEMA_NAME = {'number': 'Float', 'integer': 'Integer', 'boolean': 'Bool
 
 
 def scalar(*, value_type: str = 'number', extract: Callable[[Any], Any] | None = None) -> Converter:
-    """A primitive value -> ``{value: ...}`` (plottable). ``extract`` pulls the field off the payload."""
+    """A primitive value -> ``{value: ...}`` (plottable).
+
+    ``extract`` pulls the field off the payload, on the event loop at write time, so it may read live
+    state (a hardware module's attribute, say) and still record the value of that instant.
+    """
     schema = {'type': 'object', 'properties': {'value': {'type': value_type}}}
 
     def build(value: Any, _timestamp_ns: int) -> dict:
-        return {'value': extract(value) if extract is not None else value}
+        return {'value': value}
 
-    return custom_message(_SCALAR_SCHEMA_NAME[value_type], schema, build)
+    return custom_message(_SCALAR_SCHEMA_NAME[value_type], schema, build, sample=extract)
 
 
 def number() -> Converter:

--- a/rosys/analysis/recording/converters.py
+++ b/rosys/analysis/recording/converters.py
@@ -169,7 +169,14 @@ class _TopicWriter:
         timestamp_ns = int(self._timestamp(value) * NANOSECONDS_PER_SECOND) \
             if self._timestamp is not None else _timestamp_ns(value)
         if self._converter.sample is not None:
-            value = self._converter.sample(value)
+            try:
+                value = self._converter.sample(value)
+            except Exception:
+                # Unlike `encode`, this runs on the event loop, inside the emitting handler or the
+                # polling repeater: unguarded, a broken converter would log per emission (at up to
+                # the event rate) instead of once, and surface as an error in the app that emitted.
+                self._recorder.warn_converter_failure(self._topic, 'sampling')
+                return
             if value is None:
                 return  # nothing to record at this instant; same meaning as an encode returning None
         self._recorder.log_message(self._topic, value, encode=self._converter.encode, timestamp_ns=timestamp_ns)

--- a/rosys/analysis/recording/converters.py
+++ b/rosys/analysis/recording/converters.py
@@ -41,7 +41,8 @@ class Converter:
     The two callables run in different places, which is the whole point of splitting them:
 
     * ``sample`` reduces the payload to the value that is to be recorded, **on the event loop**, at
-      the moment the topic is written. Anything reading live state belongs here.
+      the moment the topic is written (``None`` to skip the message, as in ``encode``). Anything
+      reading live state belongs here.
     * ``encode`` turns that value into bytes (``None`` to skip the message) **on the background
       writer**, off the event loop, because JSON and JPEG encoding are the expensive part.
 
@@ -293,7 +294,8 @@ def scalar(*, value_type: str = 'number', extract: Callable[[Any], Any] | None =
     """A primitive value -> ``{value: ...}`` (plottable).
 
     ``extract`` pulls the field off the payload, on the event loop at write time, so it may read live
-    state (a hardware module's attribute, say) and still record the value of that instant.
+    state (a hardware module's attribute, say) and still record the value of that instant. Returning
+    ``None`` from it skips the message, rather than recording an unplottable ``{'value': null}``.
     """
     schema = {'type': 'object', 'properties': {'value': {'type': value_type}}}
 

--- a/rosys/analysis/recording/converters.py
+++ b/rosys/analysis/recording/converters.py
@@ -56,6 +56,11 @@ class Converter:
     moves the reference onto the queue, so the writer still encodes whatever that object holds later
     and the staircase remains. The same applies to the payload itself when there is no ``sample``
     (e.g. ``Odometer.FRAME_UPDATED`` re-emits one in-place-mutated ``Frame3d``).
+
+    That copy has to stay cheap, though: ``sample`` runs on the event loop at the topic's full rate,
+    so a field read or a small copy is the budget. Where a snapshot would cost more than that —
+    deep-copying an image, walking a list — the topic wants a smaller value to record, not a heavier
+    ``sample``.
     """
     schema: TopicSchema
     encode: Callable[[Any, int], bytes | None]

--- a/rosys/analysis/recording/foxglove.py
+++ b/rosys/analysis/recording/foxglove.py
@@ -84,8 +84,7 @@ def pose_in_frame(*, frame: str = 'map', extract: Callable[[Any], Any] | None = 
         },
     }
 
-    def build(value: Any, timestamp_ns: int) -> dict | None:
-        pose = extract(value) if extract is not None else value
+    def build(pose: Any, timestamp_ns: int) -> dict | None:
         if pose is None:
             return None
         return {
@@ -94,7 +93,7 @@ def pose_in_frame(*, frame: str = 'map', extract: Callable[[Any], Any] | None = 
                      'orientation': _quaternion_from_yaw(pose.yaw)},
         }
 
-    return custom_message('foxglove.PoseInFrame', schema, build)
+    return custom_message('foxglove.PoseInFrame', schema, build, sample=extract)
 
 
 def frame_transform(*, child: str, parent: str = 'map',
@@ -109,8 +108,7 @@ def frame_transform(*, child: str, parent: str = 'map',
         },
     }
 
-    def build(value: Any, timestamp_ns: int) -> dict | None:
-        pose = extract(value) if extract is not None else value
+    def build(pose: Any, timestamp_ns: int) -> dict | None:
         if pose is None:
             return None
         return {
@@ -120,7 +118,7 @@ def frame_transform(*, child: str, parent: str = 'map',
             'rotation': _quaternion_from_yaw(pose.yaw),
         }
 
-    return custom_message('foxglove.FrameTransform', schema, build)
+    return custom_message('foxglove.FrameTransform', schema, build, sample=extract)
 
 
 def transform_3d(*, child: str, parent: str = 'base_link',
@@ -135,8 +133,7 @@ def transform_3d(*, child: str, parent: str = 'base_link',
         },
     }
 
-    def build(value: Any, timestamp_ns: int) -> dict | None:
-        pose = extract(value) if extract is not None else value
+    def build(pose: Any, timestamp_ns: int) -> dict | None:
         if pose is None:
             return None
         w, x, y, z = pose.rotation.quaternion
@@ -147,7 +144,7 @@ def transform_3d(*, child: str, parent: str = 'base_link',
             'rotation': {'x': x, 'y': y, 'z': z, 'w': w},
         }
 
-    return custom_message('foxglove.FrameTransform', schema, build)
+    return custom_message('foxglove.FrameTransform', schema, build, sample=extract)
 
 
 # --------------------------------------------------------------------------- #
@@ -333,7 +330,8 @@ def compressed_image(*, frame: str = 'camera') -> Converter:
 def camera_calibration(camera: CalibratableCamera, *, frame: str) -> Converter:
     """A ``CalibratableCamera`` -> ``foxglove.CameraCalibration`` (intrinsics K/D/P).
 
-    Reads ``camera.calibration`` on each call; returns ``None`` while uncalibrated.
+    Samples ``camera.calibration`` on each write, on the event loop, and skips the message while the
+    camera is uncalibrated.
     """
     schema = {
         'type': 'object',
@@ -349,8 +347,7 @@ def camera_calibration(camera: CalibratableCamera, *, frame: str) -> Converter:
     }
     distortion_models = {'pinhole': 'plumb_bob', 'fisheye': 'equidistant'}
 
-    def build(_value: Any, timestamp_ns: int) -> dict | None:
-        calibration = camera.calibration
+    def build(calibration: Any, timestamp_ns: int) -> dict | None:
         if calibration is None:
             return None
         intrinsics = calibration.intrinsics
@@ -366,7 +363,8 @@ def camera_calibration(camera: CalibratableCamera, *, frame: str) -> Converter:
             'P': [fx, 0.0, cx, 0.0, 0.0, fy, cy, 0.0, 0.0, 0.0, 1.0, 0.0],
         }
 
-    return custom_message('foxglove.CameraCalibration', schema, build)
+    return custom_message('foxglove.CameraCalibration', schema, build,
+                          sample=lambda _image: camera.calibration)
 
 
 def image_annotations(*, camera_id: str | None = None, thickness: float = 2.0) -> Converter:

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -193,7 +193,7 @@ class McapRecorder:
         self._last_drop_warning: float = float('-inf')
         self._is_recording: bool = False
         self._warned_topics: set[str] = set()
-        self._warned_encode_topics: set[str] = set()
+        self._warned_converter_topics: set[tuple[str, str]] = set()
         self._disk_stats = _DiskStats(0, 0, 0)
 
         self._cleanup_orphaned_reindex_files()
@@ -539,7 +539,7 @@ class McapRecorder:
         Resilient to two failures that would otherwise lose data silently:
 
         * a converter that raises for one message is logged (once per topic) and skipped, so
-          the rest of the batch still lands (see :meth:`_warn_encode_failure`);
+          the rest of the batch still lands (see :meth:`warn_converter_failure`);
         * a lost writer — ``None`` while still recording, e.g. after a failed rotation — is
           reopened once; if that fails the recorder hard-stops with an error and a drop count
           rather than silently swallowing every future message (see :meth:`_hard_stop`).
@@ -557,7 +557,7 @@ class McapRecorder:
                 data = message.encode(message.payload, message.timestamp_ns) \
                     if message.encode is not None else message.payload
             except Exception:
-                self._warn_encode_failure(message.topic)
+                self.warn_converter_failure(message.topic, 'encoding')
                 continue
             if data is None:
                 continue  # converter chose to skip this value
@@ -576,13 +576,22 @@ class McapRecorder:
                 if not self._rotate_file(dropped_on_failure=len(batch) - index - 1):
                     return
 
-    def _warn_encode_failure(self, topic: str) -> None:
-        """Log a converter failure once per topic, so one bad message never floods the log."""
-        if topic in self._warned_encode_topics:
+    def warn_converter_failure(self, topic: str, stage: str) -> None:
+        """Log a converter failure once per topic and stage, so one bad message never floods the log.
+
+        Both halves of a converter can raise, in different places: ``sample`` on the event loop, at
+        the topic's full rate, and ``encode`` on the writer thread. Both report here, so a broken
+        converter costs one log line rather than one per message. Call from an exception handler.
+
+        :param topic: the topic whose converter raised.
+        :param stage: which half raised, ``'sampling'`` or ``'encoding'``; keyed separately so a
+            failing ``sample`` does not mute a later ``encode`` failure on the same topic.
+        """
+        if (topic, stage) in self._warned_converter_topics:
             return
-        self._warned_encode_topics.add(topic)
-        self.log.exception('encoding a message for topic %s failed; skipping it '
-                           '(further failures on this topic are silent)', topic)
+        self._warned_converter_topics.add((topic, stage))
+        self.log.exception('%s a message for topic %s failed; skipping it '
+                           '(further %s failures on this topic are silent)', stage, topic, stage)
 
     def _reopen_file(self, *, dropped_on_failure: int) -> bool:
         """Reopen a fresh file after the writer was lost (e.g. a failed rotation). Caller holds ``_lock``.

--- a/tests/test_mcap_converters.py
+++ b/tests/test_mcap_converters.py
@@ -168,6 +168,21 @@ async def test_add_pose_topic_extract_skips_none(mcap_dir: Path) -> None:
     assert recorder.message_count == 0
 
 
+async def test_none_payload_is_skipped_before_the_timestamp_is_read(mcap_dir: Path) -> None:
+    """A ``None`` payload on an auto-dispatched topic is skipped without calling ``timestamp``.
+
+    A custom ``timestamp`` reads a field off the payload, so it must not see the ``None`` that
+    auto-dispatch already gives up on — the guard has to come first, or the handler raises.
+    """
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    event = FakeEvent()
+    add_event_topic(recorder, '/pose', event=event, timestamp=lambda measurement: measurement.time)
+    recorder.start()
+    event.emit(None)
+    await recorder.stop()
+    assert recorder.message_count == 0
+
+
 async def test_unpack_records_each_element(mcap_dir: Path) -> None:
     """``unpack=True`` records each element of an iterable payload separately."""
     recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
@@ -254,6 +269,27 @@ async def test_scalar_extract_pulls_field(mcap_dir: Path) -> None:
 
     _, message = _read(_only_file(mcap_dir))[0]
     assert message == {'value': 0.25}
+
+
+async def test_extract_reads_live_state_at_write_time(mcap_dir: Path) -> None:
+    """``extract`` samples when the topic is written, not when the writer encodes it.
+
+    Regression: the extraction used to sit inside ``encode``, which runs on the background writer.
+    Every message of one flush batch then read the same, later value — a live signal came out of the
+    file as a staircase with the writer's flush period, while the timestamps stayed evenly spaced, so
+    nothing about the recording looked wrong.
+    """
+    state = SimpleNamespace(value=1)
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    event = FakeEvent()
+    add_event_topic(recorder, '/live', event=event, converter=scalar(extract=lambda _payload: state.value))
+    recorder.start()
+    event.emit(None)
+    state.value = 2  # as the robot would move on before the writer gets around to this message
+    await recorder.stop()
+
+    _, message = _read(_only_file(mcap_dir))[0]
+    assert message == {'value': 1}
 
 
 async def test_bool_dispatches_to_boolean(mcap_dir: Path) -> None:
@@ -428,7 +464,9 @@ def test_camera_calibration_encode() -> None:
     class _Camera:
         calibration = _Calibration()
 
-    message = json.loads(camera_calibration(_Camera(), frame='camera_front').encode(None, NS))
+    converter = camera_calibration(_Camera(), frame='camera_front')
+    assert converter.sample is not None
+    message = json.loads(converter.encode(converter.sample(None), NS))  # sample on the loop, encode after
     assert (message['width'], message['height']) == (640, 480)
     assert message['distortion_model'] == 'plumb_bob'
     assert message['K'][0] == 600.0  # fx
@@ -438,11 +476,14 @@ def test_camera_calibration_encode() -> None:
 
 
 def test_camera_calibration_skips_when_uncalibrated() -> None:
-    """``camera_calibration`` returns ``None`` while the camera is uncalibrated."""
+    """``camera_calibration`` skips the message while the camera is uncalibrated."""
     class _Camera:
         calibration = None
 
-    assert camera_calibration(_Camera(), frame='camera_front').encode(None, NS) is None
+    converter = camera_calibration(_Camera(), frame='camera_front')
+    assert converter.sample is not None
+    assert converter.sample(None) is None  # the writer drops it on this, before encoding
+    assert converter.encode(None, NS) is None
 
 
 async def test_compressed_image_encode(mcap_dir: Path) -> None:

--- a/tests/test_mcap_converters.py
+++ b/tests/test_mcap_converters.py
@@ -292,6 +292,18 @@ async def test_extract_reads_live_state_at_write_time(mcap_dir: Path) -> None:
     assert message == {'value': 1}
 
 
+async def test_scalar_extract_returning_none_skips_the_message(mcap_dir: Path) -> None:
+    """A ``scalar`` whose ``extract`` yields ``None`` records nothing, not an unplottable null."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    event = FakeEvent()
+    add_event_topic(recorder, '/live', event=event, converter=scalar(extract=lambda _payload: None))
+    recorder.start()
+    event.emit(0)
+    await recorder.stop()
+
+    assert recorder.message_count == 0
+
+
 async def test_a_raising_sample_does_not_reach_the_emitter(mcap_dir: Path) -> None:
     """A converter raising while sampling costs its message, not the emission that triggered it.
 

--- a/tests/test_mcap_converters.py
+++ b/tests/test_mcap_converters.py
@@ -292,6 +292,30 @@ async def test_extract_reads_live_state_at_write_time(mcap_dir: Path) -> None:
     assert message == {'value': 1}
 
 
+async def test_a_raising_sample_does_not_reach_the_emitter(mcap_dir: Path) -> None:
+    """A converter raising while sampling costs its message, not the emission that triggered it.
+
+    ``sample`` runs on the event loop inside the emitting handler, where the writer's failure path
+    around ``encode`` cannot catch it — unguarded, it would surface as an error in the app that
+    emitted.
+    """
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    event = FakeEvent()
+
+    def extract(payload: int) -> int:
+        if payload in (1, 2):
+            raise ValueError(f'cannot sample {payload}')
+        return payload
+
+    add_event_topic(recorder, '/live', event=event, converter=scalar(extract=extract))
+    recorder.start()
+    for value in range(4):
+        event.emit(value)  # raising inside a handler would propagate out of this
+    await recorder.stop()
+
+    assert [message for _, message in _read(_only_file(mcap_dir))] == [{'value': 0}, {'value': 3}]
+
+
 async def test_bool_dispatches_to_boolean(mcap_dir: Path) -> None:
     """A bool auto-dispatches to the ``Boolean`` scalar schema (registered before ``int``)."""
     recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)


### PR DESCRIPTION
### Motivation

A converter's `extract` is part of `encode`, and `McapRecorder.log_message` runs `encode` off the event loop on the background writer. Anything that reads live state through it — a hardware module's attribute, a camera's calibration — is therefore read at *flush* time, not at the instant the topic was written. Every message of one flush batch gets the same value.

A live signal then comes out of the file as a staircase whose step width is the writer's flush period, while the timestamps stay evenly spaced. Nothing about such a recording looks wrong, which is what makes it expensive.

On a robot, the per-track speeds and driver tick counters changed at about **1.4 Hz** in the file, where they should have changed at the **core message rate**, around 22 Hz — one sample per core message is all such a topic can ever be. Roughly fifteen out of sixteen samples therefore carried a value that did not belong to their timestamp — and since the timestamps themselves are evenly spaced, the file gives no hint of it. That cost a day of looking for the fault everywhere but here.

### Implementation

`Converter` carries a `sample` next to `encode`, and the two deliberately run in different places:

- `sample` reduces the payload to the value to be recorded, **on the event loop**, when the topic is written. Anything reading live state belongs here.
- `encode` turns that value into bytes, **on the background writer** — which is where the expensive JSON and JPEG work should stay, and the reason the split is worth having at all rather than simply encoding early.

Every factory that took an `extract` now passes it as `sample`, so **no call site changes**: `scalar`, `pose_in_frame`, `frame_transform`, `transform_3d`, and by extension `add_pose_topic`. `camera_calibration` gains one too, since it read `camera.calibration` inside its build. `custom_message` takes `sample=` so app-specific converters can do the same.

The sharp edge is what `sample` must return, and it is documented on the class: **an immutable snapshot**. Handing back a live mutable object merely moves the reference onto the queue, the writer still encodes whatever that object holds later, and the staircase survives the fix. The same caveat applies to a payload with no `sample` at all — `Odometer.FRAME_UPDATED` re-emits one `Frame3d` that is mutated in place.

Three ordering details in `_TopicWriter.write`, each of which is silent when wrong:

1. the `None` guard and auto-dispatch come **first**, so a custom `timestamp` that reads a field off the payload never sees a `None` that would make it raise;
2. the log time is then taken **from the payload**, because the sampled value no longer carries `time` and would silently fall back to the current time, shifting the whole trace;
3. auto-dispatch stays on the **payload** type, as before, so a topic's schema does not depend on whether it samples.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary). `test_extract_reads_live_state_at_write_time` pins the guarantee end to end: it emits with the live value at 1, moves it to 2 before the writer runs, and expects 1 in the file. Verified to fail without the change. `test_none_payload_is_skipped_before_the_timestamp_is_read` pins ordering detail 1. Two existing `camera_calibration` tests were updated, since that converter's `encode` now receives the sampled calibration rather than reading the camera itself. 91 pass in `test_mcap_converters.py`, `test_mcap_recorder.py` and `test_recorder_replay.py`.
- [x] Documentation has been added (or is not necessary). The `Converter` class documents where each callable runs, what happens when they are swapped, and the immutability requirement; the module docstring points at it.

