### PR TITLE
Add Intrinsics.scale and Intrinsics.crop for derived camera streams

### DIFF
--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -227,27 +227,6 @@ class Calibration:
 
         return Calibration(intrinsics=intrinsics, extrinsics=extrinsics)
 
-    def scale(self, size: ImageSize) -> Calibration:
-        """Derive the calibration for an image that is scaled to ``size``.
-
-        See :meth:`Intrinsics.scale`. The extrinsics are copied unchanged, because scaling the image does not move the camera.
-
-        :param size: the size the image is scaled to (same field of view)
-        :return: a new independent calibration matching the scaled image
-        """
-        return Calibration(intrinsics=self.intrinsics.scale(size), extrinsics=deepcopy(self.extrinsics))
-
-    def crop(self, crop: Rectangle) -> Calibration:
-        """Derive the calibration for an image that is cropped to ``crop``.
-
-        See :meth:`Intrinsics.crop`. The extrinsics are copied unchanged, because cropping the image does not move the camera.
-
-        :param crop: the region cut out of the image, in pixel coordinates
-        :return: a new independent calibration matching the cropped image
-        :raises ValueError: if the crop has fractional coordinates or reaches beyond the image
-        """
-        return Calibration(intrinsics=self.intrinsics.crop(crop), extrinsics=deepcopy(self.extrinsics))
-
     @overload
     def project_to_image(self, coordinates: Point3d) -> Point | None:
         """Project a 3D point to the image plane.

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -66,6 +66,54 @@ class Intrinsics:
             size=ImageSize(width=width, height=height),
         )
 
+    def scale(self, size: ImageSize) -> Intrinsics:
+        """Derive the intrinsics for an image that is scaled to ``size``.
+
+        Assumes the original and the scaled image share the same field of view, so the camera matrix scales with
+        the resolution while the distortion coefficients (defined in normalized coordinates) stay valid.
+
+        :param size: the size the image is scaled to (same field of view)
+        :return: new independent intrinsics matching the scaled image
+        """
+        scale_x = size.width / self.size.width
+        scale_y = size.height / self.size.height
+        matrix = self.matrix
+        scaled_matrix = [
+            [matrix[0][0] * scale_x, matrix[0][1] * scale_x, matrix[0][2] * scale_x],
+            [0.0, matrix[1][1] * scale_y, matrix[1][2] * scale_y],
+            [0.0, 0.0, 1.0],
+        ]
+        return Intrinsics(model=self.model,
+                          matrix=scaled_matrix,
+                          distortion=list(self.distortion),
+                          omnidir_params=deepcopy(self.omnidir_params),
+                          size=ImageSize(width=size.width, height=size.height))
+
+    def crop(self, crop: Rectangle) -> Intrinsics:
+        """Derive the intrinsics for an image that is cropped to ``crop``.
+
+        The crop only shifts the principal point; the distortion coefficients stay valid.
+
+        :param crop: the region cut out of the image, in pixel coordinates
+        :return: new independent intrinsics matching the cropped image
+        :raises ValueError: if the crop has fractional coordinates or reaches beyond the image
+        """
+        if any(value != int(value) for value in crop.tuple):
+            raise ValueError(f'crop must have integer coordinates, got {crop}')
+        if crop.x < 0 or crop.y < 0 or crop.x + crop.width > self.size.width or crop.y + crop.height > self.size.height:
+            raise ValueError(f'crop {crop} must lie inside the image size {self.size}')
+        matrix = self.matrix
+        cropped_matrix = [
+            [matrix[0][0], matrix[0][1], matrix[0][2] - crop.x],
+            [0.0, matrix[1][1], matrix[1][2] - crop.y],
+            [0.0, 0.0, 1.0],
+        ]
+        return Intrinsics(model=self.model,
+                          matrix=cropped_matrix,
+                          distortion=list(self.distortion),
+                          omnidir_params=deepcopy(self.omnidir_params),
+                          size=ImageSize(width=int(crop.width), height=int(crop.height)))
+
 
 log = logging.getLogger('rosys.vision.calibration')
 
@@ -182,54 +230,23 @@ class Calibration:
     def scale(self, size: ImageSize) -> Calibration:
         """Derive the calibration for an image that is scaled to ``size``.
 
