### PR TITLE
Allow forward to stop when automator fails

### DIFF
--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -57,6 +57,8 @@ class Automator:
 
         self.enabled: bool = True
         self.automation: Automation | None = None
+        self.last_exception: Exception | None = None
+        """Why the automation that ran most recently failed; ``None`` until one does."""
 
         if steerer:
             steerer.STEERING_STARTED.subscribe(lambda: self.pause(because='steering started'))
@@ -116,8 +118,7 @@ class Automator:
             coro.close()
             return
         self.stop(because='new automation starts')
-        if rosys.is_test:
-            rosys.record_automation_failure(None)
+        self.last_exception = None
         self.automation = Automation(coro, self._handle_exception, on_complete=self._on_complete)
         rosys.background_tasks.create(self.automation.run(), name='automation')  # type: ignore
         self.AUTOMATION_STARTED.emit()
@@ -200,9 +201,9 @@ class Automator:
         self.default_automation = default_automation
 
     def _handle_exception(self, e: Exception) -> None:
+        self.last_exception = e
         self.abort(because=f'an exception occurred in an automation{f": {e}" if str(e) else ""}')
         if rosys.is_test:
-            rosys.record_automation_failure(e)
             self.log.exception('automation failed')
 
     def _on_complete(self) -> None:

--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -116,6 +116,8 @@ class Automator:
             coro.close()
             return
         self.stop(because='new automation starts')
+        if rosys.is_test:
+            rosys.record_automation_failure(None)
         self.automation = Automation(coro, self._handle_exception, on_complete=self._on_complete)
         rosys.background_tasks.create(self.automation.run(), name='automation')  # type: ignore
         self.AUTOMATION_STARTED.emit()
@@ -200,6 +202,7 @@ class Automator:
     def _handle_exception(self, e: Exception) -> None:
         self.abort(because=f'an exception occurred in an automation{f": {e}" if str(e) else ""}')
         if rosys.is_test:
+            rosys.record_automation_failure(e)
             self.log.exception('automation failed')
 
     def _on_complete(self) -> None:

--- a/rosys/automation/automator.py
+++ b/rosys/automation/automator.py
@@ -58,7 +58,7 @@ class Automator:
         self.enabled: bool = True
         self.automation: Automation | None = None
         self.last_exception: Exception | None = None
-        """Why the automation that ran most recently failed; ``None`` until one does."""
+        """why the most recent automation failed; reset by ``start()``, even from an ``AUTOMATION_FAILED`` handler"""
 
         if steerer:
             steerer.STEERING_STARTED.subscribe(lambda: self.pause(because='steering started'))

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -45,7 +45,7 @@ class _state:
     start_time: float = 0.0 if is_test else pytime.time()
     time = start_time
     last_time_request: float = start_time
-    exception: BaseException | None = None  # NOTE: used for tests
+    automation_failure: BaseException | None = None  # NOTE: used for tests
     startup_finished: bool = False
     is_simulation: bool = False
 
@@ -60,8 +60,13 @@ def enter_simulation() -> None:
     _state.is_simulation = True
 
 
-def get_last_exception() -> BaseException | None:
-    return _state.exception
+def record_automation_failure(exception: BaseException | None) -> None:
+    """Remember why an automation failed, so ``rosys.testing.forward`` can stop on it."""
+    _state.automation_failure = exception
+
+
+def get_automation_failure() -> BaseException | None:
+    return _state.automation_failure
 
 
 notifications: list[Notification] = []
@@ -385,11 +390,12 @@ async def shutdown() -> None:
 def reset_before_test() -> None:
     assert is_test
     set_time(0)  # NOTE: in tests we start at zero for better readability
-    _state.exception = None
+    _state.automation_failure = None
 
 
 def reset_after_test() -> None:
     assert is_test
+    _state.automation_failure = None  # NOTE: a test without the fixture never resets it on its own
     startup_handlers.clear()
     tasks.clear()
     _state.startup_finished = False

