### PR TITLE
Fix parallelize not honoring uninterruptible with return_when_first_completed

### DIFF
--- a/rosys/automation/automation.py
+++ b/rosys/automation/automation.py
@@ -20,6 +20,12 @@ class AutomationStopped(BaseException):
     """
 
 
+def in_uninterruptible_section() -> bool:
+    """Whether the currently running automation is inside an ``@uninterruptible`` function."""
+    automation = _CURRENT_AUTOMATION.get()
+    return automation is not None and automation._uninterruptible_depth > 0  # pylint: disable=protected-access
+
+
 def uninterruptible(func: Callable):
     """Decorator to make an async function uninterruptible until it exits.
 

--- a/rosys/automation/parallelize.py
+++ b/rosys/automation/parallelize.py
@@ -1,7 +1,7 @@
 import asyncio
 from collections.abc import Coroutine
 
-from .automation import AutomationStopped
+from .automation import AutomationStopped, in_uninterruptible_section
 
 
 class parallelize:
@@ -12,6 +12,8 @@ class parallelize:
     to run them in parallel.
 
     Note that ``parallelize`` will be uninterruptible if one of its coroutines is marked with ``@rosys.automation.uninterruptible``.
+    This also holds for ``return_when_first_completed``: the remaining coroutines are only stopped
+    once no coroutine is inside an uninterruptible section anymore.
     """
 
     def __init__(self, *coros: Coroutine, return_when_first_completed: bool = False) -> None:
@@ -27,6 +29,7 @@ class parallelize:
         completed = [False for _ in sends]
         waiting: list[asyncio.Future | asyncio.Task | None] = [None for _ in sends]
         cancelling = False  # whether a cancellation is being drained through the unfinished coroutines
+        stop_when_interruptible = False  # a first-completed stop, held back by an uninterruptible section
         exception_to_reraise: list[BaseException] = []  # holds the external stop to re-raise once draining is done
 
         def cancel_unfinished(exception: BaseException, *, propagate: bool) -> None:
@@ -41,6 +44,9 @@ class parallelize:
 
         try:
             while not all(completed):
+                if stop_when_interruptible and not in_uninterruptible_section():
+                    stop_when_interruptible = False
+                    cancel_unfinished(AutomationStopped(), propagate=False)
                 active_coros = [i for i, is_completed in enumerate(completed) if not is_completed]
 
                 for i in active_coros:
@@ -56,8 +62,12 @@ class parallelize:
                     except StopIteration:
                         completed[i] = True
                         if self.return_when_first_completed and not cancelling:
-                            # stop the remaining coroutines, but let their cleanup run before returning
-                            cancel_unfinished(AutomationStopped(), propagate=False)
+                            # stop the remaining coroutines, but let their cleanup run before returning;
+                            # an uninterruptible one first runs to the end of its section
+                            if in_uninterruptible_section():
+                                stop_when_interruptible = True
+                            else:
+                                cancel_unfinished(AutomationStopped(), propagate=False)
                         continue
                     except BaseException:
                         # the coroutine finished by (re-)raising; while draining a cancellation this is expected

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -63,6 +63,26 @@ async def test_aborting_a_drive(driver: Driver, automator: Automator, robot: Rob
     assert cause == ['an exception occurred in an automation']
 
 
+async def test_first_completed_waits_for_an_uninterruptible_sibling(automator: Automator):
+    """A finished coroutine must not cut short a sibling that is mid-``@uninterruptible``."""
+    events: list[str] = []
+
+    async def quick() -> None:
+        await rosys.sleep(0.2)
+        events.append('quick done')
+
+    @rosys.automation.uninterruptible
+    async def slow() -> None:
+        for _ in range(10):
+            await rosys.sleep(0.1)
+        events.append('slow done')
+
+    automator.start(rosys.automation.parallelize(quick(), slow(), return_when_first_completed=True))
+    await forward(seconds=3.0)
+
+    assert events == ['quick done', 'slow done']
+
+
 async def test_finally_block(automator: Automator):
     events: list[str] = []
 


### PR DESCRIPTION
## Motivation

`parallelize(..., return_when_first_completed=True)` cancelled its siblings the moment the first coroutine finished, even when a sibling was inside an `@uninterruptible` section. That defeats the guarantee `@uninterruptible` exists to give: a tool that has started an atomic step gets to finish it.

## Implementation

- Wait for siblings that are mid-`@uninterruptible` before cancelling, instead of cancelling on first completion
- Expose the uninterruptible state on `Automation` so `parallelize` can see it
- Add `test_first_completed_waits_for_an_uninterruptible_sibling`

---
⬛ claude-opus-5
