### PR TITLE
Find the local Lizard firmware by its app image magic word

### DIFF
--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -113,14 +113,16 @@ class LizardFirmware:
                 break
 
     def read_local_version(self) -> None:
-        path = next((self.PATH / 'build').glob('*.bin'), self.PATH / 'build' / 'lizard.bin')
-        with path.open('rb') as f:
-            header = f.read(112)  # image header plus esp_app_desc_t up to the project name
-        if header[32:36] != self.APP_DESC_MAGIC:
-            self.log.error('%s is not an ESP32 app image', path)
+        build_path = self.PATH / 'build'
+        for path in build_path.glob('*.bin'):
+            with path.open('rb') as f:
+                header = f.read(112)  # image header plus esp_app_desc_t up to the project name
+            if header[32:36] != self.APP_DESC_MAGIC:
+                continue  # the build directory also holds non-firmware binaries like ota_data_initial.bin
+            self.local_version = self._parse_version(header[48:80].split(b'\x00', 1)[0].decode('utf-8', 'replace'))
+            self.local_project = header[80:112].split(b'\x00', 1)[0].decode('utf-8', 'replace') or None
             return
-        self.local_version = self._parse_version(header[48:80].split(b'\x00', 1)[0].decode('utf-8', 'replace'))
-        self.local_project = header[80:112].split(b'\x00', 1)[0].decode('utf-8', 'replace') or None
+        self.log.error('No ESP32 app image found in %s', build_path)
 
     async def read_core_version(self) -> None:
         if not self.robot_brain.is_ready:
@@ -200,10 +202,7 @@ class LizardFirmware:
 
     async def flash_core(self) -> None:
         if self.local_version is None:
-            try:
-                self.read_local_version()
-            except FileNotFoundError:
-                pass
+            self.read_local_version()
         if self._refuse_version(self.local_version, 'Flashing Core failed'):
             return
         if not self.robot_brain.is_ready:

--- a/rosys/hardware/lizard_firmware.py
+++ b/rosys/hardware/lizard_firmware.py
@@ -113,16 +113,20 @@ class LizardFirmware:
                 break
 
     def read_local_version(self) -> None:
+        self.local_version = None
+        self.local_project = None
         build_path = self.PATH / 'build'
-        for path in build_path.glob('*.bin'):
+        # NOTE: flash.py flashes build/lizard.bin, so that one takes precedence if several app images are present
+        for path in sorted(build_path.glob('*.bin'), key=lambda p: (p.name != 'lizard.bin', p.name)):
+            if not path.is_file():
+                continue
             with path.open('rb') as f:
                 header = f.read(112)  # image header plus esp_app_desc_t up to the project name
-            if header[32:36] != self.APP_DESC_MAGIC:
-                continue  # the build directory also holds non-firmware binaries like ota_data_initial.bin
-            self.local_version = self._parse_version(header[48:80].split(b'\x00', 1)[0].decode('utf-8', 'replace'))
-            self.local_project = header[80:112].split(b'\x00', 1)[0].decode('utf-8', 'replace') or None
-            return
-        self.log.error('No ESP32 app image found in %s', build_path)
+            if header[32:36] == self.APP_DESC_MAGIC:
+                self.local_version = self._parse_version(header[48:80].split(b'\x00', 1)[0].decode('utf-8', 'replace'))
+                self.local_project = header[80:112].split(b'\x00', 1)[0].decode('utf-8', 'replace') or None
+                return
+        self.log.warning('No ESP32 app image found in %s', build_path)
 
     async def read_core_version(self) -> None:
         if not self.robot_brain.is_ready:

--- a/tests/test_lizard_firmware.py
+++ b/tests/test_lizard_firmware.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from pathlib import Path
 
 import pytest