-        Assumes this calibration and the scaled image share the same field of view, so the camera
-        matrix scales with the resolution while the distortion coefficients (defined in normalized
-        coordinates) stay valid.
+        See :meth:`Intrinsics.scale`. The extrinsics are copied unchanged, because scaling the image does not move the camera.
 
         :param size: the size the image is scaled to (same field of view)
         :return: a new independent calibration matching the scaled image
         """
-        scale_x = size.width / self.intrinsics.size.width
-        scale_y = size.height / self.intrinsics.size.height
-        matrix = self.intrinsics.matrix
-        scaled_matrix = [
-            [matrix[0][0] * scale_x, matrix[0][1] * scale_x, matrix[0][2] * scale_x],
-            [0.0, matrix[1][1] * scale_y, matrix[1][2] * scale_y],
-            [0.0, 0.0, 1.0],
-        ]
-        intrinsics = Intrinsics(model=self.intrinsics.model,
-                                matrix=scaled_matrix,
-                                distortion=list(self.intrinsics.distortion),
-                                omnidir_params=deepcopy(self.intrinsics.omnidir_params),
-                                size=ImageSize(width=size.width, height=size.height))
-        return Calibration(intrinsics=intrinsics, extrinsics=deepcopy(self.extrinsics))
+        return Calibration(intrinsics=self.intrinsics.scale(size), extrinsics=deepcopy(self.extrinsics))
 
     def crop(self, crop: Rectangle) -> Calibration:
         """Derive the calibration for an image that is cropped to ``crop``.
 
-        The crop only shifts the principal point; the distortion coefficients stay valid.
+        See :meth:`Intrinsics.crop`. The extrinsics are copied unchanged, because cropping the image does not move the camera.
 
         :param crop: the region cut out of the image, in pixel coordinates
         :return: a new independent calibration matching the cropped image
         :raises ValueError: if the crop has fractional coordinates or reaches beyond the image
         """
-        if any(value != int(value) for value in crop.tuple):
-            raise ValueError(f'crop must have integer coordinates, got {crop}')
-        size = self.intrinsics.size
-        if crop.x < 0 or crop.y < 0 or crop.x + crop.width > size.width or crop.y + crop.height > size.height:
-            raise ValueError(f'crop {crop} must lie inside the image size {size}')
-        matrix = self.intrinsics.matrix
-        cropped_matrix = [
-            [matrix[0][0], matrix[0][1], matrix[0][2] - crop.x],
-            [0.0, matrix[1][1], matrix[1][2] - crop.y],
-            [0.0, 0.0, 1.0],
-        ]
-        intrinsics = Intrinsics(model=self.intrinsics.model,
-                                matrix=cropped_matrix,
-                                distortion=list(self.intrinsics.distortion),
-                                omnidir_params=deepcopy(self.intrinsics.omnidir_params),
-                                size=ImageSize(width=int(crop.width), height=int(crop.height)))
-        return Calibration(intrinsics=intrinsics, extrinsics=deepcopy(self.extrinsics))
+        return Calibration(intrinsics=self.intrinsics.crop(crop), extrinsics=deepcopy(self.extrinsics))
 
     @overload
     def project_to_image(self, coordinates: Point3d) -> Point | None:

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -178,32 +178,53 @@ class Calibration:
 
         return Calibration(intrinsics=intrinsics, extrinsics=extrinsics)
 
-    def scale_and_crop(self, *, size: ImageSize, crop: Rectangle) -> Calibration:
-        """Derive the calibration for an image that is scaled to ``size`` and then cropped to ``crop``.
+    def scale(self, size: ImageSize) -> Calibration:
+        """Derive the calibration for an image that is scaled to ``size``.
 
         Assumes this calibration and the scaled image share the same field of view, so the camera
         matrix scales with the resolution while the distortion coefficients (defined in normalized
-        coordinates) stay valid. The crop only shifts the principal point.
+        coordinates) stay valid.
 
-        :param size: the size the image is scaled to before cropping (same field of view)
-        :param crop: the region cut out of the scaled image, in scaled pixel coordinates
-        :return: a new calibration matching the cropped image (sharing this calibration's extrinsics)
-        :raises ValueError: if the crop has fractional coordinates or reaches beyond the scaled image
+        :param size: the size the image is scaled to (same field of view)
+        :return: a new calibration matching the scaled image (sharing this calibration's extrinsics)
         """
