### PR TITLE
Use "available" instead of "free" memory to decide when to collect garbage

### DIFF
--- a/rosys/rosys.py
+++ b/rosys/rosys.py
@@ -351,7 +351,7 @@ async def startup() -> None:
 
 
 async def _garbage_collection() -> None:
-    if psutil.virtual_memory().free < config.garbage_collection_mbyte_limit * 1_000_000:
+    if psutil.virtual_memory().available < config.garbage_collection_mbyte_limit * 1_000_000:
         log.warning('less than %s mb of memory remaining -> start garbage collection',
                     config.garbage_collection_mbyte_limit)
         gc.collect()


### PR DESCRIPTION
### Motivation

RoSys disables Python's automatic garbage collection and instead checks every 60 seconds whether the machine has less than 300 MB of memory left, using `psutil.virtual_memory().free`.
But "free" counts only completely unused RAM, and operating systems deliberately fill unused RAM with file caches.
On macOS "free" is therefore almost always low (e.g. 420 MB "free" vs. 11 GB "available" on a 34 GB machine), so every RoSys app logs

```
less than 300 mb of memory remaining -> start garbage collection
finished garbage collection
```

about once a minute — which looks like a memory leak but is not one.
Linux behaves the same way, just less aggressively: on a robot that has been logging and recording for days, the file cache is warm and "free" is far below what is actually usable.

### Implementation

The check now uses `psutil.virtual_memory().available` instead of `.free` — the memory a process can actually allocate without swapping, including caches the OS would give up on demand.

- **Better:** the warning only fires when the system is actually close to running out of memory, instead of permanently on macOS and on any Linux machine with a warm file cache.
- **Trade-off:** garbage collection runs later than before, and "available" is an OS estimate that can be too optimistic — so a real leak grows further before the first warning appears.

### ⚠️ Follow-up

In a Docker container with a memory limit this check is blind — before and after this PR: psutil reads `/proc/meminfo`, which shows the *host's* memory, not the container's cgroup limit.
On a big host the check never fires, and since automatic garbage collection is disabled, cyclic garbage accumulates until the kernel OOM-kills the container.
(With `.free` the constant false alarms accidentally collected garbage anyway; this PR removes that accident.)
Possible solution: read the cgroup files when a limit is set — `/sys/fs/cgroup/memory.max` and `memory.current` (v2) or `memory.limit_in_bytes`/`memory.usage_in_bytes` (v1) — and fall back to psutil otherwise.
Workaround until then: `garbage_collection_mbyte_limit = 0` plus `gc.enable()`, which triggers on allocation counts and works correctly in containers.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
