### PR TITLE
Count the bytes received from a camera's MJPEG stream

### DIFF
--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -41,6 +41,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
 
         self.mac = parts[0]
         self.device: MjpegDevice | None = None
+        self._transferred_bytes = 0  # bytes of devices this camera has already retired
 
         self._register_parameter('fps', self._get_fps, self._set_fps, default_value=fps)
         self._register_parameter('resolution', self._get_resolution, self._set_resolution, default_value=resolution)
@@ -59,6 +60,25 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
     def is_connected(self) -> bool:
         return (self.device is not None) and self.device.is_connected
 
+    @property
+    def transferred_bytes(self) -> int:
+        """Bytes read from this camera's MJPEG response bodies, counted before parsing and EXIF removal.
+
+        Monotonic across reconnects, so sampling it (e.g. with ``add_timer_topic``) and taking
+        differences measures the stream. Unlike summing ``Image.byte_size()``, which is the decoded
+        size, this counts what arrived — including frames that were skipped or failed to decode.
+        Response headers and any authentication round trip are not included, so it is a lower bound
+        on what the link carries. Only MJPEG cameras can report it; other backends receive already
+        decoded frames.
+        """
+        return self._transferred_bytes + (self.device.transferred_bytes if self.device is not None else 0)
+
+    def _retire_device(self) -> None:
+        """Drop the current device, keeping the bytes it counted."""
+        if self.device is not None:
+            self._transferred_bytes += self.device.transferred_bytes
+            self.device = None
+
     async def connect(self) -> None:
         if self.is_connected:
             return
@@ -67,6 +87,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
             self.log.error('No IP address provided')
             return
 
+        self._retire_device()
         try:
             self.device = MjpegDeviceFactory.create(self.mac, self.ip, index=self.index, username=self.username,
                                                     password=self.password, on_new_image_data=self._handle_new_image_data)
@@ -81,7 +102,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
             return
 
         self.device.shutdown()
-        self.device = None
+        self._retire_device()
 
     async def _handle_new_image_data(self, image_bytes: bytes, timestamp: float) -> None:
         image: Image | None = None

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -47,6 +47,8 @@ class MjpegDevice:
 
         self._on_new_image_data = on_new_image_data
         self._capture_task: Task | None = None
+        self.transferred_bytes = 0
+        """Bytes read from this device's MJPEG stream, counted before any parsing or EXIF removal."""
         self._username = username
         self._password = password
         url = mac_to_url(mac, ip, index=index)
@@ -88,6 +90,7 @@ class MjpegDevice:
         try:
             async for chunk in response.aiter_bytes():
                 chunk_len = len(chunk)
+                self.transferred_bytes += chunk_len
 
                 if buffer_end + chunk_len > buffer_size:
                     self.log.warning('Buffer overflow, resetting buffer')

--- a/tests/test_mjpeg_camera.py
+++ b/tests/test_mjpeg_camera.py
@@ -1,11 +1,31 @@
 import asyncio
+from contextlib import asynccontextmanager
 
+import numpy as np
 import pytest
 import pytest_asyncio
 
-from rosys.vision import MjpegCamera, MjpegCameraProvider
+from rosys.vision import Image, MjpegCamera, MjpegCameraProvider
+from rosys.vision.mjpeg_camera.mjpeg_device import MjpegDevice
 from rosys.vision.mjpeg_camera.motec_mjpeg_device import MotecMjpegDevice
 from rosys.vision.mjpeg_camera.vendors import VendorType, mac_to_vendor
+
+PART_HEADER = b'--boundary\r\nContent-Type: image/jpeg\r\n\r\n'
+GOODCAM_MAC = '2c:6f:51:00:00:01'  # a vendor whose device needs no network to configure
+
+
+def _mjpeg_stream(frames: int = 3) -> bytes:
+    noise = np.random.default_rng(seed=0).integers(0, 256, size=(240, 320, 3), dtype=np.uint8)
+    return (PART_HEADER + Image.from_array(noise).to_jpeg_bytes()) * frames
+
+
+class _StubResponse:
+    def __init__(self, stream: bytes, chunk_size: int) -> None:
+        self._chunks = [stream[i:i + chunk_size] for i in range(0, len(stream), chunk_size)]
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
 
 
 async def test_mjpeg_camera(rosys_integration):
