### PR TITLE
Fix the "should fix" findings of the camera reconnect review

### DIFF
--- a/docs/examples/cameras/README.md
+++ b/docs/examples/cameras/README.md
@@ -51,9 +51,12 @@ It automatically updates every 0.1 seconds to detect and display new cameras, an
 
 Cameras can lose their connection due to network glitches, a bad cable or a power hiccup.
 Every camera reconnects on its own: once connected, the underlying device keeps trying to restore its stream every `reconnect_interval` seconds (default 3.0) for as long as the camera stays connected.
+The wait is owned by the camera, so it also applies to a device created later, and it is clamped to at least 0.1 s so a misconfigured `0` cannot starve the event loop.
+While attempts keep failing without a single frame, the wait doubles up to one minute and is jittered, so an unreachable camera stops hammering and several cameras that went down together do not retry in lock-step.
 `RtspCamera` and `MjpegCamera` re-open their stream, `UsbCamera` re-opens the video device (even if its `/dev/video*` node changed), and `SimulatedCamera` resumes after a simulated drop.
 Reconnection runs until the camera is disconnected, so `disconnect()` both stops the retries and tears down the device.
 `is_connected` tells whether a camera is streaming right now, while `is_active` tells whether a connection is wanted at all, i.e. whether the camera keeps trying.
+`is_active` follows the device's capture loop rather than the mere existence of a device, so a camera whose loop died reports `is_active == False` and `connect()` replaces the device instead of returning early.
 
 `connect()` always creates that device, even when the camera cannot be reached at all — because its address is not known yet, or no `/dev/video*` node exists.
 Such a camera reports `is_active` but not `is_connected`, and starts streaming as soon as the address or the video device appears.

--- a/rosys/vision/arkvision_rest_client.py
+++ b/rosys/vision/arkvision_rest_client.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import httpx
 