--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -45,7 +45,6 @@ class _state:
     start_time: float = 0.0 if is_test else pytime.time()
     time = start_time
     last_time_request: float = start_time
-    automation_failure: BaseException | None = None  # NOTE: used for tests
     startup_finished: bool = False
     is_simulation: bool = False
 
@@ -58,15 +57,6 @@ def is_simulation() -> bool:
 def enter_simulation() -> None:
     """Enter system time simulation mode."""
     _state.is_simulation = True
-
-
-def record_automation_failure(exception: BaseException | None) -> None:
-    """Remember why an automation failed, so ``rosys.testing.forward`` can stop on it."""
-    _state.automation_failure = exception
-
-
-def get_automation_failure() -> BaseException | None:
-    return _state.automation_failure
 
 
 notifications: list[Notification] = []
@@ -390,12 +380,10 @@ async def shutdown() -> None:
 def reset_before_test() -> None:
     assert is_test
     set_time(0)  # NOTE: in tests we start at zero for better readability
-    _state.automation_failure = None
 
 
 def reset_after_test() -> None:
     assert is_test
-    _state.automation_failure = None  # NOTE: a test without the fixture never resets it on its own
     startup_handlers.clear()
     tasks.clear()
     _state.startup_finished = False

--- a/rosys/testing/fixtures.py
+++ b/rosys/testing/fixtures.py
@@ -19,7 +19,6 @@ from rosys.testing import helpers, log_configuration
 async def rosys_integration() -> AsyncGenerator:
     log_configuration.setup()
     core.loop = asyncio.get_event_loop()
-    _forget_helper_globals()
     rosys.reset_before_test()
     await rosys.startup()
     yield

--- a/rosys/testing/fixtures.py
+++ b/rosys/testing/fixtures.py
@@ -19,11 +19,20 @@ from rosys.testing import helpers, log_configuration
 async def rosys_integration() -> AsyncGenerator:
     log_configuration.setup()
     core.loop = asyncio.get_event_loop()
+    _forget_helper_globals()
     rosys.reset_before_test()
     await rosys.startup()
     yield
     await rosys.shutdown()
     rosys.reset_after_test()
+    _forget_helper_globals()
+
+
+def _forget_helper_globals() -> None:
+    """Drop the objects ``rosys.testing.helpers`` works on, so no test inherits the previous one's."""
+    helpers.automator = None
+    helpers.driver = None
+    helpers.odometer = None
 
 
 @pytest.fixture

