### PR TITLE
Add a resolution parameter to UsbCamera and SimulatedCamera

### DIFF
--- a/docs/examples/cameras/images.py
+++ b/docs/examples/cameras/images.py
@@ -3,7 +3,7 @@ from nicegui import ui
 
 from rosys.vision import SimulatedCamera
 
-camera = SimulatedCamera(id='test_cam', width=800, height=600)
+camera = SimulatedCamera(id='test_cam', resolution=(800, 600))
 
 image = ui.interactive_image()
 ui.timer(0.3, lambda: image.set_source(camera.get_latest_image_url()))

--- a/docs/examples/cameras/remote.py
+++ b/docs/examples/cameras/remote.py
@@ -15,7 +15,7 @@ else:
     robot = rosys.hardware.RobotSimulation([wheels])
     rosys.vision.SimulatedCameraProvider.USE_PERSISTENCE = False
     camera_provider = rosys.vision.SimulatedCameraProvider()
-    camera = rosys.vision.SimulatedCamera(id='test_cam', width=800, height=600)
+    camera = rosys.vision.SimulatedCamera(id='test_cam', resolution=(800, 600))
     rosys.on_startup(lambda: camera_provider.add_camera(camera))
 steerer = rosys.driving.Steerer(wheels)
 odometer = rosys.driving.Odometer(wheels)

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -1,4 +1,5 @@
 import random
+import warnings
 
 from ..camera.configurable_camera import ConfigurableCamera
 from ..camera.transformable_camera import TransformableCamera
@@ -33,6 +34,16 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
         return super().to_dict() | {
             name: param.value for name, param in self._parameters.items()
         }
+
+    @classmethod
+    def args_from_dict(cls, data: dict) -> dict:
+        data = super().args_from_dict(data)
+        if 'width' in data and 'height' in data:
+            warnings.warn('Persisted camera dicts with "width" and "height" are deprecated '
+                          'and will be removed in a future version. Use "resolution" instead.',
+                          DeprecationWarning, stacklevel=2)
+            data['resolution'] = (data.pop('width'), data.pop('height'))
+        return data
 
     @property
     def is_connected(self) -> bool:

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -1,5 +1,4 @@
 import random
-import warnings
 
 from ..camera.configurable_camera import ConfigurableCamera
 from ..camera.transformable_camera import TransformableCamera
@@ -34,16 +33,6 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
         return super().to_dict() | {
             name: param.value for name, param in self._parameters.items()
         }
-
-    @classmethod
-    def args_from_dict(cls, data: dict) -> dict:
-        data = super().args_from_dict(data)
-        if 'width' in data and 'height' in data:
-            warnings.warn('Persisted camera dicts with "width" and "height" are deprecated '
-                          'and will be removed in a future version. Use "resolution" instead.',
-                          DeprecationWarning, stacklevel=2)
-            data['resolution'] = (data.pop('width'), data.pop('height'))
-        return data
 
     @property
     def is_connected(self) -> bool:

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -13,8 +13,7 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
                  id: str,  # pylint: disable=redefined-builtin
                  name: str | None = None,
                  connect_after_init: bool = True,
-                 width: int = 800,
-                 height: int = 600,
+                 resolution: tuple[int, int] = (800, 600),
                  color: str | None = None,
                  fps: int = 5,
                  **kwargs,
@@ -24,7 +23,7 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
                          connect_after_init=connect_after_init,
                          **kwargs)
         self.device: SimulatedDevice | None = None