-        if any(value != int(value) for value in crop.tuple):
-            raise ValueError(f'crop must have integer coordinates, got {crop}')
-        if crop.x < 0 or crop.y < 0 or crop.x + crop.width > size.width or crop.y + crop.height > size.height:
-            raise ValueError(f'crop {crop} must lie inside the scaled image size {size}')
         scale_x = size.width / self.intrinsics.size.width
         scale_y = size.height / self.intrinsics.size.height
         matrix = self.intrinsics.matrix
         scaled_matrix = [
-            [matrix[0][0] * scale_x, matrix[0][1] * scale_x, matrix[0][2] * scale_x - crop.x],
-            [0.0, matrix[1][1] * scale_y, matrix[1][2] * scale_y - crop.y],
+            [matrix[0][0] * scale_x, matrix[0][1] * scale_x, matrix[0][2] * scale_x],
+            [0.0, matrix[1][1] * scale_y, matrix[1][2] * scale_y],
             [0.0, 0.0, 1.0],
         ]
         intrinsics = Intrinsics(model=self.intrinsics.model,
                                 matrix=scaled_matrix,
+                                distortion=list(self.intrinsics.distortion),
+                                omnidir_params=self.intrinsics.omnidir_params,
+                                size=ImageSize(width=size.width, height=size.height))
+        return Calibration(intrinsics=intrinsics, extrinsics=self.extrinsics)
+
+    def crop(self, crop: Rectangle) -> Calibration:
+        """Derive the calibration for an image that is cropped to ``crop``.
+
+        The crop only shifts the principal point; the distortion coefficients stay valid.
+
+        :param crop: the region cut out of the image, in pixel coordinates
+        :return: a new calibration matching the cropped image (sharing this calibration's extrinsics)
+        :raises ValueError: if the crop has fractional coordinates or reaches beyond the image
+        """
+        if any(value != int(value) for value in crop.tuple):
+            raise ValueError(f'crop must have integer coordinates, got {crop}')
+        size = self.intrinsics.size
+        if crop.x < 0 or crop.y < 0 or crop.x + crop.width > size.width or crop.y + crop.height > size.height:
+            raise ValueError(f'crop {crop} must lie inside the image size {size}')
+        matrix = self.intrinsics.matrix
+        cropped_matrix = [
+            [matrix[0][0], matrix[0][1], matrix[0][2] - crop.x],
+            [0.0, matrix[1][1], matrix[1][2] - crop.y],
+            [0.0, 0.0, 1.0],
+        ]
+        intrinsics = Intrinsics(model=self.intrinsics.model,
+                                matrix=cropped_matrix,
                                 distortion=list(self.intrinsics.distortion),
                                 omnidir_params=self.intrinsics.omnidir_params,
                                 size=ImageSize(width=int(crop.width), height=int(crop.height)))

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -9,7 +9,7 @@ import cv2
 import numpy as np
 from numpy.typing import NDArray
 
-from ..geometry import Frame3d, Point, Point3d, Pose3d, Rotation
+from ..geometry import Frame3d, Point, Point3d, Pose3d, Rectangle, Rotation
 from .image import Image, ImageSize
 
 FloatArray: TypeAlias = NDArray[np.float32] | NDArray[np.float64]
@@ -177,6 +177,37 @@ class Calibration:
                             rotation=rotation).in_frame(frame)
 
         return Calibration(intrinsics=intrinsics, extrinsics=extrinsics)