@@ -189,3 +189,21 @@ async def test_read_local_version(lizard_firmware: LizardFirmware, monkeypatch: 
     lizard_firmware.read_local_version()
     assert lizard_firmware.local_version == version
     assert lizard_firmware.local_project == project
+
+
+async def test_read_local_version_skips_other_binaries(lizard_firmware: LizardFirmware,
+                                                       monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The firmware is found by its magic word, not by its position among the other binaries of an ESP-IDF build."""
+    monkeypatch.setattr(LizardFirmware, 'PATH', tmp_path)
+    build_path = tmp_path / 'build'
+    build_path.mkdir()
+    (build_path / 'ota_data_initial.bin').write_bytes(b'\xff' * 8192)
+    (build_path / 'lizard.bin').write_bytes(app_image('v0.13.0'))
+
+    def glob(path: Path, pattern: str) -> Iterator[Path]:
+        assert (path, pattern) == (build_path, '*.bin')
+        return iter([build_path / 'ota_data_initial.bin', build_path / 'lizard.bin'])
+    monkeypatch.setattr(Path, 'glob', glob)  # the real order is unspecified, so pin the one that hid the firmware
+    lizard_firmware.read_local_version()
+    assert lizard_firmware.local_version == '0.13.0'
+    assert lizard_firmware.local_project == 'lizard'

--- a/tests/test_lizard_firmware.py
+++ b/tests/test_lizard_firmware.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator, Iterator
+from collections.abc import Generator
 from pathlib import Path
 
 import pytest
@@ -174,36 +174,27 @@ async def test_read_version(lizard_firmware: LizardFirmware,
     assert getattr(lizard_firmware, f'{target}_project') == project
 
 
-@pytest.mark.parametrize('filename, image, project, version', [
-    ('lizard.bin', app_image('v0.13.0'), 'lizard', '0.13.0'),
-    ('lizard-zz.bin', app_image('v0.0.1-6-g69dfddf', 'lizard-zz'), 'lizard-zz', '0.0.1'),
-    ('lizard.bin', b'not an app image', None, None),
+@pytest.mark.parametrize('files, project, version', [
+    ({'lizard.bin': app_image('v0.13.0')}, 'lizard', '0.13.0'),
+    ({'lizard-zz.bin': app_image('v0.0.1-6-g69dfddf', 'lizard-zz')}, 'lizard-zz', '0.0.1'),
+    ({'lizard.bin': b'not an app image'}, None, None),
+    ({}, None, None),
+    ({'bootloader.bin': b'\xff' * 8192, 'lizard.bin': app_image('v0.13.0')}, 'lizard', '0.13.0'),
+    ({'lizard-zz.bin': app_image('v0.0.1', 'lizard-zz'), 'lizard.bin': app_image('v0.13.0')}, 'lizard', '0.13.0'),
 ])
-async def test_read_local_version(lizard_firmware: LizardFirmware, monkeypatch: pytest.MonkeyPatch,
-                                  tmp_path: Path, filename: str, image: bytes,
-                                  project: str | None, version: str | None) -> None:
-    """The local project and version are read from the esp_app_desc_t header, whatever the binary is called."""
+async def test_read_local_version(lizard_firmware: LizardFirmware, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+                                  files: dict[str, bytes], project: str | None, version: str | None) -> None:
+    """The local project and version are read from the esp_app_desc_t header of the app image in the build directory.
+
+    Other binaries of an ESP-IDF build are skipped by their missing magic word, ``lizard.bin`` (the file ``flash.py``
+    flashes) takes precedence over other app images, and a previously read version is reset when nothing is found.
+    """
     monkeypatch.setattr(LizardFirmware, 'PATH', tmp_path)
     (tmp_path / 'build').mkdir()
-    (tmp_path / 'build' / filename).write_bytes(image)
+    for filename, content in files.items():
+        (tmp_path / 'build' / filename).write_bytes(content)
+    lizard_firmware.local_version = '0.12.0'
+    lizard_firmware.local_project = 'lizard'
     lizard_firmware.read_local_version()
     assert lizard_firmware.local_version == version
     assert lizard_firmware.local_project == project
-
-
-async def test_read_local_version_skips_other_binaries(lizard_firmware: LizardFirmware,
-                                                       monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """The firmware is found by its magic word, not by its position among the other binaries of an ESP-IDF build."""
-    monkeypatch.setattr(LizardFirmware, 'PATH', tmp_path)
-    build_path = tmp_path / 'build'
-    build_path.mkdir()
-    (build_path / 'ota_data_initial.bin').write_bytes(b'\xff' * 8192)
-    (build_path / 'lizard.bin').write_bytes(app_image('v0.13.0'))
-
-    def glob(path: Path, pattern: str) -> Iterator[Path]:
-        assert (path, pattern) == (build_path, '*.bin')
-        return iter([build_path / 'ota_data_initial.bin', build_path / 'lizard.bin'])
-    monkeypatch.setattr(Path, 'glob', glob)  # the real order is unspecified, so pin the one that hid the firmware
-    lizard_firmware.read_local_version()
-    assert lizard_firmware.local_version == '0.13.0'
-    assert lizard_firmware.local_project == 'lizard'


### PR DESCRIPTION
### Motivation

Follow-up to #452, as suggested in [this comment](https://github.com/zauberzeug/rosys/pull/452#issuecomment-5317746123).

`read_local_version()` picks the binary with `next((self.PATH / 'build').glob('*.bin'), …)` and checks the app image magic word afterwards.
But an ESP-IDF build directory holds further binaries next to the firmware — `ota_data_initial.bin` (~8 KB, no `esp_app_desc_t`) and `bootloader.bin` — and `Path.glob()` order is unspecified. Whenever one of them comes first the magic check fails, the method returns early, and `local_version` / `local_project` stay `None` — so `Local:` stays `?` in the developer UI and the local-update button never resolves. This affects build trees copied or symlinked into `~/.lizard`; the release zip from `download()` ships only `build/lizard.bin` at that level, so robots that only ever downloaded were not affected.

Measured against the 9 ESP-IDF build directories on my machine, `glob('*.bin')` yields `ota_data_initial.bin` first in **9 of 9** — the version was never read from a real build.

<details>
<summary>Per-directory measurement (before)</summary>

Every directory contains exactly `['ota_data_initial.bin', 'lizard.bin']`, and `next(glob('*.bin'))` returns `ota_data_initial.bin` in all of them:

```
BUG  dengfoc-work/lizard/build                            glob-first: ota_data_initial.bin   app images: ['lizard.bin']
BUG  lizard-224/build                                     glob-first: ota_data_initial.bin   app images: ['lizard.bin']
BUG  lizard-wt/fix-low-heap-guard/build                   glob-first: ota_data_initial.bin   app images: ['lizard.bin']
BUG  lizard-wt/i2c-247/build                              glob-first: ota_data_initial.bin   app images: ['lizard.bin']
BUG  lizard-wt/startup-246/build                          glob-first: ota_data_initial.bin   app images: ['lizard.bin']
BUG  lizard-wt/strict-module-233/build                    glob-first: ota_data_initial.bin   app images: ['lizard.bin']
BUG  worktrees/lizard-253-fix-expander-oversized-line/build   glob-first: ota_data_initial.bin   app images: ['lizard.bin']
BUG  worktrees/lizard-255-fix-expander-boot-pin-restore/build glob-first: ota_data_initial.bin   app images: ['lizard.bin']
BUG  worktrees/lizard-256-proposal-startup-save-ack/build     glob-first: ota_data_initial.bin   app images: ['lizard.bin']

=> current code picks a non-app-image in 9/9 build directories
```

</details>

### Implementation

- Iterate the `build/*.bin` candidates in a defined order — `lizard.bin` first, since that is the file `flash.py` flashes, then alphabetically — and take the first one whose magic word identifies it as an ESP32 app image. Selection no longer depends on filesystem iteration order, and with several app images present the reported version is the one that gets flashed.
- Reset `local_version` / `local_project` before scanning, so a build directory without an app image no longer leaves a stale version that `flash_core()` would trust.
- Skip entries that are not regular files (dangling symlinks, directories) and log one warning naming the directory if nothing is found; a robot without a downloaded firmware is an expected state, not an error.
- `flash_core()` no longer wraps `read_local_version()` in `try/except FileNotFoundError`: a missing `build` directory yields no candidates rather than raising, because `Path.glob()` returns nothing when its parent does not exist (checked for 3.11, 3.12 and 3.13).

<details>
<summary>Same 9 directories after the change</summary>

```
  project        version       build directory
  'lizard'       '0.12.0'      lizard-224
  'lizard'       '0.13.0'      lizard-wt/i2c-247
  'lizard'       '0.13.0'      lizard-wt/startup-246
  'lizard'       '0.13.0'      worktrees/lizard-255-fix-expander-boot-pin-restore
  'lizard'       '0.13.0'      worktrees/lizard-256-proposal-startup-save-ack
  'lizard'       None          dengfoc-work/lizard
  'lizard'       None          lizard-wt/fix-low-heap-guard
  'lizard'       None          lizard-wt/strict-module-233
  'lizard'       None          worktrees/lizard-253-fix-expander-oversized-line
```

The four remaining `None` versions are correct refusals, not a second bug: those images were built without a reachable git tag, so their raw `esp_app_desc_t` version strings are `'1'` and `'606aa60-dirty'`, which `VERSION_PATTERN` rightly does not match. The project name is now read in all nine, where previously nothing was read at all.

</details>

<details>
<summary>Regression test</summary>

The parametrize table of `test_read_local_version` now covers a decoy that sorts before the firmware (`bootloader.bin`), two app images side by side (`lizard.bin` wins over `lizard-zz.bin`), and the reset of a previously read version when the directory is empty or holds no app image. All rows use real files; since the iteration order is now defined, no fake of `Path.glob` is needed.

</details>

<details>
<summary>Gates</summary>

```
uv run pre-commit run --all-files    all hooks passed
uv run mypy ./rosys                  Success: no issues found in 217 source files
uv run pylint ./rosys                rated at 10.00/10
uv run pytest                        375 passed, 7 skipped
```

The 7 skips are the `UsbCamera`/`arp-scan` ones, none of which cover this code (`pytest -rs`).

</details>

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

[※](https://zauberzeug.github.io/colophon/#m=claude-opus-5&t=Hardware%20measurement%2C%20implementation%20and%20wording%20by%20the%20model%3B%20bug%20originally%20reported%20on%20%23452%20and%20confirmed%20by%20the%20operator.&a=claude-code "claude-opus-5: Hardware measurement, implementation and wording by the model; bug originally reported on #452 and confirmed by the operator.")

