### PR TITLE
Parse the Lizard project name and align version normalization

### DIFF
--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -19,6 +20,9 @@ class LizardFirmware:
     GITHUB_URL = 'https://api.github.com/repos/zauberzeug/lizard/releases'
     PATH = Path('~/.lizard').expanduser()
     PATH.mkdir(exist_ok=True)
+    VERSION_LINE_PATTERN = re.compile(r'version: (?:(?P<project>\S+) )?(?P<version>\S+)')
+    VERSION_PATTERN = re.compile(r'v?(\d+\.\d+\.\d+)')
+    APP_DESC_MAGIC = b'\x32\x54\xcd\xab'  # marks the esp_app_desc_t at offset 0x20 of an ESP32 app image
 
     def __init__(self, robot_brain: 'RobotBrain', *, supported_versions: str | None = None) -> None:
         """
@@ -34,8 +38,11 @@ class LizardFirmware:
         self.flash_params: list[str] = []
 
         self.core_version: str | None = None
+        self.core_project: str | None = None
         self.p0_version: str | None = None
+        self.p0_project: str | None = None
         self.local_version: str | None = None
+        self.local_project: str | None = None
         self.online_versions: dict[str, str] = {}
         self.selected_online_version: str | None = None
 
@@ -44,6 +51,21 @@ class LizardFirmware:
 
         self._p0_flash_last_complete: float = 0.0
         self.robot_brain.FLASH_P0_COMPLETE.subscribe(lambda: setattr(self, '_p0_flash_last_complete', rosys.time()))
+
+    @property
+    def core_description(self) -> str:
+        """Project name and version of the firmware on the Core, e.g. ``'lizard-zz 0.0.2'``."""
+        return ' '.join(filter(None, (self.core_project, self.core_version))) or '?'
+
+    @property
+    def p0_description(self) -> str:
+        """Project name and version of the firmware on the P0."""
+        return ' '.join(filter(None, (self.p0_project, self.p0_version))) or '?'
+
+    @property
+    def local_description(self) -> str:
+        """Project name and version of the downloaded firmware binary."""
+        return ' '.join(filter(None, (self.local_project, self.local_version))) or '?'
 
     @property
     def checksums_match(self) -> bool | None:
@@ -91,10 +113,14 @@ class LizardFirmware:
                 break
 
     def read_local_version(self) -> None:
-        path = self.PATH / 'build' / 'lizard.bin'
+        path = next((self.PATH / 'build').glob('*.bin'), self.PATH / 'build' / 'lizard.bin')
         with path.open('rb') as f:
-            head = f.read(150).decode('utf-8', 'backslashreplace')
-        self.local_version = head.replace('\x00', '').split('lizard')[0].split('v')[-1]
+            header = f.read(112)  # image header plus esp_app_desc_t up to the project name
+        if header[32:36] != self.APP_DESC_MAGIC:
+            self.log.error('%s is not an ESP32 app image', path)
+            return
+        self.local_version = self._parse_version(header[48:80].split(b'\x00', 1)[0].decode('utf-8', 'replace'))
+        self.local_project = header[80:112].split(b'\x00', 1)[0].decode('utf-8', 'replace') or None
 
     async def read_core_version(self) -> None:
         if not self.robot_brain.is_ready:
@@ -103,7 +129,7 @@ class LizardFirmware:
         deadline = rosys.time() + 5.0
         while rosys.time() < deadline:
             if response := await self.robot_brain.send_and_await('core.version()', 'version:', timeout=1):
-                self.core_version = response.split()[-1].split('-')[0][1:]
+                self.core_project, self.core_version = self._parse_version_line(response)
                 self._refuse_version(self.core_version, 'Core')
                 return
         self.log.error('Could not read Lizard version from Core')
@@ -115,10 +141,29 @@ class LizardFirmware:
         deadline = rosys.time() + 5.0
         while rosys.time() < deadline:
             if response := await self.robot_brain.send_and_await('p0.version()', 'p0:', timeout=1):
-                self.p0_version = response.split()[-1].split('-')[0][1:]
+                self.p0_project, self.p0_version = self._parse_version_line(response)
                 self._refuse_version(self.p0_version, 'P0')
                 return
         self.log.error('Could not read Lizard version from P0')
+
+    @classmethod
+    def _parse_version_line(cls, response: str) -> tuple[str | None, str | None]:
+        """Parse a ``version: [<project>] <version>`` response into project name and version.
+
+        Firmware built before the project name was reported yields ``'lizard'``,
+        an unparsable response ``(None, None)``.
+        """
+        match = cls.VERSION_LINE_PATTERN.search(response)
+        version = cls._parse_version(match.group('version')) if match else None
+        if match is None or version is None:
+            return None, None
+        return match.group('project') or 'lizard', version
+
+    @classmethod
+    def _parse_version(cls, token: str) -> str | None:
+        """Reduce a version token like ``'v0.13.0-3-g248f4ed-dirty'`` to its release version, e.g. ``'0.13.0'``."""
+        match = cls.VERSION_PATTERN.match(token)
+        return match.group(1) if match else None
 
     def read_local_checksum(self) -> None:
         checksum = sum(self.robot_brain.lizard_code.encode()) % 0x10000

--- a/rosys/hardware/robot_brain.py
+++ b/rosys/hardware/robot_brain.py
@@ -112,23 +112,23 @@ class RobotBrain:
             online_update_button = ui.button(on_click=online_update).props('icon=file_download flat round dense') \
                 .tooltip('Download and flash online version to Core and P0 microcontrollers')
         with ui.row().classes('items-center'):
-            ui.label().bind_text_from(self.lizard_firmware, 'local_version', backward=lambda x: f'Local: {x or "?"}')
+            ui.label().bind_text_from(self.lizard_firmware, 'local_description', backward=lambda x: f'Local: {x}')
             local_update_button = ui.button(on_click=local_update).props('icon=file_download flat round dense') \
                 .tooltip('Flash local version to Core and P0 microcontrollers')
         with ui.row().classes('items-center'):
-            ui.label().bind_text_from(self.lizard_firmware, 'core_version', backward=lambda x: f'Core: {x or "?"}')
+            ui.label().bind_text_from(self.lizard_firmware, 'core_description', backward=lambda x: f'Core: {x}')
             configure_button = ui.button(on_click=self.configure).props('icon=build flat round dense') \
                 .tooltip('Configure microcontrollers')
         with ui.row().classes('items-center'):
-            ui.label().bind_text_from(self.lizard_firmware, 'p0_version', backward=lambda x: f'P0: {x or "?"}')
+            ui.label().bind_text_from(self.lizard_firmware, 'p0_description', backward=lambda x: f'P0: {x}')
 
         def update_visibility() -> None:
             online_update_button.visible = \
                 self.lizard_firmware.selected_online_version != self.lizard_firmware.core_version or \
                 self.lizard_firmware.selected_online_version != self.lizard_firmware.p0_version
             local_update_button.visible = \
-                self.lizard_firmware.local_version != self.lizard_firmware.core_version or \
-                self.lizard_firmware.local_version != self.lizard_firmware.p0_version
+                self.lizard_firmware.local_description != self.lizard_firmware.core_description or \
+                self.lizard_firmware.local_description != self.lizard_firmware.p0_description
             configure_button.visible = self.lizard_firmware.checksums_match is False
         ui.timer(1.0, update_visibility)
 

--- a/tests/test_lizard_firmware.py
+++ b/tests/test_lizard_firmware.py
@@ -12,6 +12,15 @@ from rosys.hardware.lizard_firmware import LizardFirmware
 from rosys.testing import forward
 
 
+def app_image(version: str, project: str = 'lizard') -> bytes:
+    """A minimal ESP32 app image header with an esp_app_desc_t at offset 0x20."""
+    header = bytearray(112)
+    header[32:36] = LizardFirmware.APP_DESC_MAGIC
+    header[48:80] = version.encode().ljust(32, b'\x00')
+    header[80:112] = project.encode().ljust(32, b'\x00')
+    return bytes(header)
+
+
 class VersionCommunicationSimulation(CommunicationSimulation):
 
     def __init__(self) -> None:
@@ -117,7 +126,7 @@ async def test_flash_core_reads_local_version(lizard_firmware: LizardFirmware, n
     """Flashing the core reads the local version by itself if it has not been read yet."""
     monkeypatch.setattr(LizardFirmware, 'PATH', tmp_path)
     (tmp_path / 'build').mkdir()
-    (tmp_path / 'build' / 'lizard.bin').write_bytes(b'v0.13.0\x00lizard')
+    (tmp_path / 'build' / 'lizard.bin').write_bytes(app_image('v0.13.0'))
     await lizard_firmware.flash_core()
     assert lizard_firmware.local_version == '0.13.0'
     assert not any('version is unknown' in message for message in notifications)
@@ -139,3 +148,44 @@ async def test_version_warning(lizard_firmware: LizardFirmware, notifications: l
     assert task.done()
     assert getattr(lizard_firmware, f'{target}_version') == version.removeprefix('v')
     assert any('not supported' in message for message in notifications) == expect_warning
+
+
+@pytest.mark.parametrize('target', ['core', 'p0'])
+@pytest.mark.parametrize('reported, project, version', [
+    ('v0.13.0', 'lizard', '0.13.0'),                              # release build before project names
+    ('v0.13.0-3-g248f4ed-dirty', 'lizard', '0.13.0'),             # dev build before project names
+    ('lizard v0.13.0', 'lizard', '0.13.0'),                       # release build with project name
+    ('lizard-zz v0.0.2', 'lizard-zz', '0.0.2'),                   # integrator release build
+    ('lizard-zz v0.0.1-6-g69dfddf-dirty', 'lizard-zz', '0.0.1'),  # integrator dev build
+    ('unknown', None, None),                                      # built without git
+])
+async def test_read_version(lizard_firmware: LizardFirmware,
+                            target: str, reported: str, project: str | None, version: str | None) -> None:
+    """Version responses with and without a project name are parsed into project and release version."""
+    communication = lizard_firmware.robot_brain.communication
+    assert isinstance(communication, VersionCommunicationSimulation)
+    setattr(communication, f'{target}_version', reported)
+    await connect(communication)
+    read_version = getattr(lizard_firmware, f'read_{target}_version')
+    task = background_tasks.create(read_version(), name=f'read {target} version')
+    await forward(seconds=3.0)
+    assert task.done()
+    assert getattr(lizard_firmware, f'{target}_version') == version
+    assert getattr(lizard_firmware, f'{target}_project') == project
+
+
+@pytest.mark.parametrize('filename, image, project, version', [
+    ('lizard.bin', app_image('v0.13.0'), 'lizard', '0.13.0'),
+    ('lizard-zz.bin', app_image('v0.0.1-6-g69dfddf', 'lizard-zz'), 'lizard-zz', '0.0.1'),
+    ('lizard.bin', b'not an app image', None, None),
+])
+async def test_read_local_version(lizard_firmware: LizardFirmware, monkeypatch: pytest.MonkeyPatch,
+                                  tmp_path: Path, filename: str, image: bytes,
+                                  project: str | None, version: str | None) -> None:
+    """The local project and version are read from the esp_app_desc_t header, whatever the binary is called."""
+    monkeypatch.setattr(LizardFirmware, 'PATH', tmp_path)
+    (tmp_path / 'build').mkdir()
+    (tmp_path / 'build' / filename).write_bytes(image)
+    lizard_firmware.read_local_version()
+    assert lizard_firmware.local_version == version
+    assert lizard_firmware.local_project == project


### PR DESCRIPTION
### Motivation

zauberzeug/lizard#268 reports the firmware's project name in front of the version (`version: lizard-zz v0.0.2`), so a robot can tell integrator firmware like lizard-zz from public Lizard. The current parsers predate this. They also normalize inconsistently: `read_core_version` cuts the response at the first `-` (a dev build becomes `0.13.0`), while `read_local_version` string-splits the raw bin header and keeps the full `git describe` suffix — so `Local:` and `Core:` disagree on every dev build and the local-flash button never disappears.

### Implementation

- One regex-based parser extracts an optional project name and the release version from Core and P0 responses; firmware that does not report a project name yet counts as `lizard`.
- `read_local_version` reads the `esp_app_desc_t` structure at its fixed image offset (magic-word checked) instead of string splitting, yields the same normalized version plus the project name, and finds the binary by suffix (`build/*.bin`) because integrator binaries are named after their project (e.g. `lizard-zz.bin`).
- New attributes `core_project`, `p0_project`, `local_project` and `core_description`/`p0_description`/`local_description` properties; the developer UI shows e.g. `Core: lizard-zz 0.0.2` and compares project plus version for the local-update button.
- All versions now run through the same normalization, which fixes the permanent Local/Core mismatch on dev builds.

Parse results (firmware strings measured on hardware in zauberzeug/lizard-zz#15):

| Firmware reports | project | version | previous parser |
| --- | --- | --- | --- |
| `version: v0.13.0` | `lizard` | `0.13.0` | `0.13.0` |
| `version: v0.13.0-3-g248f4ed-dirty` | `lizard` | `0.13.0` | `0.13.0` |
| `version: lizard v0.14.0` | `lizard` | `0.14.0` | `0.14.0` |
| `version: lizard-zz v0.0.2` | `lizard-zz` | `0.0.2` | `0.0.2` |
| `version: lizard-zz v0.0.1-6-g69dfddf-dirty` | `lizard-zz` | `0.0.1` | `0.0.1` |
| `version: unknown` | – | – | `nknown` |

Known limitation, unchanged by this PR: the online version list points at `zauberzeug/lizard`, so `selected_online_version` can never match on a lizard-zz robot — worth a separate issue.

### Progress

- [x] The implementation is complete.
- [x] Tests adapted and extended (parametrized parsing tests for old/new formats, dev builds and unparsable responses; local header parsing including a renamed binary); `tests/test_lizard_firmware.py` passes.
- [x] Tested on hardware.

[※](https://zauberzeug.github.io/colophon/#m=claude-fable-5&t=Parser%20design%2C%20implementation%20and%20wording%20by%20the%20model%3B%20requirements%20from%20the%20hardware%20measurements%20and%20discussion%20on%20lizard-zz%2315.&a=claude-code "claude-fable-5: Parser design, implementation and wording by the model; requirements from the hardware measurements and discussion on lizard-zz#15.")