+
+    def scale_and_crop(self, *, size: ImageSize, crop: Rectangle) -> Calibration:
+        """Derive the calibration for an image that is scaled to ``size`` and then cropped to ``crop``.
+
+        Assumes this calibration and the scaled image share the same field of view, so the camera
+        matrix scales with the resolution while the distortion coefficients (defined in normalized
+        coordinates) stay valid. The crop only shifts the principal point.
+
+        :param size: the size the image is scaled to before cropping (same field of view)
+        :param crop: the region cut out of the scaled image, in scaled pixel coordinates
+        :return: a new calibration matching the cropped image (sharing this calibration's extrinsics)
+        :raises ValueError: if the crop has fractional coordinates or reaches beyond the scaled image
+        """
+        if any(value != int(value) for value in crop.tuple):
+            raise ValueError(f'crop must have integer coordinates, got {crop}')
+        if crop.x < 0 or crop.y < 0 or crop.x + crop.width > size.width or crop.y + crop.height > size.height:
+            raise ValueError(f'crop {crop} must lie inside the scaled image size {size}')
+        scale_x = size.width / self.intrinsics.size.width
+        scale_y = size.height / self.intrinsics.size.height
+        matrix = self.intrinsics.matrix
+        scaled_matrix = [
+            [matrix[0][0] * scale_x, matrix[0][1] * scale_x, matrix[0][2] * scale_x - crop.x],
+            [0.0, matrix[1][1] * scale_y, matrix[1][2] * scale_y - crop.y],
+            [0.0, 0.0, 1.0],
+        ]
+        intrinsics = Intrinsics(model=self.intrinsics.model,
+                                matrix=scaled_matrix,
+                                distortion=list(self.intrinsics.distortion),
+                                omnidir_params=self.intrinsics.omnidir_params,
+                                size=ImageSize(width=int(crop.width), height=int(crop.height)))
+        return Calibration(intrinsics=intrinsics, extrinsics=self.extrinsics)
 
     @overload
     def project_to_image(self, coordinates: Point3d) -> Point | None:

--- a/rosys/vision/calibration.py
+++ b/rosys/vision/calibration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TypeAlias, cast, overload
@@ -186,7 +187,7 @@ class Calibration:
         coordinates) stay valid.
 
         :param size: the size the image is scaled to (same field of view)
