### PR TITLE
Let one capture loop serve all four camera devices

### DIFF
--- a/rosys/vision/capture_device.py
+++ b/rosys/vision/capture_device.py
@@ -1,0 +1,180 @@
+import abc
+import asyncio
+import enum
+import logging
+from typing import ClassVar
+
+from nicegui import background_tasks
+
+from .. import rosys
+from .reconnect import MAX_RECONNECT_INTERVAL, clamp_reconnect_interval, retry_delay
+
+
+class CaptureState(enum.Enum):
+    """State of a self-healing capture loop."""
+    CONNECTING = enum.auto()    # loop alive, opening the stream or waiting to reconnect
+    STREAMING = enum.auto()     # stream open and delivering frames
+    REFUSED = enum.auto()       # camera answered without a stream; loop backs off before trying again
+    STOPPED = enum.auto()       # shutdown requested; loop gives up
+
+
+class CaptureDevice(abc.ABC):
+    """A camera device that keeps its own capture session alive.
+
+    The loop runs one session at a time, waits `reconnect_interval` after a session that ended and
+    backs off while sessions keep failing, until `shutdown()` tears it down. Subclasses supply the
+    session in `_run_session()` and say how the camera is reached; everything about staying alive
+    lives here.
+    """
+
+    REFUSED_RECONNECT_INTERVAL: ClassVar[float] = MAX_RECONNECT_INTERVAL
+    """Wait between attempts while the camera answers something other than a stream.
+
+    It is reachable and has said no, so asking again sooner cannot change the answer, and a rejected
+    login or a rate limit only gets worse for being retried.
+    """
+
+    def __init__(self, *, name: str, log: logging.Logger, reconnect_interval: float = 3.0) -> None:
+        self._name = name
+        self.log = log
+        self.reconnect_interval = reconnect_interval
+        self._state = CaptureState.CONNECTING
+        self._capture_task: asyncio.Task | None = None
+        self._failed_attempts = 0
+        self._shutting_down = False
+
+    @property
+    def reconnect_interval(self) -> float:
+        return self._reconnect_interval
+
+    @reconnect_interval.setter
+    def reconnect_interval(self, interval: float) -> None:
+        self._reconnect_interval = clamp_reconnect_interval(interval, self.log)
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the camera is delivering frames right now."""
+        return self._state is CaptureState.STREAMING
+
+    @property
+    def is_active(self) -> bool:
+        """Whether the self-healing capture loop is alive (streaming or waiting to reconnect)."""
+        return self._capture_task is not None and not self._capture_task.done()
+
+    @property
+    def is_refused(self) -> bool:
+        """Whether the camera answered the last attempt with something other than a stream."""
+        return self._state is CaptureState.REFUSED
+
+    @abc.abstractmethod
+    async def _run_session(self) -> bool:
+        """Run one capture session until it ends. Returns whether at least one frame was delivered."""
+
+    async def _tear_down_session(self) -> None:
+        """Release whatever the running session holds, so `shutdown()` leaves nothing behind."""
+
+    def _retry_reason(self) -> str | None:
+        """Why the next attempt is being delayed, when the device knows better than "the stream ended"."""
+        return None
+
+    def _start_capture_task(self) -> None:
+        if self._shutting_down:
+            self.log.warning('[%s] not starting a capture loop while the device is being torn down', self._name)
+            return
+        if self.is_active:
+            self.log.warning('[%s] capture loop already running', self._name)
+            return
+        self._state = CaptureState.CONNECTING
+        self._capture_task = background_tasks.create(self._run_capture_task(), name=f'capture {self._name}')
+
+    def _keeps_running(self) -> bool:
+        """Whether the calling capture task should carry on.
+
+        A cancelled task can resume instead of ending, because the `rosys.run` helpers turn a
+        cancellation into a ``None`` result; after a restart `_capture_task` is a different task.
+        """
+        return self._state is not CaptureState.STOPPED and self._capture_task is asyncio.current_task()
+
+    def _set_state(self, state: CaptureState) -> None:
+        """Record the state of the calling capture task, ignoring a task that has been replaced.
+
+        Several tasks may share this attribute, so a task that no longer owns the loop must not
+        report its own progress, or its end, as the state of the loop that owns it.
+        """
+        if self._capture_task is not asyncio.current_task():
+            return
+        self._state = state
+
+    async def _run_capture_task(self) -> None:
+        try:
+            while self._keeps_running():
+                # every attempt starts fresh: an earlier rejection says nothing about this one
+                self._set_state(CaptureState.CONNECTING)
+                streamed = False
+                reason = 'stream ended'
+                try:
+                    streamed = await self._run_session()
+                except Exception as e:
+                    reason = self._describe_session_error(e)
+                finally:
+                    if self._state is CaptureState.STREAMING:
+                        self._set_state(CaptureState.CONNECTING)
+                self._failed_attempts = 0 if streamed else self._failed_attempts + 1
+                if not self._keeps_running():
+                    break
+                delay = self._retry_interval  # jittered, so read it once for both the log and the wait
+                self.log.info('[%s] %s; retrying in %.1f s', self._name, self._retry_reason() or reason, delay)
+                await self._wait_before_retry(delay)
+        finally:
+            if self._capture_task is asyncio.current_task():
+                self._capture_task = None
+
+    def _describe_session_error(self, error: Exception) -> str:
+        """Turn an exception ending a session into a reason, logging a traceback only for a surprise."""
+        self.log.exception('[%s] capture session failed', self._name)
+        return f'capture session failed: {error}'
+
+    @property
+    def _retry_interval(self) -> float:
+        """How long to wait before the next session; a refusal backs off further than a lost stream."""
+        if self.is_refused:
+            return self.REFUSED_RECONNECT_INTERVAL
+        return retry_delay(self.reconnect_interval, self._failed_attempts)
+
+    async def _wait_before_retry(self, delay: float) -> None:
+        await rosys.sleep(delay)
+
+    def restart_capture(self) -> None:
+        """Give up the running session and start a new one, e.g. after the camera moved."""
+        self._stop_capture_task()
+        self._start_capture_task()
+
+    def _stop_capture_task(self) -> None:
+        self._state = CaptureState.STOPPED
+        if self._capture_task is not None:
+            self._capture_task.cancel()
+            self._capture_task = None
+
+    async def shutdown(self) -> None:
+        """Stop the capture loop and release what the running session holds."""
+        self._state = CaptureState.STOPPED
+        self._shutting_down = True
+        try:
+            await self._tear_down_session()
+            await self._await_capture_task()
+        finally:
+            self._shutting_down = False
+
+    async def _await_capture_task(self) -> None:
+        task = self._capture_task
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=5)
+            except TimeoutError:
+                self.log.warning('[%s] timeout while waiting for capture task to cancel', self._name)
+            except asyncio.CancelledError:
+                if not task.cancelled():
+                    raise  # our own caller was cancelled, not the capture task
+        if self._capture_task is task:  # a restart may have started a new loop while we waited
+            self._capture_task = None

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -90,7 +90,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         """Tear down the device. The caller must hold `device_connection_lock`."""
         if self.device is None:
             return
-        self.device.shutdown()
+        await self.device.shutdown()
         self.device = None
 
     async def _handle_new_image_data(self, image_bytes: bytes, timestamp: float) -> None:

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -1,18 +1,13 @@
-import asyncio
-import enum
 import logging
-from asyncio import Task
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
-from typing import ClassVar
 
 import httpx
-from nicegui import background_tasks
 
 from ... import rosys
+from ..capture_device import CaptureDevice, CaptureState
 from ..http import new_async_client
 from ..image_processing import remove_exif
-from ..reconnect import MAX_RECONNECT_INTERVAL, clamp_reconnect_interval, retry_delay
 from .vendors import mac_to_url
 
 log = logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device')
@@ -20,14 +15,6 @@ log = logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device')
 
 class CameraAddressUnknown(Exception):
     """Raised when the camera settings are used before discovery has found an address."""
-
-
-class CaptureState(enum.Enum):
-    """State of the self-healing capture loop."""
-    CONNECTING = enum.auto()    # loop alive, opening the stream or waiting to reconnect
-    STREAMING = enum.auto()     # stream open and delivering frames
-    REFUSED = enum.auto()       # camera answered without a stream; loop backs off before trying again
-    STOPPED = enum.auto()       # shutdown requested; loop gives up
 
 
 def parse_capture_timestamp(part_header: bytes) -> float | None:
@@ -50,13 +37,7 @@ def parse_capture_timestamp(part_header: bytes) -> float | None:
         return None
 
 
-class MjpegDevice:
-    REFUSED_RECONNECT_INTERVAL: ClassVar[float] = MAX_RECONNECT_INTERVAL
-    '''Wait time between attempts while the camera answers something other than a stream.
-
-    It is reachable and has said no, so asking again sooner cannot change the answer, and a rejected
-    login or a rate limit only gets worse for being retried.
-    '''
+class MjpegDevice(CaptureDevice):
 
     def __init__(self, mac: str, ip: str | None = None, *,
                  index: int | None = None,
@@ -65,29 +46,18 @@ class MjpegDevice:
                  on_new_image_data: Callable[[bytes, float], Awaitable | None],
                  on_connect: Callable[[], Awaitable | None] | None = None,
                  reconnect_interval: float = 3.0) -> None:
+        super().__init__(name=mac,
+                         log=logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device.' + mac),
+                         reconnect_interval=reconnect_interval)
         self._mac = mac
         self._ip = ip
         self._index = index
-        self.log = logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device.' + self._mac)
-
         self._on_new_image_data = on_new_image_data
         self._on_connect = on_connect
-        self._capture_task: Task | None = None
         self._username = username
         self._password = password
-        self.reconnect_interval = reconnect_interval
-        self._state = CaptureState.CONNECTING
-        self._failed_attempts = 0
 
         self._start_capture_task()
-
-    @property
-    def reconnect_interval(self) -> float:
-        return self._reconnect_interval
-
-    @reconnect_interval.setter
-    def reconnect_interval(self, interval: float) -> None:
-        self._reconnect_interval = clamp_reconnect_interval(interval, self.log)
 
     @property
     def ip(self) -> str | None:
@@ -109,95 +79,21 @@ class MjpegDevice:
             return None
         return mac_to_url(self._mac, self._ip, index=self._index)
 
-    @property
-    def is_connected(self) -> bool:
-        """Whether the MJPEG stream is currently delivering frames."""
-        return self._state is CaptureState.STREAMING
+    def _retry_reason(self) -> str | None:
+        if self._ip is None:
+            return 'no address known'
+        if self.url is None:
+            return f'no stream URL for mac "{self._mac}"'
+        if self.is_refused:
+            return 'camera refused the stream'
+        return None
 
-    @property
-    def is_active(self) -> bool:
-        """Whether the self-healing capture loop is alive (streaming or waiting to reconnect)."""
-        return (self._capture_task is not None) and (not self._capture_task.done())
-
-    @property
-    def is_refused(self) -> bool:
-        """Whether the camera answered the last attempt with something other than a stream."""
-        return self._state is CaptureState.REFUSED
-
-    def _start_capture_task(self) -> None:
-        if self._capture_task is not None and not self._capture_task.done():
-            self.log.warning('tried to start a capture loop while already running one')
-            return
-        self._state = CaptureState.CONNECTING
-        self._capture_task = background_tasks.create(self._run_capture_task(), name=f'mjpeg capture {self._mac}')
-
-    def _keeps_running(self) -> bool:
-        """Whether the calling capture task should carry on.
-
-        A cancelled task can resume instead of ending, because the `rosys.run` helpers turn a
-        cancellation into a ``None`` result; after a restart `_capture_task` is a different task.
-        """
-        return self._state is not CaptureState.STOPPED and self._capture_task is asyncio.current_task()
-
-    def _set_state(self, state: CaptureState) -> None:
-        """Record the state of the calling capture task, ignoring a task that has been replaced.
-
-        Several tasks may share this attribute, so a task that no longer owns the loop must not
-        report its own progress, or its end, as the state of the loop that owns it.
-        """
-        if self._capture_task is not asyncio.current_task():
-            return
-        self._state = state
-
-    async def _run_capture_task(self) -> None:
-        """Keep a single MJPEG session alive, reconnecting after `reconnect_interval` when it ends.
-
-        Runs until `shutdown()` cancels the task.
-        """
-        try:
-            while self._keeps_running():
-                # every attempt starts fresh: an earlier rejection says nothing about this one
-                self._set_state(CaptureState.CONNECTING)
-                streamed = False
-                reason = 'stream ended'
-                try:
-                    streamed = await self._connect_and_stream_images()
-                except CameraAddressUnknown:
-                    reason = 'no address known yet'
-                except httpx.HTTPError as e:
-                    reason = f'cannot reach the camera: {e}'
-                except Exception:
-                    self.log.exception('capture session failed')
-                    reason = 'capture session failed'
-                self._failed_attempts = 0 if streamed else self._failed_attempts + 1
-                if not self._keeps_running():
-                    break
-                delay = self._retry_interval  # jittered, so read it once for both the log and the wait
-                if self._state is CaptureState.REFUSED:
-                    self.log.info('camera refused the stream; retrying in %.1f s', delay)
-                elif self._ip is None:
-                    self.log.debug('no address known; retrying in %.1f s', delay)
-                elif self.url is None:
-                    self.log.debug('no stream URL for mac "%s"; retrying in %.1f s', self._mac, delay)
-                else:
-                    self.log.info('%s; reconnecting in %.1f s', reason, delay)
-                # a new address restarts the whole task, so no need to cut this wait short
-                await rosys.sleep(delay)
-        finally:
-            if self._capture_task is asyncio.current_task():
-                self._capture_task = None
-
-    @property
-    def _retry_interval(self) -> float:
-        """How long to wait before the next session; a refusal backs off further than a lost stream."""
-        if self._state is CaptureState.REFUSED:
-            return self.REFUSED_RECONNECT_INTERVAL
-        return retry_delay(self.reconnect_interval, self._failed_attempts)
-
-    def restart_capture(self) -> None:
-        self.log.debug('Restarting capture task')
-        self.shutdown()
-        self._start_capture_task()
+    def _describe_session_error(self, error: Exception) -> str:
+        if isinstance(error, CameraAddressUnknown):
+            return 'no address known yet'
+        if isinstance(error, httpx.HTTPError):
+            return f'cannot reach the camera: {error}'
+        return super()._describe_session_error(error)
 
     async def _invoke_on_connect(self) -> None:
         """Notify the owner that a capture session has been (re-)established, e.g. to reapply camera parameters."""
@@ -251,7 +147,7 @@ class MjpegDevice:
         except httpx.ReadTimeout:
             self.log.warning('Connection to %s timed out', self.url)
 
-    async def _connect_and_stream_images(self) -> bool:
+    async def _run_session(self) -> bool:
         """Open a stream and read it until it ends. Returns whether at least one frame arrived."""
         streamed = False
         url = self.url
@@ -259,43 +155,32 @@ class MjpegDevice:
             return streamed
         self.log.debug('Starting capture task for %s', url)
 
-        try:
-            async with new_async_client() as client:
-                await self._prepare_stream()
-                async with open_stream(client, url, self._username, self._password) as response:
-                    if response is None:
-                        self._set_state(CaptureState.REFUSED)
+        async with new_async_client() as client:
+            await self._prepare_stream()
+            async with open_stream(client, url, self._username, self._password) as response:
+                if response is None:
+                    self._set_state(CaptureState.REFUSED)
+                    return streamed
+                self._set_state(CaptureState.STREAMING)
+                await self._invoke_on_connect()
+                async for image, capture_time in self._frame_reader(response):
+                    if self.url != url:
+                        self.log.info('stream settings changed; reopening the stream')
                         return streamed
-                    self._set_state(CaptureState.STREAMING)
-                    await self._invoke_on_connect()
-                    async for image, capture_time in self._frame_reader(response):
-                        if self.url != url:
-                            self.log.info('stream settings changed; reopening the stream')
-                            return streamed
-                        if not image:
-                            continue
-                        streamed = True
-                        try:
-                            timestamp = capture_time if capture_time is not None else rosys.time()
-                            callback_result = self._on_new_image_data(remove_exif(image), timestamp)
-                            if isinstance(callback_result, Awaitable):
-                                await callback_result
-                        except Exception as e:
-                            self.log.error('Error processing image: %s', e)
-                        if not self._keeps_running():
-                            return streamed
-        finally:
-            if self._state is CaptureState.STREAMING:
-                self._set_state(CaptureState.CONNECTING)
+                    if not image:
+                        continue
+                    streamed = True
+                    try:
+                        timestamp = capture_time if capture_time is not None else rosys.time()
+                        callback_result = self._on_new_image_data(remove_exif(image), timestamp)
+                        if isinstance(callback_result, Awaitable):
+                            await callback_result
+                    except Exception as e:
+                        self.log.error('Error processing image: %s', e)
+                    if not self._keeps_running():
+                        return streamed
         self.log.debug('capture session ended')
         return streamed
-
-    def shutdown(self) -> None:
-        self.log.debug('Shutting down capture task')
-        self._state = CaptureState.STOPPED
-        if self._capture_task is not None:
-            self._capture_task.cancel()
-            self._capture_task = None
 
     async def get_fps(self) -> int | None:
         return None

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -14,18 +14,18 @@ from enum import Enum
 from typing import ClassVar, Literal
 
 import numpy as np
-from nicegui import background_tasks
 
 from ... import rosys
 from ...vision.image import ImageArray
+from ..capture_device import CaptureDevice
 from ..openipc_zauberzeug_settings_interface import OpenIpcZauberzeugSettingsInterface
-from ..reconnect import MAX_RECONNECT_INTERVAL, clamp_reconnect_interval, retry_delay
+from ..reconnect import MAX_RECONNECT_INTERVAL
 from .arkvision_rtsp_interface import ArkVisionRtspInterface
 from .jovision_rtsp_interface import JovisionInterface
 from .vendors import VendorType, mac_to_url, mac_to_vendor
 
 
-class RtspDevice:
+class RtspDevice(CaptureDevice):
     UNAUTHORIZED_RECONNECT_INTERVAL: ClassVar[float] = MAX_RECONNECT_INTERVAL
     '''How long to wait between attempts while the camera rejects our credentials.
 
@@ -38,9 +38,11 @@ class RtspDevice:
                  on_connect: Callable[[], Awaitable | None] | None = None,
                  avdec: Literal['h264', 'h265'] = 'h264',
                  reconnect_interval: float = 3.0) -> None:
+        super().__init__(name=mac,
+                         log=logging.getLogger('rosys.vision.rtsp_camera.rtsp_device.' + mac),
+                         reconnect_interval=reconnect_interval)
         self._mac = mac
         self._ip = ip
-        self.log = logging.getLogger('rosys.vision.rtsp_camera.rtsp_device.' + self._mac)
 
         self._fps = fps
         self._substream = substream
@@ -48,15 +50,10 @@ class RtspDevice:
         self._on_connect = on_connect
         self._avdec: Literal['h264', 'h265'] = self._clamp_avdec(avdec)
 
-        self._capture_task: asyncio.Task | None = None
         self._capture_process: Process | None = None
         self._authorized: bool = True
         self._warned_about_missing_url: bool = False
         self._warned_about_missing_settings: bool = False
-        self.reconnect_interval = reconnect_interval
-        self._should_run: bool = True
-        self._shutting_down: bool = False
-        self._failed_attempts: int = 0
 
         self._settings_interface: JovisionInterface | ArkVisionRtspInterface | OpenIpcZauberzeugSettingsInterface | None = None
         self._bind_settings_interface()
@@ -83,22 +80,9 @@ class RtspDevice:
                                  self._mac, vendor_type)
 
     @property
-    def reconnect_interval(self) -> float:
-        return self._reconnect_interval
-
-    @reconnect_interval.setter
-    def reconnect_interval(self, interval: float) -> None:
-        self._reconnect_interval = clamp_reconnect_interval(interval, self.log)
-
-    @property
     def is_connected(self) -> bool:
         """Whether the gstreamer stream is currently running."""
         return self._capture_process is not None and self._capture_process.returncode is None
-
-    @property
-    def is_active(self) -> bool:
-        """Whether the self-healing capture loop is alive (streaming or waiting to reconnect)."""
-        return self._capture_task is not None and not self._capture_task.done()
 
     @property
     def authorized(self) -> bool:
@@ -129,87 +113,24 @@ class RtspDevice:
             return None
         return mac_to_url(self._mac, self._ip, self._substream)
 
-    async def shutdown(self) -> None:
-        self._should_run = False
-        self._shutting_down = True
-        try:
-            await self._shut_down()
-        finally:
-            self._shutting_down = False
-
-    async def _shut_down(self) -> None:
+    async def _tear_down_session(self) -> None:
         process = self._capture_process
-        if process is not None:
-            self.log.debug('[%s] Terminating gstreamer process', self._mac)
-            process.terminate()
-            try:
-                await asyncio.wait_for(process.wait(), timeout=5)
-            except TimeoutError:
-                self.log.warning('[%s] Timeout while waiting for gstreamer process to terminate', self._mac)
-            else:
-                self.log.debug('[%s] Successfully shut down process (code %s)',
-                               self._mac, process.returncode if process.returncode is not None else 'None')
-                if self._capture_process is process:
-                    self._capture_process = None
-        task = self._capture_task
-        if task is not None and not task.done():
-            self.log.debug('[%s] Cancelling gstreamer task', self._mac)
-            task.cancel()
-            try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=5)
-            except TimeoutError:
-                self.log.warning('[%s] Timeout while waiting for capture task to cancel', self._mac)
-                return
-            except asyncio.CancelledError:
-                if not task.cancelled():
-                    raise  # our own caller was cancelled, not the capture task
-                self.log.debug('[%s] Task was successfully cancelled', self._mac)
-            else:
-                self.log.debug('[%s] Task finished', self._mac)
-        if self._capture_task is task:  # a restart may have started a new loop while we waited
-            self._capture_task = None
+        if process is None:
+            return
+        self.log.debug('[%s] Terminating gstreamer process', self._mac)
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+        except TimeoutError:
+            self.log.warning('[%s] Timeout while waiting for gstreamer process to terminate', self._mac)
+        else:
+            if self._capture_process is process:
+                self._capture_process = None
 
     def _start_capture_task(self) -> None:
-        self.log.debug('[%s] Starting capture loop', self._mac)
-        if self._shutting_down:
-            self.log.warning('[%s] not starting a capture loop while the device is being torn down', self._mac)
-            return
-        if self._capture_task is not None and not self._capture_task.done():
-            self.log.warning('[%s] capture loop already running', self._mac)
-            return
-        self._should_run = True
-        self._capture_task = background_tasks.create(self._run_capture_task(), name=f'capture {self._mac}')
-
-    async def _run_capture_task(self) -> None:
-        """Keep a single gstreamer session alive, reconnecting after `reconnect_interval` when it ends.
-
-        Runs until `shutdown()` cancels the task.
-        """
-        try:
-            while self._should_run:
-                # every attempt starts fresh: an earlier rejection says nothing about this one
-                self._authorized = True
-                streamed = False
-                try:
-                    streamed = await self._run_gstreamer()
-                except Exception:
-                    self.log.exception('[%s] capture session failed', self._mac)
-                self._failed_attempts = 0 if streamed else self._failed_attempts + 1
-                if not self._should_run:
-                    break
-                if not self._authorized:
-                    self.log.info('[%s] credentials rejected; retrying in %.1f s',
-                                  self._mac, self.UNAUTHORIZED_RECONNECT_INTERVAL)
-                elif self._ip is None:
-                    self.log.debug('[%s] no address known; retrying in about %.1f s', self._mac, self._retry_interval)
-                elif self.url is None:
-                    self._warn_about_missing_url()
-                else:
-                    self.log.info('[%s] stream ended; reconnecting in about %.1f s', self._mac, self._retry_interval)
-                await self._wait_before_retry()
-        finally:
-            if self._capture_task is asyncio.current_task():
-                self._capture_task = None
+        # every attempt starts fresh: an earlier rejection says nothing about this one
+        self._authorized = True
+        super()._start_capture_task()
 
     def _warn_about_missing_url(self) -> None:
         """Warn once that no URL can be built for this camera.
