### PR TITLE
Fix UsbCamera never switching to MJPEG due to dead format detection

### DIFF
--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -61,6 +61,9 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         self.device = device
         logging.info('Connecting camera %s: succeeded', self.id)
 
+        await device.load_value_ranges()
+        device.set_video_format()
+
         await self._apply_all_parameters()
 
     async def disconnect(self) -> None:

--- a/rosys/vision/usb_camera/usb_device.py
+++ b/rosys/vision/usb_camera/usb_device.py
@@ -120,7 +120,7 @@ class UsbDevice:
         else:
             self._has_manual_exposure = False
         output = await self.run_v4l('--list-formats')
-        matches = re.finditer(r"$.*'(.*)'.*", output)
+        matches = re.finditer(r"\[\d+\]:\s*'([^']*)'", output)
         for m in matches:
             self._video_formats.add(m.group(1))
 


### PR DESCRIPTION
### Motivation

`UsbCamera` never switches a camera to MJPEG because format detection is dead code. [JensOgorek diagnosed three independent causes](https://github.com/zauberzeug/rosys/issues/448) — all in `load_value_ranges()` and the connect path.

This PR fixes the format detection only. The companion JPEG decode overhead fix (#449) is in #455 which includes this fix plus the `io_bound` decode change.

### Implementation

1. **`load_value_ranges()` is never called.** It is the only method that fills `_video_formats`, and no code path invokes it.
2. **The format regex matches nothing.** `re.finditer(r"$.*'(.*)'.*", output)` starts with `$` (end-of-string anchor), so it yields zero matches on any input.
3. **`set_video_format()` runs before format detection.** It is called in `UsbDevice.__init__`, before any async format detection could have populated `_video_formats`.

**Changes:**

- **`usb_device.py`:** fix the regex to `r"\[\d+\]:\s*'([^']*)'"`, which correctly captures format FourCC codes from v4l2-ctl output.
- **`usb_camera.py`:** call `await device.load_value_ranges()` then `device.set_video_format()` in `connect()`, after device creation but before `_apply_all_parameters()`.

<details>
<summary>Raw device input — <code>v4l2-ctl -d 0 --list-formats</code> (USB3 HDMI capture card)</summary>

```
ioctl: VIDIOC_ENUM_FMT
	Type: Video Capture

	[0]: 'YUYV' (YUYV 4:2:2)
	[1]: 'MJPG' (Motion-JPEG, compressed)
```

Old regex: 0 matches. New regex: captures `'YUYV'` and `'MJPG'`.

</details>

<details>
<summary>Format switch test</summary>

```
=== YUYV (broken state) ===
Pixel Format: 'YUYV' (YUYV 4:2:2)
Streaming 3s: ~60.5 fps (USB 3.0)

=== MJPG (fixed state) ===
Pixel Format: 'MJPG' (Motion-JPEG, compressed)
Streaming 3s: ~59.9 fps (USB 3.0)
```

On USB 2.0, YUYV is bandwidth-limited to ~5 fps while MJPG delivers full frame rate.

</details>

<details>
<summary>TS2 confirmation (Jetson, feldfreund container)</summary>

Bug confirmed at `usb_device.py` line 123: `re.finditer(r"$.*'(.*)'.*", output)`.

</details>

Fixes #448.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

[※](https://zauberzeug.github.io/colophon/#m=qwen3.7-plus&t=Regex%20fix%20and%20connect-path%20reorder%20for%20rosys%23448%20from%20the%20model%3B%20device%20verification%20on%20.180%20HDMI%20capture%20card%20and%20TS2%20Jetson%20by%20the%20model%3B%20PR%20body%20by%20the%20model%20with%20operator%20review. "qwen3.7-plus: Regex fix and connect-path reorder for rosys#448 from the model; device verification on .180 HDMI capture card and TS2 Jetson by the model; PR body by the model with operator review.")