### PR TITLE
Fix links in README to point to docs/examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Another module can register on `NEW_SENSOR_DATA` and act accordingly when being 
 
 RoSys provides an `Automator` module for running "automations".
 Automations are coroutines that can not only be started and stopped, but also paused and resumed, e.g. using `AutomationControls`.
-Have a look at our [Click-and-drive](docs/examples/click-and-drive/README.md) example.
+Have a look at our [Click-and-drive](https://rosys.io/examples/click-and-drive/) example.
 
 ### Persistence
 
@@ -146,7 +146,7 @@ It is a domain-specific language interpreted by the microcontroller which enable
 RoSys builds upon the open source project [NiceGUI](https://nicegui.io/) and offers many robot-related UI elements.
 NiceGUI is a high-level UI framework for the web.
 This means you can write all UI code in Python and the state is automatically reflected in the browser through WebSockets.
-See any of our [examples](docs/examples/steering/README.md).
+See any of our [examples](https://rosys.io/examples/steering/).
 
 RoSys can also be used with other user interfaces or interaction models if required, for example a completely app-based control through Bluetooth Low Energy with Flutter.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Another module can register on `NEW_SENSOR_DATA` and act accordingly when being 
 
 RoSys provides an `Automator` module for running "automations".
 Automations are coroutines that can not only be started and stopped, but also paused and resumed, e.g. using `AutomationControls`.
-Have a look at our [Click-and-drive](examples/click-and-drive/README.md) example.
+Have a look at our [Click-and-drive](docs/examples/click-and-drive/README.md) example.
 
 ### Persistence
 
@@ -146,7 +146,7 @@ It is a domain-specific language interpreted by the microcontroller which enable
 RoSys builds upon the open source project [NiceGUI](https://nicegui.io/) and offers many robot-related UI elements.
 NiceGUI is a high-level UI framework for the web.
 This means you can write all UI code in Python and the state is automatically reflected in the browser through WebSockets.
-See any of our [examples](examples/steering/README.md).
+See any of our [examples](docs/examples/steering/README.md).
 
 RoSys can also be used with other user interfaces or interaction models if required, for example a completely app-based control through Bluetooth Low Energy with Flutter.
 


### PR DESCRIPTION
Updated links in README to point to the 'docs' directory.

### Motivation

<!-- What problem does this PR solve? Which new feature or improvement does it implement? -->

<!-- Please provide relevant links to corresponding issues and feature requests. -->

One README link didn't work.
Fixes #459

### Implementation

<!-- What is the concept behind the implementation? How does it work? -->

<!-- Include any important technical decisions or trade-offs made -->

Fixed the 2 links in README to reflect the correct location of the examples folder.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests are not necessary.
- [x] Documentation is not necessary.