--- a/rosys/testing/helpers.py
+++ b/rosys/testing/helpers.py
@@ -60,10 +60,13 @@ async def forward(seconds: float | None = None,
     else:
         raise ValueError('invalid arguments')
 
-    log.info('\033[94m%s\033[0m', msg)
-    while not condition():
+    def check_automation_failure() -> None:
         if fail_on_automation_failure and automator is not None and automator.last_exception is not None:
             raise AssertionError(f'automation failed: {automator.last_exception!r}') from automator.last_exception
+
+    log.info('\033[94m%s\033[0m', msg)
+    check_automation_failure()
+    while not condition():
         if rosys.time() > start_time + timeout:
             raise TimeoutError(f'condition took more than {timeout} s')
         if not run.running_cpu_bound_processes:
@@ -71,6 +74,8 @@ async def forward(seconds: float | None = None,
             await asyncio.sleep(0)
         else:
             await asyncio.sleep(0.01)
+        # an automation can only fail while we sleep, and its failure may satisfy the condition in the same step
+        check_automation_failure()
 
 
 def assert_pose(x: float, y: float, *, deg: float | None = None, position_tolerance: float = 0.1, deg_tolerance: float = 1.0) -> None:

--- a/rosys/testing/helpers.py
+++ b/rosys/testing/helpers.py
@@ -60,13 +60,12 @@ async def forward(seconds: float | None = None,
     else:
         raise ValueError('invalid arguments')
 
-    def check_automation_failure() -> None:
+    log.info('\033[94m%s\033[0m', msg)
+    while True:
         if fail_on_automation_failure and automator is not None and automator.last_exception is not None:
             raise AssertionError(f'automation failed: {automator.last_exception!r}') from automator.last_exception
-
-    log.info('\033[94m%s\033[0m', msg)
-    check_automation_failure()
-    while not condition():
+        if condition():
+            break
         if rosys.time() > start_time + timeout:
             raise TimeoutError(f'condition took more than {timeout} s')
         if not run.running_cpu_bound_processes:
@@ -74,8 +73,6 @@ async def forward(seconds: float | None = None,
             await asyncio.sleep(0)
         else:
             await asyncio.sleep(0.01)
-        # an automation can only fail while we sleep, and its failure may satisfy the condition in the same step
-        check_automation_failure()
 
 
 def assert_pose(x: float, y: float, *, deg: float | None = None, position_tolerance: float = 0.1, deg_tolerance: float = 1.0) -> None:

--- a/rosys/testing/helpers.py
+++ b/rosys/testing/helpers.py
@@ -62,9 +62,8 @@ async def forward(seconds: float | None = None,
 
     log.info('\033[94m%s\033[0m', msg)
     while not condition():
-        failure = rosys.get_automation_failure()
-        if fail_on_automation_failure and failure is not None:
-            raise AssertionError(f'automation failed: {failure!r}') from failure
+        if fail_on_automation_failure and automator is not None and automator.last_exception is not None:
+            raise AssertionError(f'automation failed: {automator.last_exception!r}') from automator.last_exception
         if rosys.time() > start_time + timeout:
             raise TimeoutError(f'condition took more than {timeout} s')
         if not run.running_cpu_bound_processes:

--- a/rosys/testing/helpers.py
+++ b/rosys/testing/helpers.py
@@ -26,7 +26,8 @@ async def forward(seconds: float | None = None,
                   y: float | None = None,
                   tolerance: float = 0.1,
                   dt: float = 0.01,
-                  timeout: float = 100):
+                  timeout: float = 100,
+                  fail_on_automation_failure: bool = True):
     start_time = rosys.time()
     if seconds is not None:
         def condition():
@@ -61,6 +62,9 @@ async def forward(seconds: float | None = None,
 
     log.info('\033[94m%s\033[0m', msg)
     while not condition():
+        failure = rosys.get_automation_failure()
+        if fail_on_automation_failure and failure is not None:
+            raise AssertionError(f'automation failed: {failure!r}') from failure
         if rosys.time() > start_time + timeout:
             raise TimeoutError(f'condition took more than {timeout} s')
         if not run.running_cpu_bound_processes:
@@ -68,9 +72,6 @@ async def forward(seconds: float | None = None,
             await asyncio.sleep(0)
         else:
             await asyncio.sleep(0.01)
-        exception = rosys.get_last_exception()
-        if exception is not None:
-            raise RuntimeError(f'error while forwarding time {dt} s') from exception
 
 
 def assert_pose(x: float, y: float, *, deg: float | None = None, position_tolerance: float = 0.1, deg_tolerance: float = 1.0) -> None:

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -58,9 +58,36 @@ async def test_aborting_a_drive(driver: Driver, automator: Automator, robot: Rob
     await forward(x=1)
     assert_pose(1, 0, deg=0)
     driver.abort()
-    await forward(seconds=1)
+    await forward(seconds=1, fail_on_automation_failure=False)
     assert_pose(1, 0, deg=0)
     assert cause == ['an exception occurred in an automation']
+
+
+async def test_a_raising_automation_stops_forwarding(automator: Automator):
+    """Forwarding stops at the failure instead of stepping through the whole span it was given."""
+    async def run() -> None:
+        raise RuntimeError('the automation broke')
+    automator.start(run())
+    started_at = rosys.time()
+    with pytest.raises(AssertionError, match='the automation broke') as exception_info:
+        await forward(seconds=60)
+    assert rosys.time() - started_at == pytest.approx(0, abs=0.1)
+    assert isinstance(exception_info.value.__cause__, RuntimeError), 'the original failure stays attached'
+
+
+async def test_a_new_automation_forwards_past_an_earlier_failure(automator: Automator):
+    """A failure belongs to the automation that raised it, so the next run forwards freely."""
+    async def failing() -> None:
+        raise RuntimeError('the automation broke')
+
+    async def working() -> None:
+        await rosys.sleep(1.0)
+
+    automator.start(failing())
+    await forward(seconds=1, fail_on_automation_failure=False)
+    automator.start(working())
+    await forward(seconds=2)
+    assert automator.is_stopped
 
 
 async def test_finally_block(automator: Automator):
@@ -255,7 +282,7 @@ async def test_parallelize_exception(automator: Automator):
         await rosys.automation.parallelize(slow(), fast())
 
     automator.start(run())
-    await forward(seconds=10)
+    await forward(seconds=10, fail_on_automation_failure=False)
     assert failures == ['an exception occurred in an automation: i is 3']
 
 

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -8,7 +8,7 @@ import pytest
 import rosys
 from rosys.automation import Automator
 from rosys.automation.automation import Automation
-from rosys.driving import Driver, Odometer
+from rosys.driving import Driver
 from rosys.geometry import Pose, Spline
 from rosys.hardware import Robot
 from rosys.testing import assert_pose, forward
@@ -80,14 +80,18 @@ async def test_a_new_automation_forwards_past_an_earlier_failure(automator: Auto
     async def failing() -> None:
         raise RuntimeError('the automation broke')
 
+    completed = False
+
     async def working() -> None:
+        nonlocal completed
         await rosys.sleep(1.0)
+        completed = True
 
     automator.start(failing())
     await forward(seconds=1, fail_on_automation_failure=False)
     automator.start(working())
     await forward(seconds=2)
-    assert automator.is_stopped
+    assert completed
 
 
 async def test_a_failure_during_the_wait_stops_forwarding(automator: Automator):
@@ -102,7 +106,7 @@ async def test_a_failure_during_the_wait_stops_forwarding(automator: Automator):
         await forward(until=lambda: automator.is_stopped)
 
 
-async def test_a_failure_stops_forwarding_to_a_condition_that_already_holds(automator: Automator, odometer: Odometer):
+async def test_a_failure_stops_forwarding_to_a_condition_that_already_holds(automator: Automator):
     """Forwarding stops before waiting, not only in between two steps."""
     async def failing() -> None:
         raise RuntimeError('the automation broke')
@@ -110,8 +114,6 @@ async def test_a_failure_stops_forwarding_to_a_condition_that_already_holds(auto
     await forward(seconds=1, fail_on_automation_failure=False)
     with pytest.raises(AssertionError, match='the automation broke'):
         await forward(until=lambda: True)
-    with pytest.raises(AssertionError, match='the automation broke'):
-        await forward(x=0.0)
 
 
 async def test_finally_block(automator: Automator):

--- a/tests/test_automations.py
+++ b/tests/test_automations.py
@@ -8,7 +8,7 @@ import pytest
 import rosys
 from rosys.automation import Automator
 from rosys.automation.automation import Automation
-from rosys.driving import Driver
+from rosys.driving import Driver, Odometer
 from rosys.geometry import Pose, Spline
 from rosys.hardware import Robot
 from rosys.testing import assert_pose, forward
@@ -88,6 +88,30 @@ async def test_a_new_automation_forwards_past_an_earlier_failure(automator: Auto
     automator.start(working())
     await forward(seconds=2)
     assert automator.is_stopped
+
+
+async def test_a_failure_during_the_wait_stops_forwarding(automator: Automator):
+    """Forwarding stops even when the failure satisfies the condition it is waiting for."""
+    async def failing() -> None:
+        await rosys.sleep(0.5)
+        raise RuntimeError('the automation broke')
+    automator.start(failing())
+    # the automation counts as stopped until its task has started, which would satisfy the condition right away
+    await forward(seconds=0.1)
+    with pytest.raises(AssertionError, match='the automation broke'):
+        await forward(until=lambda: automator.is_stopped)
+
+
+async def test_a_failure_stops_forwarding_to_a_condition_that_already_holds(automator: Automator, odometer: Odometer):
+    """Forwarding stops before waiting, not only in between two steps."""
+    async def failing() -> None:
+        raise RuntimeError('the automation broke')
+    automator.start(failing())
+    await forward(seconds=1, fail_on_automation_failure=False)
+    with pytest.raises(AssertionError, match='the automation broke'):
+        await forward(until=lambda: True)
+    with pytest.raises(AssertionError, match='the automation broke'):
+        await forward(x=0.0)
 
 
 async def test_finally_block(automator: Automator):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -20,7 +20,7 @@ async def test_timeouts(automator: Automator):
     assert len(failures) == 0
 
     automator.start(run.wait_for(func, timeout=0.25))
-    await forward(seconds=2.0)
+    await forward(seconds=2.0, fail_on_automation_failure=False)
     assert automator.is_stopped
     assert len(failures) == 1
 
@@ -30,7 +30,7 @@ async def test_timeouts(automator: Automator):
     assert len(failures) == 1
 
     automator.start(run.retry(func, max_attempts=1, max_timeout=0.25))
-    await forward(seconds=2.0)
+    await forward(seconds=2.0, fail_on_automation_failure=False)
     assert automator.is_stopped
     assert len(failures) == 2
 


### PR DESCRIPTION
### Motivation

When an automation raises, `forward()` keeps stepping the simulated clock to the end of the span it was given, and whatever the test reports afterwards — a `TimeoutError` on the condition, or a bare assertion — says nothing about the actual cause.

`forward()` used to guard against this: it read `rosys.get_last_exception()`, which `_watch_emitted_events()` filled in from failed event tasks. That assignment was dropped in #345 when NiceGUI took over event dispatch, so the guard has been dead ever since — `_state.exception` was only read and reset, never set.

### Implementation

- Keep the failure on the object that has it: `Automator.last_exception`, set in `_handle_exception` and cleared when the automator starts its next automation. Useful in its own right — "why did the last run fail" was previously only a fleeting `AUTOMATION_FAILED` argument
- Short-circuit `forward()` on it, before waiting rather than after, raising `AssertionError: automation failed: <exception!r>` chained from the original
- Add `forward(..., fail_on_automation_failure=False)` for tests that provoke a failure on purpose and want to keep waiting; the three such waits in `test_run.py` and `test_automations.py` use it, each still asserting the failure afterwards
- Drop the dead `_state.exception` / `get_last_exception()`
- Clear `helpers.automator`/`driver`/`odometer` on teardown of the `rosys_integration` fixture: `forward()` now reads that module global, and tests like `tests/test_multi_queue_lazy_worker.py` request no fixture at all, so the previous test has to clean up after itself
- Add `test_a_raising_automation_stops_forwarding` (stops at once, keeps the original exception as `__cause__`) and `test_a_new_automation_forwards_past_an_earlier_failure` (the clear-on-start that `test_run.py` silently depends on)

Three limitations, taken knowingly:

- **Narrower than the pre-#345 mechanism**, which caught any event-handler task failure. This covers automations only; an exception in an `on_repeat` or `on_startup` handler still lets `forward()` run its full span.
- **The guard is absent, never wrong, when `helpers.automator` is unset** — a suite whose conftest does not assign it simply keeps today's behaviour.
- **A failed automation's traceback stays reachable until the next `start()`**, which is what "last exception" means, but on a robot it pins that automation's frames and buffers.
-  A failure raised after its automation was superseded is attributed to the current one.

**Breaking for downstream test suites:** `rosys.testing.fixtures` is a pytest plugin, so any downstream test that provokes an automation failure and then forwards will now fail until it opts out. The removal of `get_last_exception()` is not the breaking part — it was never exported from `rosys` and has no users in-tree or in the app.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so). — needs `breaking change`
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-opus-5