-        :return: a new calibration matching the scaled image (sharing this calibration's extrinsics)
+        :return: a new independent calibration matching the scaled image
         """
         scale_x = size.width / self.intrinsics.size.width
         scale_y = size.height / self.intrinsics.size.height
@@ -199,9 +200,9 @@ class Calibration:
         intrinsics = Intrinsics(model=self.intrinsics.model,
                                 matrix=scaled_matrix,
                                 distortion=list(self.intrinsics.distortion),
-                                omnidir_params=self.intrinsics.omnidir_params,
+                                omnidir_params=deepcopy(self.intrinsics.omnidir_params),
                                 size=ImageSize(width=size.width, height=size.height))
-        return Calibration(intrinsics=intrinsics, extrinsics=self.extrinsics)
+        return Calibration(intrinsics=intrinsics, extrinsics=deepcopy(self.extrinsics))
 
     def crop(self, crop: Rectangle) -> Calibration:
         """Derive the calibration for an image that is cropped to ``crop``.
@@ -209,7 +210,7 @@ class Calibration:
         The crop only shifts the principal point; the distortion coefficients stay valid.
 
         :param crop: the region cut out of the image, in pixel coordinates
-        :return: a new calibration matching the cropped image (sharing this calibration's extrinsics)
+        :return: a new independent calibration matching the cropped image
         :raises ValueError: if the crop has fractional coordinates or reaches beyond the image
         """
         if any(value != int(value) for value in crop.tuple):
@@ -226,9 +227,9 @@ class Calibration:
         intrinsics = Intrinsics(model=self.intrinsics.model,
                                 matrix=cropped_matrix,
                                 distortion=list(self.intrinsics.distortion),
-                                omnidir_params=self.intrinsics.omnidir_params,
+                                omnidir_params=deepcopy(self.intrinsics.omnidir_params),
                                 size=ImageSize(width=int(crop.width), height=int(crop.height)))
-        return Calibration(intrinsics=intrinsics, extrinsics=self.extrinsics)
+        return Calibration(intrinsics=intrinsics, extrinsics=deepcopy(self.extrinsics))
 
     @overload
     def project_to_image(self, coordinates: Point3d) -> Point | None:

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -503,7 +503,8 @@ def _distorted_calibration(camera_model: CameraModel = CameraModel.PINHOLE) -> C
 def test_scale():
     """Scaling to a higher-resolution stream only rescales projected pixels."""
     calibration = _distorted_calibration()
-    scaled = calibration.scale(ImageSize(width=2560, height=1920))
+    scaled = Calibration(intrinsics=calibration.intrinsics.scale(ImageSize(width=2560, height=1920)),
+                         extrinsics=calibration.extrinsics)
     world_point = Point3d(x=0.45, y=0.1, z=0.0)
     original_pixel = calibration.project_to_image(world_point)
     scaled_pixel = scaled.project_to_image(world_point)
@@ -568,7 +569,8 @@ def test_scale_and_crop_commute():
 def test_crop():
     """Cropping only shifts projected pixels by the crop offset."""
     calibration = _distorted_calibration()
-    cropped = calibration.crop(Rectangle(x=300, y=200, width=640, height=480))
+    cropped = Calibration(intrinsics=calibration.intrinsics.crop(Rectangle(x=300, y=200, width=640, height=480)),
+                          extrinsics=calibration.extrinsics)
     world_point = Point3d(x=0.45, y=0.1, z=0.0)
     original_pixel = calibration.project_to_image(world_point)
     cropped_pixel = cropped.project_to_image(world_point)
@@ -583,7 +585,9 @@ def test_crop():
 def test_scale_then_crop_round_trip(camera_model: CameraModel):
     """A pixel in the scaled and cropped image projects onto the same ground point as in the original."""
     calibration = _distorted_calibration(camera_model)
-    scaled = calibration.scale(ImageSize(width=2560, height=1920)).crop(Rectangle(x=600, y=400, width=1280, height=720))
+    intrinsics = calibration.intrinsics.scale(ImageSize(width=2560, height=1920)) \
+        .crop(Rectangle(x=600, y=400, width=1280, height=720))
+    scaled = Calibration(intrinsics=intrinsics, extrinsics=calibration.extrinsics)
     world_point = Point3d(x=0.45, y=0.1, z=0.0)
     scaled_pixel = scaled.project_to_image(world_point)
     assert scaled_pixel is not None
@@ -594,8 +598,8 @@ def test_scale_then_crop_round_trip(camera_model: CameraModel):
 
 def test_crop_rejects_invalid_crops():
     """Fractional coordinates would desync from the integer pixel crop; out-of-bounds crops would be clamped."""
-    calibration = _distorted_calibration()
+    intrinsics = _distorted_calibration().intrinsics
     with pytest.raises(ValueError, match='integer'):
-        calibration.crop(Rectangle(x=600.5, y=400, width=640, height=480))
+        intrinsics.crop(Rectangle(x=600.5, y=400, width=640, height=480))
     with pytest.raises(ValueError, match='inside'):
-        calibration.crop(Rectangle(x=700, y=400, width=640, height=480))
+        intrinsics.crop(Rectangle(x=700, y=400, width=640, height=480))

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -487,9 +487,14 @@ def test_distort_points_fisheye(crop: bool):
     assert np.allclose(points, redistorted_points, atol=1e-6)
 
 
-def _distorted_calibration() -> Calibration:
-    intrinsics = Intrinsics(matrix=[[720.0, 0.0, 660.0], [0.0, 720.0, 500.0], [0.0, 0.0, 1.0]],
-                            distortion=[-0.35, 0.15, 0.001, -0.002, -0.03],
+def _distorted_calibration(camera_model: CameraModel = CameraModel.PINHOLE) -> Calibration:
+    distortion = [-0.35, 0.15, 0.001, -0.002, -0.03] if camera_model == CameraModel.PINHOLE else \
+        [-0.05, 0.01, -0.002, 0.001]
+    omnidir_params = OmnidirParameters(xi=0.8) if camera_model == CameraModel.OMNIDIRECTIONAL else None
+    intrinsics = Intrinsics(model=camera_model,
+                            matrix=[[720.0, 0.0, 660.0], [0.0, 720.0, 500.0], [0.0, 0.0, 1.0]],
+                            distortion=distortion,
+                            omnidir_params=omnidir_params,
                             size=ImageSize(width=1280, height=960))
     extrinsics = Pose3d(x=0.3, y=0.0, z=0.6, rotation=Rotation.from_euler(np.pi, 0.0, 0.0))
     return Calibration(intrinsics=intrinsics, extrinsics=extrinsics)
@@ -523,9 +528,10 @@ def test_crop():
     assert cropped.intrinsics.size == ImageSize(width=640, height=480)
 
 
-def test_scale_then_crop_round_trip():
+@pytest.mark.parametrize('camera_model', [CameraModel.PINHOLE, CameraModel.FISHEYE, CameraModel.OMNIDIRECTIONAL])
+def test_scale_then_crop_round_trip(camera_model: CameraModel):
     """A pixel in the scaled and cropped image projects onto the same ground point as in the original."""
-    calibration = _distorted_calibration()
+    calibration = _distorted_calibration(camera_model)
     scaled = calibration.scale(ImageSize(width=2560, height=1920)).crop(Rectangle(x=600, y=400, width=1280, height=720))
     world_point = Point3d(x=0.45, y=0.1, z=0.0)
     scaled_pixel = scaled.project_to_image(world_point)

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -3,10 +3,10 @@ import copy
 import numpy as np
 import pytest
 
-from rosys.geometry import Point, Point3d, Pose3d
+from rosys.geometry import Point, Point3d, Pose3d, Rectangle, Rotation
 from rosys.geometry.object3d import frame_registry
 from rosys.testing import approx
-from rosys.vision import CalibratableCamera, Calibration, Image
+from rosys.vision import CalibratableCamera, Calibration, Image, ImageSize, Intrinsics
 from rosys.vision.calibration import CameraModel, OmnidirParameters
 
 
@@ -485,3 +485,50 @@ def test_distort_points_fisheye(crop: bool):
     undistorted_points = cam.calibration.undistort_points(points, crop=crop)
     redistorted_points = cam.calibration.distort_points(undistorted_points, crop=crop)
     assert np.allclose(points, redistorted_points, atol=1e-6)
+
+
+def _distorted_calibration() -> Calibration:
+    intrinsics = Intrinsics(matrix=[[720.0, 0.0, 660.0], [0.0, 720.0, 500.0], [0.0, 0.0, 1.0]],
+                            distortion=[-0.35, 0.15, 0.001, -0.002, -0.03],
+                            size=ImageSize(width=1280, height=960))
+    extrinsics = Pose3d(x=0.3, y=0.0, z=0.6, rotation=Rotation.from_euler(np.pi, 0.0, 0.0))
+    return Calibration(intrinsics=intrinsics, extrinsics=extrinsics)
+
+
+def test_scale_and_crop():
+    """Scaling to a higher-resolution stream and cropping only rescales and shifts projected pixels."""
+    calibration = _distorted_calibration()
+    scaled = calibration.scale_and_crop(size=ImageSize(width=2560, height=1920),
+                                        crop=Rectangle(x=600, y=400, width=1280, height=720))
+    world_point = Point3d(x=0.45, y=0.1, z=0.0)
+    original_pixel = calibration.project_to_image(world_point)
+    scaled_pixel = scaled.project_to_image(world_point)
+    assert original_pixel is not None
+    assert scaled_pixel is not None
+    approx(scaled_pixel.x, original_pixel.x * 2 - 600)
+    approx(scaled_pixel.y, original_pixel.y * 2 - 400)
+    assert scaled.intrinsics.size == ImageSize(width=1280, height=720)
+
+
+def test_scale_and_crop_round_trip():
+    """A pixel in the cropped image projects onto the same ground point as in the original."""
+    calibration = _distorted_calibration()
+    scaled = calibration.scale_and_crop(size=ImageSize(width=2560, height=1920),
+                                        crop=Rectangle(x=600, y=400, width=1280, height=720))
+    world_point = Point3d(x=0.45, y=0.1, z=0.0)
+    scaled_pixel = scaled.project_to_image(world_point)
+    assert scaled_pixel is not None
+    projected = scaled.project_from_image(scaled_pixel)
+    assert projected is not None
+    approx(projected.tuple, world_point.tuple, abs=1e-4)
+
+
+def test_scale_and_crop_rejects_invalid_crops():
+    """Fractional coordinates would desync from the integer pixel crop; out-of-bounds crops would be clamped."""
+    calibration = _distorted_calibration()
+    with pytest.raises(ValueError, match='integer'):
+        calibration.scale_and_crop(size=ImageSize(width=2560, height=1920),
+                                   crop=Rectangle(x=600.5, y=400, width=1280, height=720))
+    with pytest.raises(ValueError, match='inside'):
+        calibration.scale_and_crop(size=ImageSize(width=2560, height=1920),
+                                   crop=Rectangle(x=1400, y=400, width=1280, height=720))

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -495,26 +495,38 @@ def _distorted_calibration() -> Calibration:
     return Calibration(intrinsics=intrinsics, extrinsics=extrinsics)
 
 
-def test_scale_and_crop():
-    """Scaling to a higher-resolution stream and cropping only rescales and shifts projected pixels."""
+def test_scale():
+    """Scaling to a higher-resolution stream only rescales projected pixels."""
     calibration = _distorted_calibration()
-    scaled = calibration.scale_and_crop(size=ImageSize(width=2560, height=1920),
-                                        crop=Rectangle(x=600, y=400, width=1280, height=720))
+    scaled = calibration.scale(ImageSize(width=2560, height=1920))
     world_point = Point3d(x=0.45, y=0.1, z=0.0)
     original_pixel = calibration.project_to_image(world_point)
     scaled_pixel = scaled.project_to_image(world_point)
     assert original_pixel is not None
     assert scaled_pixel is not None
-    approx(scaled_pixel.x, original_pixel.x * 2 - 600)
-    approx(scaled_pixel.y, original_pixel.y * 2 - 400)
-    assert scaled.intrinsics.size == ImageSize(width=1280, height=720)
+    approx(scaled_pixel.x, original_pixel.x * 2)
+    approx(scaled_pixel.y, original_pixel.y * 2)
+    assert scaled.intrinsics.size == ImageSize(width=2560, height=1920)
 
 
-def test_scale_and_crop_round_trip():
-    """A pixel in the cropped image projects onto the same ground point as in the original."""
+def test_crop():
+    """Cropping only shifts projected pixels by the crop offset."""
     calibration = _distorted_calibration()
-    scaled = calibration.scale_and_crop(size=ImageSize(width=2560, height=1920),
-                                        crop=Rectangle(x=600, y=400, width=1280, height=720))
+    cropped = calibration.crop(Rectangle(x=300, y=200, width=640, height=480))
+    world_point = Point3d(x=0.45, y=0.1, z=0.0)
+    original_pixel = calibration.project_to_image(world_point)
+    cropped_pixel = cropped.project_to_image(world_point)
+    assert original_pixel is not None
+    assert cropped_pixel is not None
+    approx(cropped_pixel.x, original_pixel.x - 300)
+    approx(cropped_pixel.y, original_pixel.y - 200)
+    assert cropped.intrinsics.size == ImageSize(width=640, height=480)
+
+
+def test_scale_then_crop_round_trip():
+    """A pixel in the scaled and cropped image projects onto the same ground point as in the original."""
+    calibration = _distorted_calibration()
+    scaled = calibration.scale(ImageSize(width=2560, height=1920)).crop(Rectangle(x=600, y=400, width=1280, height=720))
     world_point = Point3d(x=0.45, y=0.1, z=0.0)
     scaled_pixel = scaled.project_to_image(world_point)
     assert scaled_pixel is not None
@@ -523,12 +535,10 @@ def test_scale_and_crop_round_trip():
     approx(projected.tuple, world_point.tuple, abs=1e-4)
 
 
-def test_scale_and_crop_rejects_invalid_crops():
+def test_crop_rejects_invalid_crops():
     """Fractional coordinates would desync from the integer pixel crop; out-of-bounds crops would be clamped."""
     calibration = _distorted_calibration()
     with pytest.raises(ValueError, match='integer'):
-        calibration.scale_and_crop(size=ImageSize(width=2560, height=1920),
-                                   crop=Rectangle(x=600.5, y=400, width=1280, height=720))
+        calibration.crop(Rectangle(x=600.5, y=400, width=640, height=480))
     with pytest.raises(ValueError, match='inside'):
-        calibration.scale_and_crop(size=ImageSize(width=2560, height=1920),
-                                   crop=Rectangle(x=1400, y=400, width=1280, height=720))
+        calibration.crop(Rectangle(x=700, y=400, width=640, height=480))

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -514,6 +514,22 @@ def test_scale():
     assert scaled.intrinsics.size == ImageSize(width=2560, height=1920)
 
 
+def test_intrinsics_scale_and_crop_leave_original_untouched():
+    """Scaling and cropping intrinsics leave the original untouched."""
+    intrinsics = _distorted_calibration(CameraModel.OMNIDIRECTIONAL).intrinsics
+    scaled = intrinsics.scale(ImageSize(width=2560, height=1920))
+    cropped = intrinsics.crop(Rectangle(x=300, y=200, width=640, height=480))
+    assert scaled.matrix[0][0] == 1440.0
+    assert cropped.matrix[0][2] == 360.0
+    scaled.distortion[0] = 0.0
+    assert cropped.omnidir_params is not None
+    cropped.omnidir_params.xi = 0.0
+    assert intrinsics.matrix[0][0] == 720.0
+    assert intrinsics.distortion[0] == -0.05
+    assert intrinsics.omnidir_params is not None
+    assert intrinsics.omnidir_params.xi == 0.8
+
+
 def test_crop():
     """Cropping only shifts projected pixels by the crop offset."""
     calibration = _distorted_calibration()

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -530,6 +530,41 @@ def test_intrinsics_scale_and_crop_leave_original_untouched():
     assert intrinsics.omnidir_params.xi == 0.8
 
 
+def _assert_same_intrinsics(a: Intrinsics, b: Intrinsics) -> None:
+    assert a.model == b.model
+    assert np.allclose(a.matrix, b.matrix)
+    assert np.allclose(a.distortion, b.distortion)
+    assert a.omnidir_params == b.omnidir_params
+    assert a.size == b.size
+
+
+@pytest.mark.parametrize('camera_model', [CameraModel.PINHOLE, CameraModel.FISHEYE, CameraModel.OMNIDIRECTIONAL])
+def test_scale_up_and_down_restores_intrinsics(camera_model: CameraModel):
+    """Scaling to another size and back yields the original intrinsics."""
+    intrinsics = _distorted_calibration(camera_model).intrinsics
+    restored = intrinsics.scale(ImageSize(width=1920, height=1920)).scale(intrinsics.size)
+    _assert_same_intrinsics(restored, intrinsics)
+
+
+def test_two_crops_equal_one_combined_crop():
+    """Cropping twice is the same as cropping once with the offsets added up."""
+    intrinsics = _distorted_calibration().intrinsics
+    first = intrinsics.crop(Rectangle(x=300, y=200, width=800, height=600))
+    twice = first.crop(Rectangle(x=100, y=50, width=640, height=480))
+    once = intrinsics.crop(Rectangle(x=400, y=250, width=640, height=480))
+    _assert_same_intrinsics(twice, once)
+
+
+def test_scale_and_crop_commute():
+    """Cropping the scaled image equals scaling the cropped image, when the crop is scaled along."""
+    intrinsics = _distorted_calibration().intrinsics
+    scaled = intrinsics.scale(ImageSize(width=2560, height=1920))
+    scale_then_crop = scaled.crop(Rectangle(x=600, y=400, width=1280, height=960))
+    cropped = intrinsics.crop(Rectangle(x=300, y=200, width=640, height=480))
+    crop_then_scale = cropped.scale(ImageSize(width=1280, height=960))
+    _assert_same_intrinsics(scale_then_crop, crop_then_scale)
+
+
 def test_crop():
     """Cropping only shifts projected pixels by the crop offset."""
     calibration = _distorted_calibration()


### PR DESCRIPTION
### Motivation

Cameras can stream at a higher resolution than they were calibrated at and crop to a region of interest (e.g. an agricultural robot cropping its main camera to the plant region). The existing calibration should be reusable for such a stream without re-calibrating.

### Implementation

- Add `Intrinsics.scale(size)`: scales the camera matrix to the new resolution, assuming the same field of view. The distortion coefficients act in normalized coordinates before the camera matrix, so they stay valid.
- Add `Intrinsics.crop(crop)`: shifts the principal point by the crop offset. Rejects fractional crop coordinates (`process_ndarray_image` truncates to whole pixels, which would silently desync the calibration from the actual crop) and crops reaching beyond the image.
- Both return new, independent `Intrinsics` and chain: `calibration.intrinsics.scale(stream_size).crop(region)`. To use the result on an existing calibration, assign it back: `calibration.intrinsics = calibration.intrinsics.crop(region)`. The extrinsics do not change, because cropping or scaling the image does not move the camera.
- The tests assert projection equality per step, a ground round trip of the chain with nonzero distortion for all three camera models, and cycle properties: scaling up and back down restores the intrinsics, two crops equal one combined crop, and scale and crop commute when the crop is scaled along.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5