@@ -93,3 +113,43 @@ async def test_stream_port(motec_settings_interface):
         assert await motec_settings_interface.get_stream_port() == 8886
     finally:
         await motec_settings_interface.set_stream_port(port)
+
+
+@pytest.mark.parametrize('chunk_size', [4096, 1_000_000])
+async def test_transferred_bytes_counts_every_byte_read(chunk_size, monkeypatch):
+    """Everything the stream delivers is counted, however it is chunked and however many frames survive."""
+    stream = _mjpeg_stream()
+    camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1', connect_after_init=False)
+    camera.device = MjpegDevice(mac=camera.mac, ip='127.0.0.1',
+                                on_new_image_data=camera._handle_new_image_data)  # pylint: disable=protected-access
+
+    @asynccontextmanager
+    async def fake_open_stream(*_, **__):
+        yield _StubResponse(stream, chunk_size)
+    monkeypatch.setattr('rosys.vision.mjpeg_camera.mjpeg_device.open_stream', fake_open_stream)
+
+    await camera.device.run_capture_task()
+
+    assert camera.transferred_bytes == len(stream)
+    assert len(camera.images) <= 3  # frames may be skipped to stay current, bytes are not
+    assert camera.images[-1].byte_size() != camera.transferred_bytes  # traffic, not decoded size
+
+
+async def test_transferred_bytes_survives_a_reconnect():
+    """Reconnecting replaces the device, so the camera keeps the retired one's bytes to stay monotonic."""
+    camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1', connect_after_init=False)
+    assert camera.transferred_bytes == 0
+
+    await camera.connect()
+    assert camera.device is not None
+    camera.device.transferred_bytes = 1000
+    assert camera.transferred_bytes == 1000
+
+    await camera.disconnect()
+    assert camera.transferred_bytes == 1000
+
+    await camera.connect()
+    assert camera.device is not None
+    assert camera.device.transferred_bytes == 0  # the new device starts from zero
+    camera.device.transferred_bytes = 7
+    assert camera.transferred_bytes == 1007


### PR DESCRIPTION
### Motivation

There is no way to measure a camera's stream throughput today. The only per-image size available is `Image.byte_size()`, which measures the decoded array — a constant per resolution that says nothing about the network.

`MjpegCamera` is also the only backend that could answer the question at all: `RtspCamera` receives an already decoded array out of GStreamer, `UsbCamera` captures locally, and the simulated and replay cameras have no wire. So this is deliberately MJPEG-only, not a first step toward covering every backend.

### Implementation

`MjpegDevice` counts bytes in the read loop, where everything the stream delivers passes exactly once — before framing and before `remove_exif`:

```python
async for chunk in response.aiter_bytes():
    chunk_len = len(chunk)
    self.transferred_bytes += chunk_len
```

`MjpegCamera` exposes it as a read-only `transferred_bytes` property. Because a reconnect replaces the device, the camera folds a retired device's count into its own accumulator, so it rises monotonically for the life of the process — a reconnect does not reset it. A process restart does; see the limits below.

That is the shape `rosys.analysis.recording.add_timer_topic(..., read=...)` already exists to poll:

```python
add_timer_topic(recorder, f'/camera/{cam.id}/bytes', interval=1.0, read=lambda: cam.transferred_bytes)
```

**Trade-offs and limits**