@@ -223,21 +144,26 @@ class RtspDevice:
         self.log.warning('[%s] no RTSP URL known for vendor %s; this camera cannot be reached',
                          self._mac, mac_to_vendor(self._mac))
 
-    @property
-    def _retry_interval(self) -> float:
-        """How long to wait before the next session; grows while attempts keep failing."""
-        return retry_delay(self.reconnect_interval, self._failed_attempts)
+    def _retry_reason(self) -> str | None:
+        if not self._authorized:
+            return 'credentials rejected'
+        if self._ip is None:
+            return 'no address known'
+        if self.url is None:
+            self._warn_about_missing_url()
+            return 'no stream URL known'
+        return None
 
-    async def _wait_before_retry(self) -> None:
-        """Wait `reconnect_interval` before the next session, extending the wait while our login stays rejected.
+    async def _wait_before_retry(self, delay: float) -> None:
+        """Extend the wait while our login stays rejected.
 
         Waiting in chunks re-reads the verdict, so a new address ends a long wait early instead of
         holding on to a verdict that was about the previous address. The deadline bounds the whole
         wait, whatever the chunk size is.
         """
         deadline = rosys.time() + self.UNAUTHORIZED_RECONNECT_INTERVAL
-        await rosys.sleep(self._retry_interval)
-        while self._should_run and not self._authorized and rosys.time() < deadline:
+        await rosys.sleep(delay)
+        while self._keeps_running() and not self._authorized and rosys.time() < deadline:
             await rosys.sleep(self._retry_interval)
 
     async def restart_gstreamer(self) -> None:
@@ -252,7 +178,7 @@ class RtspDevice:
         if isinstance(result, Awaitable):
             await result
 
-    async def _run_gstreamer(self) -> bool:
+    async def _run_session(self) -> bool:
         """Run a gstreamer session until it ends. Returns whether at least one frame arrived."""
         streamed = False
         if self.is_connected:

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -69,7 +69,7 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
         """Tear down the device. The caller must hold `device_connection_lock`."""
         if self.device is None:
             return
-        self.device.shutdown()
+        await self.device.shutdown()
         self.device = None
 
     def _set_color(self, value: str) -> None:

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -1,3 +1,4 @@
+import logging
 import random
 from collections.abc import Awaitable, Callable
 
@@ -7,10 +8,14 @@ import PIL.ImageDraw
 
 from ... import rosys
 from ...geometry import Point
+from ..capture_device import CaptureDevice, CaptureState
 from ..image import Image, ImageSize
 
+MEAN_TIME_TO_FAILURE = 30.0
+"""Average seconds a simulated stream survives while `simulate_failing` is set."""
 
-class SimulatedDevice:
+
+class SimulatedDevice(CaptureDevice):
 
     def __init__(self,
                  id: str,  # pylint: disable=redefined-builtin
@@ -22,53 +27,40 @@ class SimulatedDevice:
                  fps: float = 30.0,
                  reconnect_interval: float = 3.0,
                  simulate_failing: bool = False) -> None:
+        super().__init__(name=id,
+                         log=logging.getLogger('rosys.vision.simulated_camera.simulated_device.' + id),
+                         reconnect_interval=reconnect_interval)
         self._id = id
         self._size = size
         self.color = color
         self._on_new_image = on_new_image
         self._on_connect = on_connect
-        self.reconnect_interval = reconnect_interval
         self.simulate_failing = simulate_failing
-        self._connected: bool = True
-        self._last_connect_time: float = rosys.time()
-        self._disconnect_time: float | None = None
+        self._frame_interval = 1.0 / fps
 
-        self._repeater = rosys.on_repeat(self._step, interval=1.0 / fps)
-
-    @property
-    def is_connected(self) -> bool:
-        return self._connected
-
-    @property
-    def is_active(self) -> bool:
-        """Whether the self-healing loop is alive (streaming or waiting to reconnect)."""
-        return self._repeater.running
+        self._start_capture_task()
+        self._state = CaptureState.STREAMING  # a simulated camera is reachable the moment it exists
 
     def disconnect(self) -> None:
         """Simulate a connection loss (e.g. a bad cable); the device reconnects itself after `reconnect_interval`."""
-        if not self._connected:
-            return
-        self._connected = False
-        self._disconnect_time = rosys.time()
+        if self._state is CaptureState.STREAMING:
+            self._state = CaptureState.CONNECTING
 
-    def shutdown(self) -> None:
-        """Stop the image loop; the device no longer reconnects on its own."""
-        self._repeater.stop()
-
-    async def _step(self) -> None:
-        if not self._connected:
-            assert self._disconnect_time is not None
-            if rosys.time() - self._disconnect_time >= self.reconnect_interval:
-                self._connected = True
-                self._last_connect_time = rosys.time()
-                self._disconnect_time = None
-                await self._invoke_on_connect()
-            return
-        if self.simulate_failing and \
-                random.random() < (rosys.time() - self._last_connect_time) / 30.0 * self._repeater.interval:
-            self.disconnect()
-            return
-        await self._create_image()
+    async def _run_session(self) -> bool:
+        streamed = False
+        self._set_state(CaptureState.STREAMING)
+        await self._invoke_on_connect()
+        session_start = rosys.time()
+        while self._keeps_running() and self.is_connected:
+            await rosys.sleep(self._frame_interval)
+            if not self.is_connected:
+                break
+            if self.simulate_failing and \
+                    random.random() < (rosys.time() - session_start) / MEAN_TIME_TO_FAILURE * self._frame_interval:
+                return streamed
+            await self._create_image()
+            streamed = True
+        return streamed
 
     async def _create_image(self) -> None:
         timestamp = rosys.time()
@@ -90,10 +82,10 @@ class SimulatedDevice:
             await result
 
     def set_fps(self, fps: float) -> None:
-        self._repeater.interval = 1.0 / fps
+        self._frame_interval = 1.0 / fps
 
     def get_fps(self) -> float:
-        return 1.0 / self._repeater.interval
+        return 1.0 / self._frame_interval
 
 
 def _create_image_data(id: str, size: ImageSize, color: str, timestamp: float) -> Image:  # pylint: disable=redefined-builtin

--- a/rosys/vision/usb_camera/usb_device.py
+++ b/rosys/vision/usb_camera/usb_device.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import re
 from collections.abc import Awaitable, Callable
@@ -7,7 +6,7 @@ import cv2
 import numpy as np
 
 from ... import rosys
-from ..reconnect import clamp_reconnect_interval, retry_delay
+from ..capture_device import CaptureDevice
 from .usb_camera_scanner import device_nodes_from_uid
 
 MJPG = cv2.VideoWriter.fourcc(*'MJPG')
@@ -25,7 +24,7 @@ def to_bytes(image: np.ndarray) -> bytes:
     return image.tobytes()
 
 
-class UsbDevice:
+class UsbDevice(CaptureDevice):
     MAX_READ_FAILURES = 10
     """Number of consecutive failed reads before the capture is considered lost (e.g. unplugged cable)."""
 
@@ -33,25 +32,22 @@ class UsbDevice:
                  on_new_image_data: Callable[[np.ndarray | bytes, float], Awaitable | None],
                  on_connect: Callable[[], Awaitable | None] | None = None,
                  reconnect_interval: float = 3.0) -> None:
+        super().__init__(name=uid,
+                         log=logging.getLogger('rosys.vision.usb_camera.usb_device.' + uid),
+                         reconnect_interval=reconnect_interval)
         self.uid = uid
-        self.log = logging.getLogger('rosys.vision.usb_camera.usb_device.' + uid)
         self._device_node: str | None = None
         self._capture: cv2.VideoCapture | None = None
         self._on_new_image_data = on_new_image_data
         self._on_connect = on_connect
-        self.reconnect_interval = reconnect_interval
         self._exposure_min: int = 0
         self._exposure_max: int = 0
         self._exposure_default: int = 0
         self._has_manual_exposure: bool = False
         self._video_formats: set[str] = set()
         self._image_is_jpg: bool = False
-        self._should_run: bool = True
-        self._shutting_down: bool = False
         self._read_failures: int = 0
-        self._capture_task: asyncio.Task | None = None
         self._unavailable_node: str | None = None
-        self._failed_attempts: int = 0
 
         self._start_capture_task()
 
@@ -59,24 +55,6 @@ class UsbDevice:
     def is_connected(self) -> bool:
         """Whether a working capture is currently open (False while a lost capture is being reconnected)."""
         return self._capture is not None
-
-    @property
-    def is_active(self) -> bool:
-        """Whether the self-healing capture loop is alive (capturing or waiting to reconnect)."""
-        return self._capture_task is not None and not self._capture_task.done()
-
-    @property
-    def reconnect_interval(self) -> float:
-        return self._reconnect_interval
-
-    @reconnect_interval.setter
-    def reconnect_interval(self, interval: float) -> None:
-        self._reconnect_interval = clamp_reconnect_interval(interval, self.log)
-
-    @property
-    def _retry_interval(self) -> float:
-        """How long to wait before the next session; grows while attempts keep failing."""
-        return retry_delay(self.reconnect_interval, self._failed_attempts)
 
     @property
     def video_formats(self) -> set[str]:
@@ -97,49 +75,13 @@ class UsbDevice:
             return None
         return capture
 
-    def _start_capture_task(self) -> None:
-        if self._shutting_down:
-            self.log.warning('[%s] not starting a capture loop while the device is being torn down', self.uid)
-            return
-        if self._capture_task is not None and not self._capture_task.done():
-            self.log.warning('[%s] capture loop already running', self.uid)
-            return
-        self._should_run = True
-        self._capture_task = rosys.background_tasks.create(
-            self._run_capture_task(), name=f'usb capture {self.uid}')
-
-    async def _run_capture_task(self) -> None:
-        """Keep a single capture session alive, reconnecting after `reconnect_interval` when it ends.
-
-        Runs until `shutdown()` cancels the task.
-        """
-        try:
-            while self._should_run:
-                streamed = False
-                try:
-                    streamed = await self._run_capture_session()
-                except Exception:
-                    self.log.exception('[%s] capture session failed', self.uid)
-                self._failed_attempts = 0 if streamed else self._failed_attempts + 1
-                if not self._should_run:
-                    break
-                delay = self._retry_interval  # jittered, so read it once for both the log and the wait
-                if streamed:
-                    self.log.info('[%s] capture ended; reconnecting in %.1f s', self.uid, delay)
-                else:
-                    self.log.debug('[%s] no capture; retrying in %.1f s', self.uid, delay)
-                await rosys.sleep(delay)
-        finally:
-            if self._capture_task is asyncio.current_task():
-                self._capture_task = None
-
-    async def _run_capture_session(self) -> bool:
+    async def _run_session(self) -> bool:
         """Read frames until the capture is lost, then release it.
 
         Returns whether at least one frame was delivered.
         """
         streamed = False
-        while self._should_run:
+        while self._keeps_running():
             if self._capture is None or not self._capture.isOpened():
                 await self._open_capture()
                 if self._capture is None:
@@ -211,27 +153,7 @@ class UsbDevice:
             self._capture = None
         self._device_node = None
 
-    async def shutdown(self) -> None:
-        self._should_run = False
-        self._shutting_down = True
-        try:
-            await self._shut_down()
-        finally:
-            self._shutting_down = False
-
-    async def _shut_down(self) -> None:
-        task = self._capture_task
-        if task is not None and not task.done():
-            task.cancel()
-            try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=5)
-            except TimeoutError:
-                self.log.warning('[%s] timeout while waiting for capture task to cancel', self.uid)
-            except asyncio.CancelledError:
-                if not task.cancelled():
-                    raise  # our own caller was cancelled, not the capture task
-        if self._capture_task is task:  # a restart may have started a new loop while we waited
-            self._capture_task = None
+    async def _tear_down_session(self) -> None:
         await self._release()
 
     async def load_value_ranges(self) -> None:

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -2,7 +2,6 @@ import asyncio
 import gc
 import logging
 import weakref
-from collections.abc import Awaitable
 from contextlib import asynccontextmanager, suppress
 from unittest.mock import AsyncMock, patch
 
@@ -63,12 +62,12 @@ async def _no_stream(self) -> None:
 
 def stalled_mjpeg_stream():
     """Keep an `MjpegDevice` in a single capture session without touching the network."""
-    return patch.object(MjpegDevice, '_connect_and_stream_images', _no_stream)
+    return patch.object(MjpegDevice, '_run_session', _no_stream)
 
 
 def stalled_rtsp_stream():
     """Keep an `RtspDevice` in a single capture session without spawning gstreamer."""
-    return patch.object(RtspDevice, '_run_gstreamer', _no_stream)
+    return patch.object(RtspDevice, '_run_session', _no_stream)
 
 
 class FakeGstreamerProcess:
@@ -96,7 +95,7 @@ async def _connected_rtsp_stream(self) -> None:
 
 def connected_rtsp_stream():
     """Keep an `RtspDevice` in a single *connected* capture session without spawning gstreamer."""
-    return patch.object(RtspDevice, '_run_gstreamer', _connected_rtsp_stream)
+    return patch.object(RtspDevice, '_run_session', _connected_rtsp_stream)
 
 
 async def forward_until(condition, *, step: float = 0.3, real_step: float = 0.05,
@@ -130,13 +129,6 @@ def vision_log(rosys_integration: None, caplog: pytest.LogCaptureFixture):
     logger.addHandler(caplog.handler)
     yield caplog
     logger.removeHandler(caplog.handler)
-
-
-async def shutdown_device(device) -> None:
-    """Shut a device down, whichever of the two shapes its `shutdown` has."""
-    result = device.shutdown()
-    if isinstance(result, Awaitable):
-        await result
 
 
 async def wait_in_real_time(condition, *, step: float = 0.02, attempts: int = 200,
@@ -265,7 +257,7 @@ async def test_mjpeg_device_reconnects_after_stream_drops(rosys_integration):
         await forward_until(lambda: len(frames) >= 3, attempts=60,
                             message='no frames received across reconnects')
 
-        device.shutdown()
+        await device.shutdown()
         await asyncio.sleep(0.1)
         assert not device.is_connected
         connections_at_shutdown = server.connections
@@ -274,7 +266,7 @@ async def test_mjpeg_device_reconnects_after_stream_drops(rosys_integration):
             await asyncio.sleep(0.05)
         assert server.connections == connections_at_shutdown, 'device kept reconnecting after shutdown'
     finally:
-        device.shutdown()
+        await device.shutdown()
         await server.stop()
 
 
@@ -286,7 +278,7 @@ async def test_rtsp_device_reconnects_until_shutdown(rosys_integration):
         sessions += 1
         await rosys.sleep(0.05)  # simulate a short-lived stream that ends on its own
 
-    with patch.object(RtspDevice, '_run_gstreamer', fake_gstreamer):
+    with patch.object(RtspDevice, '_run_session', fake_gstreamer):
         device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
                             on_new_image_data=lambda array, timestamp: None,
                             reconnect_interval=0.2)
@@ -545,7 +537,7 @@ async def test_rtsp_is_active_distinct_from_is_connected(rosys_integration):
         sessions += 1
         await rosys.sleep(0.05)
 
-    with patch.object(RtspDevice, '_run_gstreamer', fake_gstreamer):
+    with patch.object(RtspDevice, '_run_session', fake_gstreamer):
         device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
                             on_new_image_data=lambda array, timestamp: None,
                             reconnect_interval=0.2)
@@ -584,7 +576,7 @@ async def test_mjpeg_device_backs_off_after_401(rosys_integration):
         await forward_until(lambda: server.connections > connections_after_401, step=0.5, attempts=40,
                             message='expected the device to retry once the back-off elapsed')
     finally:
-        device.shutdown()
+        await device.shutdown()
         await server.stop()
 
 
@@ -607,7 +599,7 @@ async def test_mjpeg_device_backs_off_after_any_refusal(rosys_integration, statu
         assert server.connections == connections_after_refusal, \
             f'expected the device to throttle its retries after a {status} response'
     finally:
-        device.shutdown()
+        await device.shutdown()
         await server.stop()
 
 
@@ -621,7 +613,7 @@ async def test_mjpeg_device_reports_an_unreachable_camera_without_a_traceback(vi
             'expected no traceback for a camera that is simply not there'
         )
     finally:
-        device.shutdown()
+        await device.shutdown()
 
 
 async def test_mjpeg_device_retries_at_a_new_address_despite_back_off(rosys_integration):
@@ -641,7 +633,7 @@ async def test_mjpeg_device_retries_at_a_new_address_despite_back_off(rosys_inte
         await forward_until(lambda: new_server.connections >= 1, step=0.2,
                             message='expected an address change to end the back-off')
     finally:
-        device.shutdown()
+        await device.shutdown()
         await rejecting_server.stop()
         await new_server.stop()
 
@@ -654,7 +646,7 @@ async def test_rtsp_device_backs_off_with_a_zero_reconnect_interval(rosys_integr
         sessions += 1
         self._authorized = False  # pylint: disable=protected-access
 
-    with patch.object(RtspDevice, '_run_gstreamer', unauthorized_gstreamer):
+    with patch.object(RtspDevice, '_run_session', unauthorized_gstreamer):
         device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
                             on_new_image_data=lambda array, timestamp: None,
                             reconnect_interval=0.0)
@@ -686,7 +678,7 @@ async def test_devices_never_retry_without_a_delay(vision_log, interval: float):
         assert len(complaints) == len(devices), 'expected every device to report the interval it cannot honor'
     finally:
         for device in devices:
-            await shutdown_device(device)
+            await device.shutdown()
 
 
 async def test_a_reconnect_interval_that_can_be_honored_is_kept(vision_log):
@@ -699,7 +691,7 @@ async def test_a_reconnect_interval_that_can_be_honored_is_kept(vision_log):
         assert device.reconnect_interval == MIN_RECONNECT_INTERVAL, 'expected a later assignment to be held too'
         assert [record for record in vision_log.records if 'too short' in record.getMessage()]
     finally:
-        device.shutdown()
+        await device.shutdown()
 
 
 async def test_rtsp_device_backs_off_after_rejected_login(rosys_integration):
@@ -710,7 +702,7 @@ async def test_rtsp_device_backs_off_after_rejected_login(rosys_integration):
         sessions += 1
         self._authorized = False  # pylint: disable=protected-access
 
-    with patch.object(RtspDevice, '_run_gstreamer', unauthorized_gstreamer):
+    with patch.object(RtspDevice, '_run_session', unauthorized_gstreamer):
         device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
                             on_new_image_data=lambda array, timestamp: None,
                             reconnect_interval=0.2)
@@ -751,7 +743,7 @@ async def test_mjpeg_device_invokes_on_connect_per_session(rosys_integration):
         await forward_until(lambda: connect_calls >= 3,
                             message='on_connect was not invoked for each new stream')
     finally:
-        device.shutdown()
+        await device.shutdown()
         await server.stop()
 
 
@@ -781,7 +773,7 @@ async def test_axis_camera_applies_parameters_without_restarting_its_own_session
         await rosys.sleep(60.0)
 
     camera = MjpegCamera(id=AXIS_MAC, ip='192.168.0.5', fps=12, connect_after_init=False)
-    with patch.object(MjpegDevice, '_connect_and_stream_images', stream):
+    with patch.object(MjpegDevice, '_run_session', stream):
         await camera.connect()
         try:
             await forward_until(lambda: sessions >= 1, message='expected a capture session to start')
@@ -817,7 +809,7 @@ async def test_mjpeg_device_reopens_the_stream_when_its_url_changes(rosys_integr
                                 message='expected the stream to reopen after the settings changed')
             assert 'fps=6' in opened_urls[0] and 'fps=12' in opened_urls[1]
         finally:
-            device.shutdown()
+            await device.shutdown()
 
 
 async def test_mjpeg_device_stops_streaming_when_shut_down_during_a_callback(rosys_integration):
@@ -834,15 +826,15 @@ async def test_mjpeg_device_stops_streaming_when_shut_down_during_a_callback(ros
         device = MjpegDevice(GOODCAM_MAC, f'127.0.0.1:{server.port}', on_new_image_data=handle_image)
         try:
             await wait_in_real_time(decode.started.is_set, message='no frame reached the callback')
-            device.shutdown()
+            await device.shutdown()
             await wait_in_real_time(decode.finished.is_set, message='the stalled callback never returned')
             await asyncio.sleep(0.05)  # let the frame that was in flight finish
             frames_after_shutdown = len(frames)
             await asyncio.sleep(0.15)  # a surviving session would deliver several more frames
             assert len(frames) == frames_after_shutdown, 'the capture task kept streaming after shutdown'
-            assert not live_capture_tasks(f'mjpeg capture {GOODCAM_MAC}'), 'the capture task survived shutdown'
+            assert not live_capture_tasks(f'capture {GOODCAM_MAC}'), 'the capture task survived shutdown'
         finally:
-            await cancel_leftover_loops(f'mjpeg capture {GOODCAM_MAC}')
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')
             await server.stop()
 
 
@@ -858,11 +850,11 @@ async def test_mjpeg_device_keeps_one_capture_loop_across_an_address_change(rosy
             device.ip = '127.0.0.1:1'  # a provider rebinds the camera to another address
             await wait_in_real_time(decode.finished.is_set, message='the stalled callback never returned')
             await asyncio.sleep(0.1)
-            assert len(live_capture_tasks(f'mjpeg capture {GOODCAM_MAC}')) == 1, \
+            assert len(live_capture_tasks(f'capture {GOODCAM_MAC}')) == 1, \
                 'the replaced capture loop is still running'
         finally:
-            device.shutdown()
-            await cancel_leftover_loops(f'mjpeg capture {GOODCAM_MAC}')
+            await device.shutdown()
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')
             await server.stop()
 
 
@@ -890,8 +882,8 @@ async def test_rtsp_device_keeps_one_capture_loop_across_concurrent_restarts(ros
 
 async def test_usb_camera_keeps_one_capture_loop_across_concurrent_reconnects(rosys_integration):
     camera_id = 'usb_reconnect_race'
-    task_name = f'usb capture {camera_id}'
-    with patch.object(UsbDevice, '_run_capture_session', _stub_usb_session):
+    task_name = f'capture {camera_id}'
+    with patch.object(UsbDevice, '_run_session', _stub_usb_session):
         camera = UsbCamera(id=camera_id, connect_after_init=False)
         try:
             await camera.connect()
@@ -962,7 +954,7 @@ async def test_devices_do_not_leak_shutdown_handlers(rosys_integration):
             'expected direct device construction to avoid registering shutdown handlers'
         )
     finally:
-        device.shutdown()
+        await device.shutdown()
 
     handlers_before_camera = len(rosys_core.shutdown_handlers)
     camera = SimulatedCamera(id='sim_camera_shutdown_hook', connect_after_init=False)
@@ -1023,7 +1015,7 @@ async def test_axis_device_derives_url_from_its_settings(rosys_integration):
             assert 'fps=12' in device.url and 'resolution=1280x720' in device.url and 'mirror=1' in device.url
             assert device.url.count('fps=') == 1, 'expected the URL to be rebuilt rather than appended to'
         finally:
-            device.shutdown()
+            await device.shutdown()
 
 
 async def test_axis_device_url_follows_address_and_keeps_settings(rosys_integration):
@@ -1039,7 +1031,7 @@ async def test_axis_device_url_follows_address_and_keeps_settings(rosys_integrat
             assert 'fps=12' in device.url, 'expected the stream settings to survive the address change'
             assert device.is_active
         finally:
-            device.shutdown()
+            await device.shutdown()
 
 
 async def test_mjpeg_camera_is_active_without_known_address(rosys_integration):
@@ -1296,7 +1288,7 @@ async def test_devices_back_off_while_attempts_keep_failing(rosys_integration):
         assert device._retry_interval > 0.2 * (1 + RECONNECT_JITTER)  # pylint: disable=protected-access
         assert device._retry_interval <= MAX_RECONNECT_INTERVAL  # pylint: disable=protected-access
     finally:
-        device.shutdown()
+        await device.shutdown()
 
 
 async def test_camera_is_not_active_once_its_capture_loop_died(rosys_integration):
@@ -1307,7 +1299,7 @@ async def test_camera_is_not_active_once_its_capture_loop_died(rosys_integration
         try:
             assert camera.is_active
             assert camera.device is not None
-            await cancel_leftover_loops(f'mjpeg capture {GOODCAM_MAC}')  # as a crashing loop would
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')  # as a crashing loop would
             assert not camera.is_active, 'expected a camera with a dead capture loop to report is_active False'
             assert not camera.is_reconnecting, 'expected no reconnect state without a loop that could reconnect'
         finally:
@@ -1320,7 +1312,7 @@ async def test_camera_connect_replaces_a_device_whose_loop_died(rosys_integratio
         await camera.connect()
         try:
             dead_device = camera.device
-            await cancel_leftover_loops(f'mjpeg capture {GOODCAM_MAC}')
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')
 
             await camera.connect()
             assert camera.device is not dead_device, 'expected connect() to replace the dead device'
@@ -1337,7 +1329,7 @@ async def test_mjpeg_device_state_survives_a_dying_zombie_session(rosys_integrat
         device._set_state(CaptureState.CONNECTING)  # pylint: disable=protected-access
         assert device.is_connected, 'expected a foreign task not to change the state of the live loop'
     finally:
-        device.shutdown()
+        await device.shutdown()
 
 
 async def test_rtsp_shutdown_reraises_a_cancellation_of_its_caller(rosys_integration):
@@ -1389,7 +1381,7 @@ async def test_mjpeg_device_factory_builds_the_vendor_device(rosys_integration, 
             assert type(device) is expected_type
             assert device.reconnect_interval == 4.0, 'expected the factory to forward the reconnect interval'
         finally:
-            device.shutdown()
+            await device.shutdown()
 
 
 async def test_mjpeg_device_factory_warns_about_an_unknown_vendor(rosys_integration, vision_log):
@@ -1400,7 +1392,7 @@ async def test_mjpeg_device_factory_warns_about_an_unknown_vendor(rosys_integrat
             assert [record for record in vision_log.records if 'no stream URL known' in record.getMessage()], \
                 'expected the factory to say that this camera cannot be reached'
         finally:
-            device.shutdown()
+            await device.shutdown()
 
 
 def test_settings_of_a_camera_without_an_address_raise_a_domain_error():
@@ -1415,7 +1407,7 @@ async def test_mjpeg_device_reports_a_missing_address_without_a_traceback(rosys_
     async def unknown_address(self) -> None:
         raise CameraAddressUnknown('no address')
 
-    with patch.object(MjpegDevice, '_connect_and_stream_images', unknown_address):
+    with patch.object(MjpegDevice, '_run_session', unknown_address):
         device = MjpegDevice(GOODCAM_MAC, '127.0.0.1:1', on_new_image_data=lambda data, timestamp: None,
                              reconnect_interval=0.2)
         try:
@@ -1426,7 +1418,7 @@ async def test_mjpeg_device_reports_a_missing_address_without_a_traceback(rosys_
             assert not [record for record in vision_log.records if record.exc_info], \
                 'expected a missing address to be reported without a traceback'
         finally:
-            device.shutdown()
+            await device.shutdown()
 
 
 async def test_a_device_being_torn_down_is_not_restarted(rosys_integration):
@@ -1443,3 +1435,25 @@ async def test_a_device_being_torn_down_is_not_restarted(rosys_integration):
 
         await asyncio.gather(device.shutdown(), restart_while_shutting_down())
         assert not device.is_active, 'expected the device to stay down while it was being torn down'
+
+
+async def test_every_device_backs_off_the_same_way(rosys_integration):
+    """The simulation twin must back off like the hardware devices, or it cannot stand in for them."""
+    devices = [
+        MjpegDevice(GOODCAM_MAC, on_new_image_data=lambda data, timestamp: None, reconnect_interval=0.2),
+        RtspDevice(GOODCAM_MAC, substream=0, fps=5,
+                   on_new_image_data=lambda data, timestamp: None, reconnect_interval=0.2),
+        UsbDevice('no-such-camera', on_new_image_data=lambda data, timestamp: None, reconnect_interval=0.2),
+        SimulatedDevice(id='sim', size=ImageSize(width=64, height=48),
+                        on_new_image=lambda image: None, reconnect_interval=0.2),
+    ]
+    try:
+        for device in devices:
+            # pylint: disable=protected-access
+            assert device._retry_interval <= 0.2 * (1 + RECONNECT_JITTER), type(device).__name__
+            device._failed_attempts = 20
+            assert device._retry_interval > 0.2 * (1 + RECONNECT_JITTER), type(device).__name__
+            assert device._retry_interval <= MAX_RECONNECT_INTERVAL, type(device).__name__
+    finally:
+        for device in devices:
+            await device.shutdown()


### PR DESCRIPTION
### Motivation

Follow-up to the review of #423 (finding RV-1d8f9460, with RV-5f4d079b and RV-9921748d folded in), split out because it might be a bigger change.

Each of the four devices carried its own copy of the same capture loop: run a session, count attempts that delivered no frame, log a reason, wait, clear the task handle. The copies had drifted:

- only `MjpegDevice` could tell a refusal from a lost stream (`CaptureState.REFUSED`),
- only `RtspDevice` could cut a wait short when a rejected login turned out to be about the previous address,
- the `UsbDevice` copy counted an *opened capture* as a delivered frame — the bug fixed in 4f9d25a1 on the base branch,
- `SimulatedDevice` was not a copy at all: it ran on `on_repeat` with a hand-written deadline, so the twin reconnected on a fixed interval with neither back-off nor jitter — the very behaviour it exists to stand in for.

Every fix had to be remembered three times, and no test could hold the devices to one behaviour because they did not share one.

### Implementation

`rosys/vision/capture_device.py` adds `CaptureDevice`, which owns the loop, the back-off, the task handle and the lifecycle, on the `CaptureState` enum `MjpegDevice` already used. A device supplies:

| Hook | Required | What it does |
|---|---|---|
| `_run_session()` | yes | run one session, return whether a frame was delivered |
| `_tear_down_session()` | no | release what the running session holds |
| `_retry_reason()` | no | why the wait is happening, when the device knows better than "stream ended" |
| `_describe_session_error()` | no | turn an expected exception into a reason instead of a traceback |

All four devices now inherit it, including `SimulatedDevice`, so the twin gets the same growing, jittered back-off. `test_every_device_backs_off_the_same_way` holds all four to it.

`shutdown()` is async everywhere now. That is what callers already expected — the two synchronous ones cancelled the task and returned without waiting for it to end, which is why the tests needed a `shutdown_device()` helper to paper over the two shapes. The helper is gone.

**Net: -81 lines**, and each device file shrank:

```
usb_device.py        332 -> 254
rtsp_device.py       416 -> 342
mjpeg_device.py      351 -> 236
simulated_device.py  119 -> 111
capture_device.py      0 -> 180  (new)
```

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

### Notes for the reviewer

Targets `device-level-camera-reconnect`, not `main`, so it reads as a diff on top of the fixes from the review round.

Behaviour that is deliberately *not* uniform, because it is genuinely per-device:

- `RtspDevice.is_connected` still follows the gstreamer process rather than `CaptureState`, since the process is the honest answer there.
- `RtspDevice` keeps its chunked `_wait_before_retry()` override for the unauthorized case.
- `SimulatedDevice` sets `STREAMING` in its constructor: a simulated camera is reachable the moment it exists, and `test_simulated_camera` asserts `is_connected` right after `connect()`.

Gates: `pre-commit`, `mypy` (220 files), `pylint` (10.00/10), `pytest` 454 passed with only the seven failures this sandbox produces on the base branch too (`No library named udev`, path-planning subprocess timeouts).

One thing worth a second opinion: `_retry_reason()` returning `str | None` with the base filling in `'stream ended'` is the part I like least. The alternative — every device always returning a reason — duplicates the common case four times. Happy to change it if you prefer that.

[※](https://zauberzeug.github.io/colophon/#m=claude-opus-5&t=Refactor%20designed%20and%20implemented%20by%20the%20agent%3B%20the%20reviewer%20set%20the%20direction%20and%20the%20scope.)