-        self.resolution = ImageSize(width=width, height=height)
+        self._register_parameter('resolution', self._get_resolution, self._set_resolution, resolution)
         self._register_parameter('color', self._get_color, self._set_color,
                                  color or f'#{random.randint(0, 0xffffff):06x}')
         self._register_parameter('fps', self._get_fps, self._set_fps,
@@ -32,9 +31,6 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
     def to_dict(self) -> dict:
         return super().to_dict() | {
-            'width': self.resolution.width,
-            'height': self.resolution.height,
-        } | {
             name: param.value for name, param in self._parameters.items()
         }
 
@@ -44,12 +40,21 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
     async def connect(self) -> None:
         if not self.is_connected:
-            self.device = SimulatedDevice(id=self.id, size=self.resolution, fps=self.parameters['fps'],
-                                          on_new_image=self._add_image)
+            width, height = self.parameters['resolution']
+            self.device = SimulatedDevice(id=self.id, size=ImageSize(width=width, height=height),
+                                          fps=self.parameters['fps'], on_new_image=self._add_image)
             await self._apply_all_parameters()
 
     async def disconnect(self) -> None:
         self.device = None
+
+    def _set_resolution(self, value: tuple[int, int]) -> None:
+        assert self.device is not None
+        self.device.size = ImageSize(width=value[0], height=value[1])
+
+    def _get_resolution(self) -> tuple[int, int]:
+        assert self.device is not None
+        return (self.device.size.width, self.device.size.height)
 
     def _set_color(self, value: str) -> None:
         assert self.device is not None

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -1,5 +1,6 @@
 import random
 
+from ...helpers.deprecation import deprecated_param
 from ..camera.configurable_camera import ConfigurableCamera
 from ..camera.transformable_camera import TransformableCamera
 from ..image import ImageSize
@@ -8,12 +9,16 @@ from .simulated_device import SimulatedDevice
 
 class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
+    @deprecated_param('width')
+    @deprecated_param('height', stacklevel=3)
     def __init__(self,
                  *,
                  id: str,  # pylint: disable=redefined-builtin
                  name: str | None = None,
                  connect_after_init: bool = True,
                  resolution: tuple[int, int] = (800, 600),
+                 width: int | None = None,
+                 height: int | None = None,
                  color: str | None = None,
                  fps: int = 5,
                  **kwargs,
@@ -23,6 +28,8 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
                          connect_after_init=connect_after_init,
                          **kwargs)
         self.device: SimulatedDevice | None = None
+        if width is not None or height is not None:
+            resolution = (width or resolution[0], height or resolution[1])
         self._register_parameter('resolution', self._get_resolution, self._set_resolution, resolution)
         self._register_parameter('color', self._get_color, self._set_color,
                                  color or f'#{random.randint(0, 0xffffff):06x}')
@@ -33,6 +40,13 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
         return super().to_dict() | {
             name: param.value for name, param in self._parameters.items()
         }
+
+    @classmethod
+    def args_from_dict(cls, data: dict) -> dict:
+        data = super().args_from_dict(data)
+        if 'width' in data and 'height' in data:
+            data['resolution'] = (data.pop('width'), data.pop('height'))
+        return data
 
     @property
     def is_connected(self) -> bool:

--- a/rosys/vision/simulated_camera/simulated_camera_provider.py
+++ b/rosys/vision/simulated_camera/simulated_camera_provider.py
@@ -52,7 +52,7 @@ class SimulatedCameraProvider(CameraProvider[SimulatedCamera]):
         async for camera_id in self.scan_for_cameras():
             camera = self._cameras.get(camera_id)
             if not camera:
-                camera = SimulatedCamera(id=camera_id, width=640, height=480)
+                camera = SimulatedCamera(id=camera_id, resolution=(640, 480))
                 self.add_camera(camera)
 
             if not camera.is_connected:
@@ -69,4 +69,4 @@ class SimulatedCameraProvider(CameraProvider[SimulatedCamera]):
     def add_cameras(self, num_cameras: int) -> None:
         for _ in range(num_cameras):
             new_id = f'cam{len(self._cameras)}'
-            self.add_camera(SimulatedCamera(id=new_id, width=640, height=480))
+            self.add_camera(SimulatedCamera(id=new_id, resolution=(640, 480)))

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -19,7 +19,7 @@ class SimulatedDevice:
                  color: str = '#ffffff',
                  fps: float = 30.0) -> None:
         self._id = id
-        self._size = size
+        self.size = size
         self.color = color
         self._on_new_image = on_new_image
         self._creation_time: float = rosys.time()
@@ -34,9 +34,9 @@ class SimulatedDevice:
         timestamp = rosys.time()
         image: Image
         if rosys.is_test:
-            image = _create_simple_image(self._id, self._size, self.color, timestamp)
+            image = _create_simple_image(self._id, self.size, self.color, timestamp)
         else:
-            image = _create_image_data(self._id, self._size, self.color, timestamp)
+            image = _create_image_data(self._id, self.size, self.color, timestamp)
         result = self._on_new_image(image)
         if isinstance(result, Awaitable):
             await result

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -4,6 +4,7 @@ from typing import Any
 import numpy as np
 
 from ... import rosys
+from ...helpers.deprecation import deprecated_param
 from ..camera.configurable_camera import ConfigurableCamera
 from ..camera.transformable_camera import TransformableCamera
 from ..image import Image
@@ -14,6 +15,8 @@ from .usb_device import UsbDevice
 
 class UsbCamera(ConfigurableCamera, TransformableCamera):
 
+    @deprecated_param('width')
+    @deprecated_param('height', stacklevel=3)
     def __init__(self,
                  *,
                  id: str,  # pylint: disable=redefined-builtin
@@ -22,6 +25,8 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
                  auto_exposure: bool = True,
                  exposure: float = 0.01,
                  resolution: tuple[int, int] = (800, 600),
+                 width: int | None = None,
+                 height: int | None = None,
                  fps: int = 10,
                  **kwargs) -> None:
         super().__init__(id=id,
@@ -33,6 +38,8 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         self.detect: bool = False
         self.color: str | None = None
 
+        if width is not None or height is not None:
+            resolution = (width or resolution[0], height or resolution[1])
         self._register_parameter('auto_exposure', self.get_exposure, self.set_exposure, auto_exposure)
         self._register_parameter('exposure', self.get_exposure, self.set_exposure, exposure)
         self._register_parameter('resolution', self.get_resolution, self.set_resolution, resolution)
@@ -42,6 +49,13 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         return super().to_dict() | {
             name: param.value for name, param in self._parameters.items()
         }
+
+    @classmethod
+    def args_from_dict(cls, data: dict[str, Any]) -> dict:
+        data = super().args_from_dict(data)
+        if 'width' in data and 'height' in data:
+            data['resolution'] = (data.pop('width'), data.pop('height'))
+        return data
 
     @property
     def is_connected(self) -> bool:

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -21,8 +21,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
                  connect_after_init: bool = True,
                  auto_exposure: bool = True,
                  exposure: float = 0.01,
-                 width: int = 800,
-                 height: int = 600,
+                 resolution: tuple[int, int] = (800, 600),
                  fps: int = 10,
                  **kwargs) -> None:
         super().__init__(id=id,
@@ -36,8 +35,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
 
         self._register_parameter('auto_exposure', self.get_exposure, self.set_exposure, auto_exposure)
         self._register_parameter('exposure', self.get_exposure, self.set_exposure, exposure)
-        self._register_parameter('width', self.get_width, self.set_width, width)
-        self._register_parameter('height', self.get_height, self.set_height, height)
+        self._register_parameter('resolution', self.get_resolution, self.set_resolution, resolution)
         self._register_parameter('fps', self.get_fps, self.set_fps, fps)
 
     def to_dict(self) -> dict[str, Any]:
@@ -113,21 +111,14 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         assert self.device is not None
         return self.device.get_exposure()
 
-    def set_width(self, width: int) -> None:
+    def set_resolution(self, resolution: tuple[int, int]) -> None:
         assert self.device is not None
-        self.device.set_width(width)
+        self.device.set_width(resolution[0])
+        self.device.set_height(resolution[1])
 
-    def get_width(self) -> int:
+    def get_resolution(self) -> tuple[int, int]:
         assert self.device is not None
-        return self.device.get_width()
-
-    def set_height(self, height: int) -> None:
-        assert self.device is not None
-        self.device.set_height(height)
-
-    def get_height(self) -> int:
-        assert self.device is not None
-        return self.device.get_height()
+        return (self.device.get_width(), self.device.get_height())
 
     def set_fps(self, fps: int) -> None:
         assert self.device is not None

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import Any
 
 import numpy as np
@@ -42,6 +43,16 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         return super().to_dict() | {
             name: param.value for name, param in self._parameters.items()
         }
+
+    @classmethod
+    def args_from_dict(cls, data: dict[str, Any]) -> dict:
+        data = super().args_from_dict(data)
+        if 'width' in data and 'height' in data:
+            warnings.warn('Persisted camera dicts with "width" and "height" are deprecated '
+                          'and will be removed in a future version. Use "resolution" instead.',
+                          DeprecationWarning, stacklevel=2)
+            data['resolution'] = (data.pop('width'), data.pop('height'))
+        return data
 
     @property
     def is_connected(self) -> bool:

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from typing import Any
 
 import numpy as np
@@ -43,16 +42,6 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         return super().to_dict() | {
             name: param.value for name, param in self._parameters.items()
         }
-
-    @classmethod
-    def args_from_dict(cls, data: dict[str, Any]) -> dict:
-        data = super().args_from_dict(data)
-        if 'width' in data and 'height' in data:
-            warnings.warn('Persisted camera dicts with "width" and "height" are deprecated '
-                          'and will be removed in a future version. Use "resolution" instead.',
-                          DeprecationWarning, stacklevel=2)
-            data['resolution'] = (data.pop('width'), data.pop('height'))
-        return data
 
     @property
     def is_connected(self) -> bool:

--- a/tests/test_camera_persistence.py
+++ b/tests/test_camera_persistence.py
@@ -59,6 +59,31 @@ async def test_storing_simulated_camera_as_dict(rosys_integration, base_camera_p
     assert restored_camera.parameters == camera.parameters
 
 
+def test_simulated_camera_backward_compat(rosys_integration):
+    camera = SimulatedCamera.from_dict({
+        'id': 'test_cam',
+        'connect_after_init': False,
+        'width': 808,
+        'height': 606,
+        'color': '#010101',
+        'fps': 1,
+    })
+    assert camera.parameters['resolution'] == (808, 606)
+
+
+def test_usb_camera_backward_compat(rosys_integration):
+    camera = UsbCamera.from_dict({
+        'id': 'test_cam',
+        'connect_after_init': False,
+        'auto_exposure': True,
+        'exposure': 0.01,
+        'width': 808,
+        'height': 606,
+        'fps': 5,
+    })
+    assert camera.parameters['resolution'] == (808, 606)
+
+
 def test_storing_transformable_camera_as_dict(rosys_integration, base_camera_parameters):
     camera = TransformableCamera(crop=Rectangle(x=10, y=10, width=100, height=100),
                                  rotation=90, **base_camera_parameters)

--- a/tests/test_camera_persistence.py
+++ b/tests/test_camera_persistence.py
@@ -59,31 +59,6 @@ async def test_storing_simulated_camera_as_dict(rosys_integration, base_camera_p
     assert restored_camera.parameters == camera.parameters
 
 
-def test_simulated_camera_backward_compat(rosys_integration):
-    camera = SimulatedCamera.from_dict({
-        'id': 'test_cam',
-        'connect_after_init': False,
-        'width': 808,
-        'height': 606,
-        'color': '#010101',
-        'fps': 1,
-    })
-    assert camera.parameters['resolution'] == (808, 606)
-
-
-def test_usb_camera_backward_compat(rosys_integration):
-    camera = UsbCamera.from_dict({
-        'id': 'test_cam',
-        'connect_after_init': False,
-        'auto_exposure': True,
-        'exposure': 0.01,
-        'width': 808,
-        'height': 606,
-        'fps': 5,
-    })
-    assert camera.parameters['resolution'] == (808, 606)
-
-
 def test_storing_transformable_camera_as_dict(rosys_integration, base_camera_parameters):
     camera = TransformableCamera(crop=Rectangle(x=10, y=10, width=100, height=100),
                                  rotation=90, **base_camera_parameters)

--- a/tests/test_camera_persistence.py
+++ b/tests/test_camera_persistence.py
@@ -50,13 +50,12 @@ async def test_storing_camera_with_no_basepath_overwrite(rosys_integration, base
 
 
 async def test_storing_simulated_camera_as_dict(rosys_integration, base_camera_parameters):
-    camera = SimulatedCamera(width=808, height=606, color='#010101', fps=1, **base_camera_parameters)
+    camera = SimulatedCamera(resolution=(808, 606), color='#010101', fps=1, **base_camera_parameters)
     await camera.connect()
     camera_as_dict = camera.to_dict()
     restored_camera = SimulatedCamera.from_dict(camera_as_dict)
     assert isinstance(restored_camera, SimulatedCamera)
     assert_base_camera_parameters_match(camera, restored_camera)
-    assert restored_camera.resolution == camera.resolution
     assert restored_camera.parameters == camera.parameters
 
 
@@ -126,7 +125,7 @@ def test_rtsp_camera_backward_compat(rosys_integration):
 
 
 def test_storing_usb_camera_as_dict(rosys_integration, base_camera_parameters):
-    camera = UsbCamera(auto_exposure=False, exposure=100, width=808, height=606, fps=1, **base_camera_parameters)
+    camera = UsbCamera(auto_exposure=False, exposure=100, resolution=(808, 606), fps=1, **base_camera_parameters)
     camera_as_dict = camera.to_dict()
     restored_camera = UsbCamera.from_dict(camera_as_dict)
     assert isinstance(restored_camera, UsbCamera)

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -10,7 +10,7 @@ from rosys.vision import RtspCamera, RtspCameraProvider, SimulatedCamera, UsbCam
 
 
 async def test_simulated_camera(rosys_integration):
-    camera = SimulatedCamera(id='test_cam', width=800, height=600, fps=1)
+    camera = SimulatedCamera(id='test_cam', resolution=(800, 600), fps=1)
     await camera.connect()
     assert camera.is_connected
     await forward(1.1)

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -19,6 +19,16 @@ async def test_simulated_camera(rosys_integration):
     assert camera.images[0].size.height == 600
 
 
+async def test_changing_simulated_camera_resolution_while_connected(rosys_integration):
+    camera = SimulatedCamera(id='test_cam', resolution=(800, 600), fps=1)
+    await camera.connect()
+    await camera.set_parameters({'resolution': (100, 50)})
+    await forward(1.1)
+    assert camera.latest_captured_image is not None
+    assert camera.latest_captured_image.size.width == 100
+    assert camera.latest_captured_image.size.height == 50
+
+
 async def test_usb_camera(rosys_integration):
     if platform.system() != 'Linux':
         pytest.skip('UsbCamera is only supported on Linux.')

--- a/tests/test_recorder_replay.py
+++ b/tests/test_recorder_replay.py
@@ -15,7 +15,7 @@ from rosys.vision.record_replay.replay_camera_provider import ReplayCameraProvid
 async def test_record_images(recordings_dir: Path):
     # ARRANGE
     provider = SimulatedCameraProvider(auto_scan=False)
-    cam = SimulatedCamera(id='cam:0', width=64, height=48, fps=1)
+    cam = SimulatedCamera(id='cam:0', resolution=(64, 48), fps=1)
     provider.add_camera(cam)
     await cam.connect()
 
@@ -41,7 +41,7 @@ async def test_record_images(recordings_dir: Path):
 async def test_playback_replays_images(recordings_dir: Path):
     # ARRANGE
     provider = SimulatedCameraProvider(auto_scan=False)
-    cam = SimulatedCamera(id='cam:1', width=32, height=24, fps=1)
+    cam = SimulatedCamera(id='cam:1', resolution=(32, 24), fps=1)
     provider.add_camera(cam)
     await cam.connect()
     recorder = ImageRecorder(provider, recordings_dir)


### PR DESCRIPTION
### Motivation

Each camera type exposes its resolution differently: `MjpegCamera` has a single `resolution` parameter, `UsbCamera` two separate `width`/`height` parameters, and `SimulatedCamera` only a plain attribute. Generic tooling (camera UIs, config layers) has to special-case every type to answer "what resolution does this camera stream?".

### Implementation

- `UsbCamera`: replace the `width`/`height` parameters with one `resolution` parameter (v4l2 still sets both values on the device).
- `SimulatedCamera`: replace the constructor arguments and the `resolution` attribute with a `resolution` parameter; `SimulatedDevice.size` is now public and mutable so the parameter can be changed while connected — covered by a new test.
- `RtspCamera` is untouched: RTSP has no resolution control — the encoder profile (`substream`) determines it.
- Update tests and the camera docs examples; the `docs/examples/cameras/control.py` UI already handles a generic `resolution` parameter.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5