+from .http import new_async_client
+
 # The achievable frame rates depend on the sensor mode, which fixes a "base" frame rate.
 # (frequency, mode) -> base fps.  frequency: 0 = 50 Hz, 1 = 60 Hz.  See /imageSensorMode in the REST spec.
 SENSOR_MODE_BASE_FPS: dict[tuple[int, int], int] = {
@@ -39,7 +41,7 @@ class ArkVisionRestClient:
 
     async def _get(self, endpoint: str) -> dict[str, Any] | None:
         try:
-            async with httpx.AsyncClient() as client:
+            async with new_async_client() as client:
                 response = await client.get(f'{self.base_url}/{endpoint}', timeout=5)
             response.raise_for_status()
             return response.json()
@@ -49,7 +51,7 @@ class ArkVisionRestClient:
 
     async def _post(self, endpoint: str, data: dict[str, Any]) -> None:
         try:
-            async with httpx.AsyncClient() as client:
+            async with new_async_client() as client:
                 response = await client.post(f'{self.base_url}/{endpoint}', json=data, timeout=5)
             response.raise_for_status()
         except httpx.HTTPError as e:

--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import asyncio
 import logging
+import random
 from collections import deque
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -23,6 +24,28 @@ An interval of zero reads as "retry at once", which on a single event loop means
 that never lets anything else run.
 """
 
+MAX_RECONNECT_INTERVAL = 60.0
+"""Longest wait between two connection attempts, i.e. the cap of the back-off."""
+
+RECONNECT_JITTER = 0.2
+"""Relative spread of the wait between two connection attempts."""
+
+
+def retry_delay(reconnect_interval: float, failed_attempts: int = 0) -> float:
+    """How long a device waits before its next connection attempt.
+
+    The wait doubles from the second consecutive failure on, up to `MAX_RECONNECT_INTERVAL`, so an
+    unreachable camera stops hammering, and is jittered so cameras that went down together do not
+    retry in lock-step.
+
+    :param reconnect_interval: the configured wait after a stream that was working ended
+    :param failed_attempts: how many attempts in a row have failed to deliver a single frame
+    """
+    interval = max(reconnect_interval, MIN_RECONNECT_INTERVAL)
+    interval *= 2 ** min(max(failed_attempts - 1, 0), 16)
+    interval *= random.uniform(1 - RECONNECT_JITTER, 1 + RECONNECT_JITTER)
+    return min(max(interval, MIN_RECONNECT_INTERVAL), MAX_RECONNECT_INTERVAL)
+
 
 class Camera(abc.ABC):
     IMAGE_HISTORY_LENGTH: ClassVar[int] = 16
@@ -39,11 +62,14 @@ class Camera(abc.ABC):
                  streaming: bool | None = None,
                  polling_interval: float | None = None,
                  base_path_overwrite: str | None = None,
+                 reconnect_interval: float = 3.0,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self.id: str = id
         self.name = name or self.id
         self.connect_after_init = connect_after_init
+        self._reconnect_interval = MIN_RECONNECT_INTERVAL
+        self.reconnect_interval = reconnect_interval
         self.images: deque[Image] = deque(maxlen=Camera.IMAGE_HISTORY_LENGTH)
         self.base_path: str = f'images/{base_path_overwrite or id}'
 
@@ -61,6 +87,15 @@ class Camera(abc.ABC):
         if connect_after_init:
             rosys.on_startup(self.connect)
         rosys.on_shutdown(self.disconnect)
+
+    @property
+    def reconnect_interval(self) -> float:
+        """Seconds the device waits before reopening a stream that ended; the wait grows while attempts fail."""
+        return self._reconnect_interval
+
+    @reconnect_interval.setter
+    def reconnect_interval(self, interval: float) -> None:
+        self._reconnect_interval = clamp_reconnect_interval(interval, logger)
 
     @property
     def streaming(self) -> bool:
@@ -96,6 +131,7 @@ class Camera(abc.ABC):
             'name': self.name,
             'connect_after_init': self.connect_after_init,
             'base_path_overwrite': base_path_id if base_path_id != self.id else None,
+            'reconnect_interval': self.reconnect_interval,
         }
 
     @classmethod

--- a/rosys/vision/http.py
+++ b/rosys/vision/http.py
@@ -1,0 +1,22 @@
+import functools
+import ssl
+
+import httpx
+
+DEFAULT_TIMEOUT = 5.0
+"""Seconds an idle camera connection is given before it counts as lost."""
+
+
+@functools.cache
+def _ssl_context() -> ssl.SSLContext:
+    """Reuse a single SSL context, because building one costs tens of milliseconds of event loop time."""
+    return httpx.create_ssl_context()
+
+
+def new_async_client(*, timeout: float | None = DEFAULT_TIMEOUT, **kwargs) -> httpx.AsyncClient:
+    """Create an `httpx.AsyncClient` with a shared SSL context and an explicit timeout.
+
+    Cameras are retried in a loop, so building a fresh SSL context per attempt would stall the event
+    loop; and a stream that stops sending data must time out rather than park the capture loop forever.
+    """
+    return httpx.AsyncClient(verify=_ssl_context(), timeout=timeout, **kwargs)

--- a/rosys/vision/mjpeg_camera/arkvision_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/arkvision_mjpeg_device.py
@@ -13,13 +13,15 @@ class ArkVisionMjpegDevice(MjpegDevice):
                  username: str | None = None,
                  password: str | None = None,
                  on_new_image_data: Callable[[bytes, float], Awaitable | None],
-                 on_connect: Callable[[], Awaitable | None] | None = None) -> None:
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.ARKVISION:
             raise ValueError(
                 f'ArkVisionMjpegDevice can only be used with ARKVISION devices. Got {vendor} for mac="{mac}"')
         super().__init__(mac, ip, index=index, username=username, password=password,
-                         on_new_image_data=on_new_image_data, on_connect=on_connect)
+                         on_new_image_data=on_new_image_data, on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
 
     @property
     def settings_interface(self) -> ArkVisionSettingsInterface:

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -33,7 +33,8 @@ class AxisMjpegDevice(MjpegDevice):
                  username: str | None = None,
                  password: str | None = None,
                  on_new_image_data: Callable[[bytes, float], Awaitable | None],
-                 on_connect: Callable[[], Awaitable | None] | None = None) -> None:
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.AXIS:
             raise ValueError(f'AxisMjpegDevice can only be used with AXIS devices. Got {vendor} for mac="{mac}"')
@@ -41,7 +42,8 @@ class AxisMjpegDevice(MjpegDevice):
         self.axis_settings = AxisSettings(fps=6, resolution=(640, 480), mirrored=False)
 
         super().__init__(mac, ip, index=index, username=username, password=password,
-                         on_new_image_data=on_new_image_data, on_connect=on_connect)
+                         on_new_image_data=on_new_image_data, on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
 
     @property
     def url(self) -> str | None:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -24,7 +24,6 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
                  fps: int = 10,
                  resolution: tuple[int, int] = (640, 480),
                  mirrored: bool = False,
-                 reconnect_interval: float = 3.0,
                  **kwargs: Any,
                  ) -> None:
         super().__init__(id=id, name=name, connect_after_init=connect_after_init,
@@ -32,7 +31,6 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         self.log = logging.getLogger(f'rosys.vision.mjpeg_camera.{self.id}')
         self.username = username
         self.password = password
-        self.reconnect_interval = reconnect_interval
 
         parts = self.id.split('-')
         self.index: int | None = int(parts[1]) if len(parts) == 2 and parts[1].isdigit() else None
@@ -51,7 +49,6 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
             'username': self.username,
             'password': self.password,
             'ip': self.ip,
-            'reconnect_interval': self.reconnect_interval,
         }
 
     @property
@@ -60,7 +57,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
 
     @property
     def is_active(self) -> bool:
-        return self.device is not None
+        return (self.device is not None) and self.device.is_active
 
     @property
     def ip(self) -> str | None:
@@ -76,19 +73,25 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
     async def connect(self) -> None:
         async with self._device_connection():
             if self.device is not None:
-                return
+                if self.device.is_active:
+                    return
+                await self._tear_down_device()  # a device whose capture loop died is replaced, not kept
             self.device = MjpegDeviceFactory.create(self.mac, self.ip, index=self.index, username=self.username,
                                                     password=self.password,
                                                     on_new_image_data=self._handle_new_image_data,
-                                                    on_connect=self._apply_all_parameters)
-            self.device.reconnect_interval = self.reconnect_interval
+                                                    on_connect=self._apply_all_parameters,
+                                                    reconnect_interval=self.reconnect_interval)
 
     async def disconnect(self) -> None:
         async with self._device_connection():
-            if self.device is None:
-                return
-            self.device.shutdown()
-            self.device = None
+            await self._tear_down_device()
+
+    async def _tear_down_device(self) -> None:
+        """Shut the device down and forget it; the caller holds `device_connection_lock`."""
+        if self.device is None:
+            return
+        self.device.shutdown()
+        self.device = None
 
     async def _handle_new_image_data(self, image_bytes: bytes, timestamp: float) -> None:
         image: Image | None = None

--- a/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
@@ -4,6 +4,7 @@ import httpx
 
 from ... import rosys
 from ..camera_provider import CameraProvider
+from ..http import new_async_client
 from ..rtsp_camera.arp_scan import find_cameras
 from .mjpeg_camera import MjpegCamera
 from .vendors import VendorType, mac_to_vendor
@@ -53,7 +54,7 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera]):
                     httpx.DigestAuth(self.username, self.password)
                 url = f'http://{ip}/axis-cgi/videostatus.cgi'
                 try:
-                    async with httpx.AsyncClient() as client:
+                    async with new_async_client() as client:
                         response = await client.get(url, auth=authentication)
                 except httpx.HTTPError as e:
                     self.log.warning('Error while looking for cameras at axis router (%s): %s', url, e)

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -10,7 +10,8 @@ import httpx
 from nicegui import background_tasks
 
 from ... import rosys
-from ..camera.camera import clamp_reconnect_interval
+from ..camera.camera import clamp_reconnect_interval, retry_delay
+from ..http import new_async_client
 from ..image_processing import remove_exif
 from .vendors import mac_to_url
 
@@ -76,6 +77,7 @@ class MjpegDevice:
         self._password = password
         self.reconnect_interval = reconnect_interval
         self._state = CaptureState.CONNECTING
+        self._failed_attempts = 0
 
         self._start_capture_task()
 
@@ -137,6 +139,16 @@ class MjpegDevice:
         """
         return self._state is not CaptureState.STOPPED and self._capture_task is asyncio.current_task()
 
+    def _set_state(self, state: CaptureState) -> None:
+        """Record the state of the calling capture task, ignoring a task that has been replaced.
+
+        The dying and the new task share this attribute, so a zombie must not report its own progress
+        (or its end) as the state of the loop that replaced it (see `_keeps_running`).
+        """
+        if self._capture_task is not asyncio.current_task():
+            return
+        self._state = state
+
     async def _run_capture_task(self) -> None:
         """Keep a single MJPEG session alive, reconnecting after `reconnect_interval` when it ends.
 
@@ -145,28 +157,30 @@ class MjpegDevice:
         try:
             while self._keeps_running():
                 # every attempt starts fresh: an earlier rejection says nothing about this one
-                self._state = CaptureState.CONNECTING
+                self._set_state(CaptureState.CONNECTING)
+                streamed = False
                 reason = 'stream ended'
                 try:
-                    await self._connect_and_stream_images()
+                    streamed = await self._connect_and_stream_images()
                 except httpx.HTTPError as e:
                     reason = f'cannot reach the camera: {e}'
                 except Exception:
                     self.log.exception('capture session failed')
                     reason = 'capture session failed'
+                self._failed_attempts = 0 if streamed else self._failed_attempts + 1
                 if not self._keeps_running():
                     break
+                delay = self._retry_interval  # jittered, so log the wait we are about to take
                 if self._state is CaptureState.REFUSED:
-                    self.log.info('camera refused the stream; retrying in %.1f s', self._retry_interval)
+                    self.log.info('camera refused the stream; retrying in %.1f s', delay)
                 elif self._ip is None:
-                    self.log.debug('no address known; retrying in %.1f s', self._retry_interval)
+                    self.log.debug('no address known; retrying in %.1f s', delay)
                 elif self.url is None:
-                    self.log.debug('no stream URL for mac "%s"; retrying in %.1f s',
-                                   self._mac, self._retry_interval)
+                    self.log.debug('no stream URL for mac "%s"; retrying in %.1f s', self._mac, delay)
                 else:
-                    self.log.info('%s; reconnecting in %.1f s', reason, self._retry_interval)
+                    self.log.info('%s; reconnecting in %.1f s', reason, delay)
                 # a new address restarts the whole task, so no need to cut this wait short
-                await rosys.sleep(self._retry_interval)
+                await rosys.sleep(delay)
         finally:
             if self._capture_task is asyncio.current_task():
                 self._capture_task = None
@@ -176,7 +190,7 @@ class MjpegDevice:
         """How long to wait before the next session; a refusal backs off further than a lost stream."""
         if self._state is CaptureState.REFUSED:
             return self.REFUSED_RECONNECT_INTERVAL
-        return self.reconnect_interval
+        return retry_delay(self.reconnect_interval, self._failed_attempts)
 
     def restart_capture(self) -> None:
         self.log.debug('Restarting capture task')
@@ -235,27 +249,30 @@ class MjpegDevice:
         except httpx.ReadTimeout:
             self.log.warning('Connection to %s timed out', self.url)
 
-    async def _connect_and_stream_images(self) -> None:
+    async def _connect_and_stream_images(self) -> bool:
+        """Open a stream and read it until it ends. Returns whether at least one frame arrived."""
+        streamed = False
         url = self.url
         if url is None:
-            return
+            return streamed
         self.log.debug('Starting capture task for %s', url)
 
         try:
-            async with httpx.AsyncClient() as client:
+            async with new_async_client() as client:
                 await self._prepare_stream()
                 async with open_stream(client, url, self._username, self._password) as response:
                     if response is None:
-                        self._state = CaptureState.REFUSED
-                        return
-                    self._state = CaptureState.STREAMING
+                        self._set_state(CaptureState.REFUSED)
+                        return streamed
+                    self._set_state(CaptureState.STREAMING)
                     await self._invoke_on_connect()
                     async for image, capture_time in self._frame_reader(response):
                         if self.url != url:
                             self.log.info('stream settings changed; reopening the stream')
-                            return
+                            return streamed
                         if not image:
                             continue
+                        streamed = True
                         try:
                             timestamp = capture_time if capture_time is not None else rosys.time()
                             callback_result = self._on_new_image_data(remove_exif(image), timestamp)
@@ -264,11 +281,12 @@ class MjpegDevice:
                         except Exception as e:
                             self.log.error('Error processing image: %s', e)
                         if not self._keeps_running():
-                            return
+                            return streamed
         finally:
-            if self._keeps_running() and self._state is CaptureState.STREAMING:
-                self._state = CaptureState.CONNECTING
+            if self._state is CaptureState.STREAMING:
+                self._set_state(CaptureState.CONNECTING)
         self.log.debug('capture session ended')
+        return streamed
 
     def shutdown(self) -> None:
         self.log.debug('Shutting down capture task')

--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -19,33 +19,39 @@ class MjpegDeviceFactory:
                password: str | None = None,
                control_port: int | None = None,
                on_new_image_data: Callable[[bytes, float], Awaitable | None],
-               on_connect: Callable[[], Awaitable | None] | None = None) -> MjpegDevice:
+               on_connect: Callable[[], Awaitable | None] | None = None,
+               reconnect_interval: float = 3.0) -> MjpegDevice:
 
         vendor = mac_to_vendor(mac)
 
         if vendor == VendorType.AXIS:
             return AxisMjpegDevice(mac, ip,
                                    index=index, username=username, password=password,
-                                   on_new_image_data=on_new_image_data, on_connect=on_connect)
+                                   on_new_image_data=on_new_image_data, on_connect=on_connect,
+                                   reconnect_interval=reconnect_interval)
 
         if vendor == VendorType.MOTEC:
             return MotecMjpegDevice(mac, ip,
                                     username=username, password=password, control_port=control_port,
-                                    on_new_image_data=on_new_image_data, on_connect=on_connect)
+                                    on_new_image_data=on_new_image_data, on_connect=on_connect,
+                                    reconnect_interval=reconnect_interval)
 
         if vendor == VendorType.ARKVISION:
             return ArkVisionMjpegDevice(mac, ip,
                                         index=index, username=username, password=password,
-                                        on_new_image_data=on_new_image_data, on_connect=on_connect)
+                                        on_new_image_data=on_new_image_data, on_connect=on_connect,
+                                        reconnect_interval=reconnect_interval)
 
         if vendor == VendorType.OPENIPC_ZAUBERZEUG:
             return OpenIpcZauberzeugMjpegDevice(mac, ip,
                                                 username=username, password=password,
-                                                on_new_image_data=on_new_image_data, on_connect=on_connect)
+                                                on_new_image_data=on_new_image_data, on_connect=on_connect,
+                                                reconnect_interval=reconnect_interval)
 
         if vendor is VendorType.OTHER:
             log.warning('unknown vendor for mac="%s", no stream URL known for this camera', mac)
 
         return MjpegDevice(mac, ip,
                            username=username, password=password,
-                           on_new_image_data=on_new_image_data, on_connect=on_connect)
+                           on_new_image_data=on_new_image_data, on_connect=on_connect,
+                           reconnect_interval=reconnect_interval)

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -11,7 +11,8 @@ class MotecMjpegDevice(MjpegDevice):
                  password: str | None = '',
                  control_port: int | None = 8885,
                  on_new_image_data: Callable[[bytes, float], Awaitable | None],
-                 on_connect: Callable[[], Awaitable | None] | None = None) -> None:
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.MOTEC:
             raise ValueError(f'MotecMjpegDevice can only be used with MOTEC devices. Got {vendor} for mac="{mac}"')
@@ -19,7 +20,8 @@ class MotecMjpegDevice(MjpegDevice):
         self._control_port = control_port or 8885
 
         super().__init__(mac, ip, username=username, password=password,
-                         on_new_image_data=on_new_image_data, on_connect=on_connect)
+                         on_new_image_data=on_new_image_data, on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
 
     @property
     def settings_interface(self) -> MotecSettingsInterface:

--- a/rosys/vision/mjpeg_camera/openipc_zauberzeug_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/openipc_zauberzeug_mjpeg_device.py
@@ -17,14 +17,16 @@ class OpenIpcZauberzeugMjpegDevice(MjpegDevice):
                  username: str | None = None,
                  password: str | None = None,
                  on_new_image_data: Callable[[bytes, float], Awaitable | None],
-                 on_connect: Callable[[], Awaitable | None] | None = None) -> None:
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.OPENIPC_ZAUBERZEUG:
             raise ValueError(f'OpenIpcZauberzeugMjpegDevice can only be used with '
                              f'OPENIPC_ZAUBERZEUG devices. Got {vendor} for mac="{mac}"')
 
         super().__init__(mac, ip, username=username, password=password,
-                         on_new_image_data=on_new_image_data, on_connect=on_connect)
+                         on_new_image_data=on_new_image_data, on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
 
     @property
     def settings_interface(self) -> OpenIpcZauberzeugSettingsInterface:

--- a/rosys/vision/openipc_zauberzeug_settings_interface.py
+++ b/rosys/vision/openipc_zauberzeug_settings_interface.py
@@ -19,6 +19,8 @@ from typing import Any
 
 import httpx
 
+from .http import new_async_client
+
 # Bitrate is in kbps on both sides: RoSys models kbps and divinus forwards mp4_bitrate
 # straight to the encoder, whose bitrate fields are kbps. Passed through unchanged.
 
@@ -38,7 +40,7 @@ class OpenIpcZauberzeugSettingsInterface:
 
     async def _request(self, path: str, **params: Any) -> dict[str, Any]:
         params = {key: value for key, value in params.items() if value is not None}
-        async with httpx.AsyncClient(auth=self._auth, timeout=REQUEST_TIMEOUT) as client:
+        async with new_async_client(auth=self._auth, timeout=REQUEST_TIMEOUT) as client:
             response = await client.get(f'{self.base_url}{path}', params=params)
             response.raise_for_status()
             return response.json()

--- a/rosys/vision/rtsp_camera/jovision_rtsp_interface.py
+++ b/rosys/vision/rtsp_camera/jovision_rtsp_interface.py
@@ -3,8 +3,9 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-import httpx
 from httpx import QueryParams
+
+from ..http import new_async_client
 
 
 @dataclass
@@ -68,7 +69,7 @@ class JovisionInterface:
             cmd=json.dumps(cmd),
             _=int(time.time() * 1000),  # current time as a timestamp
         )
-        async with httpx.AsyncClient() as client:
+        async with new_async_client() as client:
             await client.get(self.settings_url, params=params)
 
     async def set_fps(self, stream_id: int, fps: int) -> None:
@@ -118,7 +119,7 @@ class JovisionInterface:
             cmd=json.dumps(cmd),
             _=int(time.time() * 1000),
         )
-        async with httpx.AsyncClient() as client:
+        async with new_async_client() as client:
             response = await client.get(self.settings_url, params=params)
 
         return [
@@ -152,7 +153,7 @@ class JovisionInterface:
         #     'cmd': json.dumps(cmd),
         #     '_': time.time() * 1000,
         # }
-        # async with httpx.AsyncClient() as client:
+        # async with new_async_client() as client:
         #     response = await client.get(self.settings_url, params=params)
 
         # for stream_id, stream in enumerate(response.json()['result']['all']):

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -21,7 +21,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
                  bitrate: int = 4096,
                  avdec: Literal['h264', 'h265'] = 'h264',
                  ip: str | None = None,
-                 reconnect_interval: float = 3.0,
                  **kwargs) -> None:
         self.mac = mac
         super().__init__(id=id or f'{mac}-{substream}',
@@ -33,7 +32,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
         self.device: RtspDevice | None = None
         self._ip: str | None = ip
-        self.reconnect_interval = reconnect_interval
 
         self._register_parameter('substream', self.get_substream, self.set_substream,
                                  min_value=0, max_value=1, step=1, default_value=substream)
@@ -50,7 +48,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         return super().to_dict() | parameters | {
             'mac': self.mac,
             'ip': self.ip,
-            'reconnect_interval': self.reconnect_interval,
         }
 
     @classmethod
@@ -70,7 +67,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
     @property
     def is_active(self) -> bool:
-        return self.device is not None
+        return self.device is not None and self.device.is_active
 
     @property
     def ip(self) -> str | None:
@@ -92,7 +89,9 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
     async def connect(self) -> None:
         async with self._device_connection():
             if self.device is not None:
-                return
+                if self.device.is_active:
+                    return
+                await self._tear_down_device()  # a device whose capture loop died is replaced, not kept
             self.device = RtspDevice(mac=self.mac, ip=self.ip,
                                      substream=self.parameters['substream'],
                                      fps=self.parameters['fps'],
@@ -103,11 +102,15 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
     async def disconnect(self) -> None:
         async with self._device_connection():
-            if self.device is None:
-                return
-            self.log.info('disconnect initialized...')
-            await self.device.shutdown()
-            self.device = None
+            await self._tear_down_device()
+
+    async def _tear_down_device(self) -> None:
+        """Shut the device down and forget it; the caller holds `device_connection_lock`."""
+        if self.device is None:
+            return
+        self.log.info('disconnect initialized...')
+        await self.device.shutdown()
+        self.device = None
 
     async def _handle_new_image_data(self, image_array: ImageArray, timestamp: float) -> None:
         transformed_image_array = process_ndarray_image(image_array, self.rotation, self.crop)

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -18,7 +18,7 @@ from nicegui import background_tasks
 
 from ... import rosys
 from ...vision.image import ImageArray
-from ..camera.camera import clamp_reconnect_interval
+from ..camera.camera import clamp_reconnect_interval, retry_delay
 from ..openipc_zauberzeug_settings_interface import OpenIpcZauberzeugSettingsInterface
 from .arkvision_rtsp_interface import ArkVisionRtspInterface
 from .jovision_rtsp_interface import JovisionInterface
@@ -55,6 +55,7 @@ class RtspDevice:
         self._warned_about_missing_settings: bool = False
         self.reconnect_interval = reconnect_interval
         self._should_run: bool = True
+        self._failed_attempts: int = 0
 
         self._settings_interface: JovisionInterface | ArkVisionRtspInterface | OpenIpcZauberzeugSettingsInterface | None = None
         self._bind_settings_interface()
@@ -147,11 +148,13 @@ class RtspDevice:
             self.log.debug('[%s] Cancelling gstreamer task', self._mac)
             task.cancel()
             try:
-                await asyncio.wait_for(task, timeout=5)
+                await asyncio.wait_for(asyncio.shield(task), timeout=5)
             except TimeoutError:
                 self.log.warning('[%s] Timeout while waiting for capture task to cancel', self._mac)
                 return
             except asyncio.CancelledError:
+                if not task.cancelled():
+                    raise  # our own caller was cancelled, not the capture task
                 self.log.debug('[%s] Task was successfully cancelled', self._mac)
             else:
                 self.log.debug('[%s] Task finished', self._mac)
@@ -175,21 +178,23 @@ class RtspDevice:
             while self._should_run:
                 # every attempt starts fresh: an earlier rejection says nothing about this one
                 self._authorized = True
+                streamed = False
                 try:
-                    await self._run_gstreamer()
+                    streamed = await self._run_gstreamer()
                 except Exception:
                     self.log.exception('[%s] capture session failed', self._mac)
+                self._failed_attempts = 0 if streamed else self._failed_attempts + 1
                 if not self._should_run:
                     break
                 if not self._authorized:
                     self.log.info('[%s] credentials rejected; retrying in %.1f s',
                                   self._mac, self.UNAUTHORIZED_RECONNECT_INTERVAL)
                 elif self._ip is None:
-                    self.log.debug('[%s] no address known; retrying in %.1f s', self._mac, self.reconnect_interval)
+                    self.log.debug('[%s] no address known; retrying in about %.1f s', self._mac, self._retry_interval)
                 elif self.url is None:
                     self._warn_about_missing_url()
                 else:
-                    self.log.info('[%s] stream ended; reconnecting in %.1f s', self._mac, self.reconnect_interval)
+                    self.log.info('[%s] stream ended; reconnecting in about %.1f s', self._mac, self._retry_interval)
                 await self._wait_before_retry()
         finally:
             if self._capture_task is asyncio.current_task():
@@ -207,6 +212,11 @@ class RtspDevice:
         self.log.warning('[%s] no RTSP URL known for vendor %s; this camera cannot be reached',
                          self._mac, mac_to_vendor(self._mac))
 
+    @property
+    def _retry_interval(self) -> float:
+        """How long to wait before the next session; grows while attempts keep failing (see `retry_delay`)."""
+        return retry_delay(self.reconnect_interval, self._failed_attempts)
+
     async def _wait_before_retry(self) -> None:
         """Wait `reconnect_interval` before the next session, extending the wait while our login stays rejected.
 
@@ -214,10 +224,10 @@ class RtspDevice:
         holding on to a verdict that was about the previous address. The deadline bounds the whole
         wait, whatever the chunk size is.
         """
-        await rosys.sleep(self.reconnect_interval)
-        deadline = rosys.time() + self.UNAUTHORIZED_RECONNECT_INTERVAL - self.reconnect_interval
+        deadline = rosys.time() + self.UNAUTHORIZED_RECONNECT_INTERVAL
+        await rosys.sleep(self._retry_interval)
         while self._should_run and not self._authorized and rosys.time() < deadline:
-            await rosys.sleep(self.reconnect_interval)
+            await rosys.sleep(self._retry_interval)
 
     async def restart_gstreamer(self) -> None:
         await self.shutdown()
@@ -231,15 +241,20 @@ class RtspDevice:
         if isinstance(result, Awaitable):
             await result
 
-    async def _run_gstreamer(self) -> None:
+    async def _run_gstreamer(self) -> bool:
+        """Run a gstreamer session until it ends. Returns whether at least one frame arrived."""
+        streamed = False
         if self.is_connected:
             self.log.warning('[%s] capture process already running', self._mac)
-            return
+            return streamed
         url = self.url
         if url is None:
-            return
+            return streamed
+
+        capture_process: Process | None = None
 
         async def stream() -> AsyncGenerator[ImageArray, None]:
+            nonlocal capture_process
             self.log.debug('[%s] Starting gstreamer pipeline for %s', self._mac, url)
             # to try: replace avdec_h264 with nvh264dec ! nvvidconv (!videoconvert)
             command = f'gst-launch-1.0 --quiet rtspsrc location="{url}" latency=0 protocols=tcp ! rtp{self._avdec}depay ! avdec_{self._avdec} ! videoconvert ! video/x-raw,format=RGB ! queue max-size-buffers=1 leaky=downstream ! gdppay ! fdsink sync=false'
@@ -252,6 +267,7 @@ class RtspDevice:
             assert process.stdout is not None
             assert process.stderr is not None
             self._capture_process = process
+            capture_process = process
             await self._invoke_on_connect()
 
             width = None
@@ -306,17 +322,19 @@ class RtspDevice:
 
         try:
             async for image in stream():
+                streamed = True
                 timestamp = rosys.time()
                 result = self._on_new_image_data(image, timestamp)
                 if isinstance(result, Awaitable):
                     await result
             self.log.info('[%s] stream ended', self._mac)
         finally:
-            process = self._capture_process
-            if process is not None and process.returncode is None:
+            if capture_process is not None and capture_process.returncode is None:
                 self.log.debug('[%s] terminating leftover gstreamer process', self._mac)
-                process.terminate()
-            self._capture_process = None
+                capture_process.terminate()
+            if self._capture_process is capture_process:  # a restart may have spawned a new process
+                self._capture_process = None
+        return streamed
 
     async def set_fps(self, fps: int) -> None:
         self._fps = fps

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -17,7 +17,6 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
                  height: int = 600,
                  color: str | None = None,
                  fps: int = 5,
-                 reconnect_interval: float = 3.0,
                  simulate_failing: bool = False,
                  **kwargs,
                  ) -> None:
@@ -27,7 +26,6 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
                          **kwargs)
         self.device: SimulatedDevice | None = None
         self.resolution = ImageSize(width=width, height=height)
-        self.reconnect_interval = reconnect_interval
         self.simulate_failing = simulate_failing
         self._register_parameter('color', self._get_color, self._set_color,
                                  color or f'#{random.randint(0, 0xffffff):06x}')
@@ -38,7 +36,6 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
         return super().to_dict() | {
             'width': self.resolution.width,
             'height': self.resolution.height,
-            'reconnect_interval': self.reconnect_interval,
         } | {
             name: param.value for name, param in self._parameters.items()
         }
@@ -49,12 +46,14 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
     @property
     def is_active(self) -> bool:
-        return self.device is not None
+        return self.device is not None and self.device.is_active
 
     async def connect(self) -> None:
         async with self._device_connection():
             if self.device is not None:
-                return
+                if self.device.is_active:
+                    return
+                await self._tear_down_device()  # a device whose image loop died is replaced, not kept
             self.device = SimulatedDevice(id=self.id, size=self.resolution, fps=self.parameters['fps'],
                                           on_new_image=self._add_image,
                                           on_connect=self._apply_all_parameters,
@@ -64,10 +63,14 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
     async def disconnect(self) -> None:
         async with self._device_connection():
-            if self.device is None:
-                return
-            self.device.shutdown()
-            self.device = None
+            await self._tear_down_device()
+
+    async def _tear_down_device(self) -> None:
+        """Shut the device down and forget it; the caller holds `device_connection_lock`."""
+        if self.device is None:
+            return
+        self.device.shutdown()
+        self.device = None
 
     def _set_color(self, value: str) -> None:
         assert self.device is not None

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -24,14 +24,12 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
                  width: int = 800,
                  height: int = 600,
                  fps: int = 10,
-                 reconnect_interval: float = 3.0,
                  **kwargs) -> None:
         super().__init__(id=id,
                          name=name,
                          connect_after_init=connect_after_init,
                          **kwargs)
         self.log = logging.getLogger(f'rosys.vision.usb_camera.{self.id}')
-        self.reconnect_interval = reconnect_interval
         self._pending_operations = 0
         self.device: UsbDevice | None = None
         self.detect: bool = False
@@ -46,8 +44,6 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
     def to_dict(self) -> dict[str, Any]:
         return super().to_dict() | {
             name: param.value for name, param in self._parameters.items()
-        } | {
-            'reconnect_interval': self.reconnect_interval,
         }
 
     @property
@@ -56,12 +52,14 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
 
     @property
     def is_active(self) -> bool:
-        return self.device is not None
+        return self.device is not None and self.device.is_active
 
     async def connect(self) -> None:
         async with self._device_connection():
             if self.device is not None:
-                return
+                if self.device.is_active:
+                    return
+                await self._tear_down_device()  # a device whose capture loop died is replaced, not kept
             self.device = UsbDevice(self.id,
                                     on_new_image_data=self._handle_new_image_data,
                                     on_connect=self._apply_all_parameters,
@@ -69,11 +67,15 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
 
     async def disconnect(self) -> None:
         async with self._device_connection():
-            if self.device is None:
-                return
-            await self.device.shutdown()
-            self.device = None
-            self.log.info('disconnected')
+            await self._tear_down_device()
+
+    async def _tear_down_device(self) -> None:
+        """Shut the device down and forget it; the caller holds `device_connection_lock`."""
+        if self.device is None:
+            return
+        await self.device.shutdown()
+        self.device = None
+        self.log.info('disconnected')
 
     async def _handle_new_image_data(self, image_data: np.ndarray | bytes, timestamp: float) -> None:
         if self.device is None:

--- a/rosys/vision/usb_camera/usb_camera_scanner.py
+++ b/rosys/vision/usb_camera/usb_camera_scanner.py
@@ -12,12 +12,6 @@ def _udev_context() -> pyudev.Context:
     return pyudev.Context()
 
 
-def _video_devices() -> list[pyudev.Device]:
-    # libudev keeps a non-atomic reference count on its context, so concurrent scans must not share it unguarded
-    with _udev_lock:
-        return list(_udev_context().list_devices(subsystem='video4linux'))
-
-
 def uid_from_device(device: pyudev.Device) -> str | None:
     parts = [
         device.get('ID_VENDOR_ID'),
@@ -27,10 +21,21 @@ def uid_from_device(device: pyudev.Device) -> str | None:
     return '-'.join(parts) if all(parts) else device.get('DEVNAME') or None
 
 
+def _scan() -> list[tuple[str | None, str | None]]:
+    """List ``(uid, device node)`` of all video devices.
+
+    libudev keeps a non-atomic reference count on its context, so concurrent scans must not share it
+    unguarded. `pyudev.Device` objects hold a reference to that context and drop it when they are
+    garbage-collected, so none of them may leave the lock; only plain strings do.
+    """
+    with _udev_lock:
+        return [(uid_from_device(device), device.device_node)
+                for device in _udev_context().list_devices(subsystem='video4linux')]
+
+
 def scan_for_connected_devices() -> set[str]:
-    return {uid for uid in (uid_from_device(device) for device in _video_devices()) if uid is not None}
+    return {uid for uid, _ in _scan() if uid is not None}
 
 
 def device_nodes_from_uid(uid: str) -> set[str]:
-    matching_devices = [device for device in _video_devices() if uid_from_device(device) == uid]
-    return {device.device_node for device in matching_devices if device.device_node is not None}
+    return {node for device_uid, node in _scan() if device_uid == uid and node is not None}

--- a/rosys/vision/usb_camera/usb_device.py
+++ b/rosys/vision/usb_camera/usb_device.py
@@ -7,7 +7,7 @@ import cv2
 import numpy as np
 
 from ... import rosys
-from ..camera.camera import clamp_reconnect_interval
+from ..camera.camera import clamp_reconnect_interval, retry_delay
 from .usb_camera_scanner import device_nodes_from_uid
 
 MJPG = cv2.VideoWriter.fourcc(*'MJPG')
@@ -50,16 +50,9 @@ class UsbDevice:
         self._read_failures: int = 0
         self._capture_task: asyncio.Task | None = None
         self._unavailable_node: str | None = None
+        self._failed_attempts: int = 0
 
         self._start_capture_task()
-
-    def __del__(self) -> None:
-        self._should_run = False
-        if self._capture_task is not None and not self._capture_task.done():
-            self._capture_task.cancel()
-        if self._capture is not None:
-            self._capture.release()
-            self._capture = None
 
     @property
     def is_connected(self) -> bool:
@@ -78,6 +71,11 @@ class UsbDevice:
     @reconnect_interval.setter
     def reconnect_interval(self, interval: float) -> None:
         self._reconnect_interval = clamp_reconnect_interval(interval, self.log)
+
+    @property
+    def _retry_interval(self) -> float:
+        """How long to wait before the next session; grows while attempts keep failing (see `retry_delay`)."""
+        return retry_delay(self.reconnect_interval, self._failed_attempts)
 
     @property
     def video_formats(self) -> set[str]:
@@ -118,13 +116,15 @@ class UsbDevice:
                     streamed = await self._run_capture_session()
                 except Exception:
                     self.log.exception('[%s] capture session failed', self.uid)
+                self._failed_attempts = 0 if streamed else self._failed_attempts + 1
                 if not self._should_run:
                     break
+                delay = self._retry_interval  # jittered, so log the wait we are about to take
                 if streamed:
-                    self.log.info('[%s] capture ended; reconnecting in %.1f s', self.uid, self.reconnect_interval)
+                    self.log.info('[%s] capture ended; reconnecting in %.1f s', self.uid, delay)
                 else:
-                    self.log.debug('[%s] no capture; retrying in %.1f s', self.uid, self.reconnect_interval)
-                await rosys.sleep(self.reconnect_interval)
+                    self.log.debug('[%s] no capture; retrying in %.1f s', self.uid, delay)
+                await rosys.sleep(delay)
         finally:
             if self._capture_task is asyncio.current_task():
                 self._capture_task = None
@@ -213,11 +213,12 @@ class UsbDevice:
         if task is not None and not task.done():
             task.cancel()
             try:
-                await asyncio.wait_for(task, timeout=5)
+                await asyncio.wait_for(asyncio.shield(task), timeout=5)
             except TimeoutError:
                 self.log.warning('[%s] timeout while waiting for capture task to cancel', self.uid)
             except asyncio.CancelledError:
-                pass
+                if not task.cancelled():
+                    raise  # our own caller was cancelled, not the capture task
         if self._capture_task is task:  # a restart may have started a new loop while we waited
             self._capture_task = None
         await self._release()

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 import cv2
 import numpy as np
 import pytest
+from nicegui import background_tasks
 
 import rosys
 import rosys.rosys as rosys_core
@@ -24,7 +25,12 @@ from rosys.vision import (
     UsbCamera,
     UsbCameraProvider,
 )
-from rosys.vision.camera.camera import MIN_RECONNECT_INTERVAL
+from rosys.vision.camera.camera import (
+    MAX_RECONNECT_INTERVAL,
+    MIN_RECONNECT_INTERVAL,
+    RECONNECT_JITTER,
+    retry_delay,
+)
 from rosys.vision.mjpeg_camera.axis_mjpeg_device import AxisMjpegDevice
 from rosys.vision.mjpeg_camera.mjpeg_device import CaptureState, MjpegDevice
 from rosys.vision.rtsp_camera.rtsp_device import RtspDevice
@@ -97,6 +103,13 @@ async def forward_until(condition, *, step: float = 0.3, real_step: float = 0.05
     assert condition(), message
 
 
+async def _survives_one_cancellation() -> None:
+    """Stand-in for a capture task that outlives its first cancellation, as one stuck in `cpu_bound` does."""
+    with suppress(asyncio.CancelledError):
+        await asyncio.sleep(60.0)
+    await asyncio.sleep(60.0)
+
+
 JPEG_FRAME = b'\xff\xd8' + bytes(32) + b'\xff\xd9'  # minimal SOI..EOI JPEG marker pair
 
 
@@ -135,10 +148,16 @@ def live_capture_tasks(name: str) -> list[asyncio.Task]:
 
 
 async def cancel_leftover_loops(name: str) -> None:
-    """Keep a failing test from leaving a capture loop behind that would hold up the next one."""
-    for task in live_capture_tasks(name):
+    """Cancel the capture loops under this name and wait for them to end, as a crashing loop leaves them.
+
+    Also keeps a failing test from leaving a loop behind that would hold up the next one.
+    """
+    tasks = live_capture_tasks(name)
+    for task in tasks:
         task.cancel()
-    await asyncio.sleep(0)
+    for task in tasks:
+        with suppress(asyncio.CancelledError):
+            await task
 
 
 class SlowFirstDecode:
@@ -1162,3 +1181,111 @@ async def test_simulated_provider_leaves_disconnected_camera_alone(rosys_integra
 
     await provider.update_device_list()
     assert not camera.is_active, 'expected the provider to leave a deliberately disconnected camera alone'
+
+
+async def test_camera_clamps_a_reconnect_interval_that_would_not_wait(rosys_integration):
+    for interval in (0.0, -1.0):
+        camera = SimulatedCamera(id='sim', reconnect_interval=interval, connect_after_init=False)
+        assert camera.reconnect_interval == MIN_RECONNECT_INTERVAL, 'expected the camera to clamp the interval'
+
+
+async def test_camera_passes_its_reconnect_interval_to_a_replaced_device(rosys_integration):
+    """The interval lives on the camera, so a device created later must still see it."""
+    camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1:1', connect_after_init=False)
+    camera.reconnect_interval = 7.0
+    with stalled_mjpeg_stream():
+        await camera.connect()
+        try:
+            assert camera.device is not None
+            assert camera.device.reconnect_interval == 7.0
+        finally:
+            await camera.disconnect()
+
+
+def test_retry_delay_grows_and_is_capped():
+    """An unreachable camera must not keep retrying at `reconnect_interval` forever."""
+    first = min(retry_delay(1.0, 1) for _ in range(50))
+    later = min(retry_delay(1.0, 4) for _ in range(50))
+    assert later > first, 'expected the wait to grow while attempts keep failing'
+    assert max(retry_delay(1.0, 30) for _ in range(50)) <= MAX_RECONNECT_INTERVAL, \
+        'expected the back-off to be capped'
+
+
+def test_retry_delay_is_jittered_so_cameras_do_not_retry_in_lock_step():
+    delays = {retry_delay(3.0) for _ in range(20)}
+    assert len(delays) > 1, 'expected jitter, otherwise all cameras retry at the same instant'
+    assert all(MIN_RECONNECT_INTERVAL <= delay <= MAX_RECONNECT_INTERVAL for delay in delays)
+
+
+async def test_devices_back_off_while_attempts_keep_failing(rosys_integration):
+    device = MjpegDevice(GOODCAM_MAC, '127.0.0.1:1', on_new_image_data=lambda data, timestamp: None,
+                         reconnect_interval=0.2)
+    try:
+        assert device._retry_interval <= 0.2 * (1 + RECONNECT_JITTER)  # pylint: disable=protected-access
+        device._failed_attempts = 20  # pylint: disable=protected-access
+        assert device._retry_interval > 0.2 * (1 + RECONNECT_JITTER)  # pylint: disable=protected-access
+        assert device._retry_interval <= MAX_RECONNECT_INTERVAL  # pylint: disable=protected-access
+    finally:
+        device.shutdown()
+
+
+async def test_camera_is_not_active_once_its_capture_loop_died(rosys_integration):
+    """`is_active` must see a dead loop; otherwise the camera reports reconnecting forever."""
+    camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1:1', connect_after_init=False)
+    with stalled_mjpeg_stream():
+        await camera.connect()
+        try:
+            assert camera.is_active
+            assert camera.device is not None
+            await cancel_leftover_loops(f'mjpeg capture {GOODCAM_MAC}')  # what a crashing loop leaves behind
+            assert not camera.is_active, 'expected a camera with a dead capture loop to report is_active False'
+            assert not camera.is_reconnecting, 'expected no reconnect state without a loop that could reconnect'
+        finally:
+            await camera.disconnect()
+
+
+async def test_camera_connect_replaces_a_device_whose_loop_died(rosys_integration):
+    camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1:1', connect_after_init=False)
+    with stalled_mjpeg_stream():
+        await camera.connect()
+        try:
+            dead_device = camera.device
+            await cancel_leftover_loops(f'mjpeg capture {GOODCAM_MAC}')
+
+            await camera.connect()
+            assert camera.device is not dead_device, 'expected connect() to replace the dead device'
+            assert camera.is_active
+        finally:
+            await camera.disconnect()
+
+
+async def test_mjpeg_device_state_survives_a_dying_zombie_session(rosys_integration):
+    """A replaced capture task must not report its own end as the state of the loop that replaced it."""
+    device = MjpegDevice(GOODCAM_MAC, '127.0.0.1:1', on_new_image_data=lambda data, timestamp: None)
+    try:
+        device._state = CaptureState.STREAMING  # pylint: disable=protected-access
+        device._set_state(CaptureState.CONNECTING)  # pylint: disable=protected-access
+        assert device.is_connected, 'expected a foreign task not to change the state of the live loop'
+    finally:
+        device.shutdown()
+
+
+async def test_rtsp_shutdown_reraises_a_cancellation_of_its_caller(rosys_integration):
+    """A cancellation aimed at the caller of `shutdown()` must not be swallowed by it."""
+    with stalled_rtsp_stream():
+        device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
+                            on_new_image_data=lambda array, timestamp: None)
+        try:
+            device._capture_task = background_tasks.create(  # pylint: disable=protected-access
+                _survives_one_cancellation(), name=f'capture {GOODCAM_MAC}')
+            await asyncio.sleep(0)
+
+            caller = background_tasks.create(device.shutdown(), name='shutdown caller')
+            await asyncio.sleep(0)
+            caller.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await caller
+        finally:
+            for task in asyncio.all_tasks():
+                if task.get_name() == f'capture {GOODCAM_MAC}':
+                    task.cancel()


### PR DESCRIPTION
### Motivation

The second review round of #423 listed six blocking defects (B0–B6) and six "should fix" ones (A1–A6).
The blocking ones are being fixed on the base branch; this PR clears the "should fix" list.

- **A1** — all four cameras defined `is_active` as `self.device is not None`, so a camera whose capture loop died reported `is_reconnecting == True` forever while nothing was running, and `connect()`'s early return could not replace it. The device-level `is_active` was never read outside the tests.
- **A2** — `reconnect_interval` was stored, persisted and forwarded separately by each of the four cameras, and the fourth copy had already drifted: `MjpegDeviceFactory.create` did not accept it, so `MjpegCamera.connect` patched `device.reconnect_interval` after construction.
- **A3** — the dying and the new capture task shared `MjpegDevice._state`, so a zombie's `finally` reported its own end as the state of the loop that had replaced it.
- **A4** — `RtspDevice.shutdown()` and `UsbDevice.shutdown()` caught `asyncio.CancelledError` around their `wait_for`, discarding a cancellation aimed at the *caller* — which, as `rosys.on_shutdown` handlers, is exactly where cancellation arrives.
- **A5** — the udev lock was released as soon as the device list was built, so `pyudev.Device` objects escaped it and decremented libudev's non-atomic refcount on the calling thread, outside the lock the comment claimed to hold.
- **A6** — a fixed interval with no jitter and no cap made N unreachable cameras retry in lock-step forever, each attempt building a fresh `httpx.AsyncClient` at ~33 ms of synchronous SSL-context construction on the event loop.

### Implementation

**`reconnect_interval` moves to `Camera` (A2).**
`Camera.__init__` takes it, runs it through the base branch's `clamp_reconnect_interval` in a property setter and persists it in `Camera.to_dict`, so the four per-camera copies and the four `to_dict` entries disappear.
`MjpegDeviceFactory.create` and the four vendor `MjpegDevice` subclasses now accept and forward it, which removes the post-construction patching in `MjpegCamera.connect`.

**`is_active` follows the loop (A1).**
All four cameras delegate to `device.is_active`, and their `connect()` replaces a device whose loop has died instead of returning early.
Since the base branch now serializes `connect`/`disconnect` under `device_connection_lock`, the teardown moved into a lock-free `_tear_down_device()` that both `disconnect()` and `connect()` call while holding the lock — calling `disconnect()` from inside `connect()` would self-deadlock on the condition.

**Back-off with a cap and jitter (A6).**
A single `retry_delay(reconnect_interval, failed_attempts)` in `rosys/vision/camera/camera.py` is now the one place the wait is computed; all three devices call it from `_retry_interval` and count consecutive attempts that delivered no frame.
The wait doubles from the second consecutive failure up to `MAX_RECONNECT_INTERVAL` (60 s) and is jittered by ±20 %, clamped to `[MIN, MAX]` after the jitter so neither bound can be exceeded.
Because the value is jittered, the loops now compute it once and log the wait they are about to take.
A new `rosys/vision/http.py` provides `new_async_client()` with a cached SSL context and an explicit timeout; the six `httpx.AsyncClient()` call sites in `rosys/vision` use it, which cuts client construction from ~33 ms to ~0.3 ms and makes the MJPEG stream timeout explicit instead of inherited from httpx.

**State that belongs to one task (A3).**
`MjpegDevice._set_state()` ignores a task that is no longer `_capture_task`, so a zombie cannot overwrite the live loop's state.
(The equivalent `RtspDevice._capture_process` guard landed with the B3 fix on the base branch; `_run_gstreamer` now also keeps its process in a local so its `finally` cannot clear a successor's.)

**Cancellation belongs to the caller (A4).**
Both `shutdown()`s shield the task they wait on and re-raise unless the task itself was cancelled.

**One udev scan under one lock (A5).**
`_scan()` returns plain `(uid, node)` string tuples built inside the lock, so no `pyudev.Device` escapes it.

Also drops the dead `UsbDevice.__del__` (while the loop runs the coroutine frame keeps the object alive; after `shutdown()` every branch is a no-op, and it implied a GC-time `cv2.release()`).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Notes for the reviewer

Rebased onto `f55db606`, so this now sits on top of the B3 and B5 fixes.
Both touched the same code, and the merge was resolved in favour of the base branch throughout: `clamp_reconnect_interval` replaced my duplicate clamp, `REFUSED`/`is_refused` and the removal of `StreamOpenResult` were kept and `retry_delay` layered onto them, and the new `_device_connection()` locking was kept with the teardown refactor described above.
The test helper `cancel_leftover_loops` was extended to await the tasks it cancels rather than adding a second helper next to it.

Nine tests were added to `tests/test_camera_reconnect.py`, covering the clamp, the interval reaching a device created later, the growing and capped back-off, the jitter, `is_active` after a killed loop, `connect()` replacing a dead device, the zombie-state guard and `shutdown()` re-raising its caller's cancellation.

Gates: `pre-commit`, `mypy` (218 files) and `pylint` (10.00/10) pass, `pytest` is 434 passed with only the seven failures this sandbox produces on the base branch too (`No library named udev`, path-planning subprocess timeouts).