- **It is a counter, not per-frame attribution.** You can ask "what is this camera's bandwidth"; you cannot ask "which frame blew the budget". Counting in the read loop is what makes the first question answerable exactly, and I did not have a use for the second.
- **It measures response bodies, not the link.** TCP/IP and HTTP chunked-transfer framing sit below `aiter_bytes()`, and neither the response headers nor an authentication round trip in `open_stream` is counted. So it is a lower bound on what the link carries — the right order of magnitude for "is this camera saturating the link", not a NIC counter.
- **It is per device-lifetime, folded across reconnects** — not persisted, so it resets when the app restarts. Differencing it is the intended use.
- **A device orphaned before startup is not folded in.** `connect()` retires the old device, but `MjpegDevice.shutdown()` cancels only `_capture_task` and not the `on_startup` handler that creates it. A device replaced before that handler has fired will still start and count into an object the camera no longer holds. That orphaning is pre-existing — `connect()` already replaced `self.device` without shutting it down — so I have not tried to fix task lifecycle here; flagging it because this change gives it a visible symptom. Happy to address it separately if you want.

<details>
<summary>Why the read loop, and not per image</summary>

The first version of this attached the byte count to each `Image` as metadata, measured in `MjpegCamera._handle_new_image_data`. Two things were wrong with that, and both are the reason the counter sits where it does.

**The measurement was in the wrong place.** By the time the camera sees the bytes, `_frame_reader` has already yielded `buffer_view[start:end]` — SOI through EOI only, with the multipart part header excluded — and `run_capture_task` has already called `remove_exif`. So `len(image_bytes)` is the sanitized payload, not the traffic. The undercount is the part header plus whatever EXIF the vendor stamped, which varies by camera — exactly the property a bandwidth metric must not have. (Measured on that revision's fixture it was a few hundred bytes per frame; those numbers are not reproducible from this branch, whose tests no longer construct that case.)

**Per-image is the wrong granularity even once the measurement is right.** `Camera.images` is a `deque(maxlen=16)` — under two seconds at the default 10 fps — so "sum it over the camera's images" is not a throughput figure. Worse, three classes of byte never reach an image at all: frames the reader skips to stay current when a read delivers several at once, frames whose decode returns `None`, and the bytes dropped by the buffer-overflow reset. All three happen precisely when a camera is struggling and someone is measuring it.

Counting in the read loop captures all of that — exactly, for the response-body bytes it can see — and it removes the change from the six device files the per-image version had to touch to widen the `on_new_image_data` callback.

</details>

<details>
<summary>Verification</summary>

Gates from `AGENTS.md` (macOS, Python 3.13.11):

```
uv run pre-commit run --all-files   # all hooks Passed
uv run mypy ./rosys                 # Success: no issues found in 217 source files
uv run pylint ./rosys               # 10.00/10
uv run pytest                       # 360 passed, 7 skipped
```

The 7 skips are pre-existing hardware/platform gates (`arp-scan` absent, `UsbCamera` Linux-only), checked with `pytest -rs`; none cover this change. The three new tests all execute.

**Also green on Linux.** Because `on_push.yml` is `on: push`, this workflow does not run for a PR from a fork, so I pushed the same commit to a branch on my fork to get the real matrix: [run 31994348566](https://github.com/evnchn/rosys/actions/runs/31994348566) — `checker` plus `pytest` on 3.11, 3.12 and 3.13, all green, `360 passed, 7 skipped` on each, and `test_examples.py` run as well.

**Seen to fail without the fix.** Removing the `self.transferred_bytes += chunk_len` line fails both parametrizations of `test_transferred_bytes_counts_every_byte_read`.

`test_transferred_bytes_counts_every_byte_read` drives `run_capture_task` against a stubbed stream at two chunk sizes — 4096 (one frame per read) and 1 MB (all three frames in one read, so two are skipped) — and asserts the camera's count equals the whole stream either way.

`test_transferred_bytes_survives_a_reconnect` goes through real `connect()` / `disconnect()` calls (using a vendor whose device configures without network) rather than assigning `camera.device` directly, so it fails if the fold is wired wrong — verified by removing the fold: `assert 0 == 1000`.

`tests/test_examples.py` could not run on my machine (port 8080 was already bound by something unrelated); it did run in the fork CI above.

<sub>Drafted with Claude Code. The shape came from review rather than first intent: a second-model pass caught that the original per-image measurement was reading post-strip bytes, and a later one caught that per-image was the wrong granularity given the 16-frame deque.</sub>

</details>

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [ ] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary). — property and attribute docstrings; no user-facing docs affected
