### PR TITLE
Keep a long MCAP recording readable: duration rotation, run names, metadata and the log

### DIFF
--- a/docs/examples/mcap_recording/README.md
+++ b/docs/examples/mcap_recording/README.md
@@ -12,6 +12,15 @@ Recorder
 : The `McapRecorder` writes every registered topic to rotating MCAP files under `~/.rosys/mcap`.
 With `auto_start=False` it stays idle until you press the record button in `developer_ui`.
 
+Runs and parts
+: Each recording is a run named after its start time, and its files are numbered parts: `<run>_01.mcap`, `<run>_02.mcap`, ...
+A part is rotated by size (`max_file_size_mb`) and, with `max_file_duration`, by age.
+`recorder.start(name='mission', metadata={'field': 'north'})` names the run `<timestamp>_mission`, writes the metadata into every part and returns the run's name.
+
+Disk budget
+: Before a part is opened, the oldest recordings are deleted to stay within `max_total_size_mb`, the recorder's own parts first.
+Renamed and merged recordings count as kept and have a bound of their own, `max_kept_size_mb`, which spares the newest kept file.
+
 Topics
 : `add_event_topic` and `add_pose_topic` bind a topic to a RoSys event; the matching Foxglove converter is picked from the payload type automatically.
 The subscription is only active while a recording is open.
@@ -20,6 +29,14 @@ Image quality
 : Camera topics dominate a recording's size.
 Keyword arguments are forwarded to the converter, so `add_event_topic(recorder, '/camera/front/image', event=camera.NEW_IMAGE, quality=75)` records JPEGs at quality 75 instead of the default 90, roughly halving the bytes per frame.
 
+Log lines
+: `logger.addHandler(McapLogHandler(recorder))` records what a logger logs on the `/log` topic, so Foxglove shows the log next to the data it explains.
+
+Merging
+: `await recorder.merge(parts, 'mission_merged', start_time_ns=...)` merges finished recordings into one kept `mission_merged.mcap` and deletes the parts once it is in place.
+Messages before `start_time_ns` are dropped, and the merged file keeps the metadata of every run it holds.
+
 Recordings page
-: `RecordingsPage` mounts a page for listing, renaming, reindexing and downloading recordings, plus a download endpoint at `/api/recordings/{name}`.
+: `RecordingsPage` mounts a page for listing, renaming, reindexing, merging and downloading recordings, plus a download endpoint at `/api/recordings/{name}`.
+The parts of a run are listed as one entry that can be merged with a click.
 The optional `header` callback renders shared navigation at the top of the page.

--- a/rosys/analysis/recording/__init__.py
+++ b/rosys/analysis/recording/__init__.py
@@ -33,6 +33,7 @@ from .mcap_recorder import (
     RecordingInfo,
     RecordingSource,
     TopicSchema,
+    is_auto_named,
 )
 from .paths import DOWNLOAD_PATH, PAGE_PATH
 from .recordings_page_ import RecordingsPage
@@ -62,6 +63,7 @@ __all__ = [
     'image_annotations',
     'imu',
     'integer',
+    'is_auto_named',
     'is_indexed',
     'location_fix',
     'number',

--- a/rosys/analysis/recording/__init__.py
+++ b/rosys/analysis/recording/__init__.py
@@ -35,11 +35,13 @@ from .mcap_recorder import (
     TopicSchema,
     is_auto_named,
 )
+from .merging import MERGE_METADATA_NAME, merge_recordings
 from .paths import DOWNLOAD_PATH, PAGE_PATH
 from .recordings_page_ import RecordingsPage
 
 __all__ = [
     'DOWNLOAD_PATH',
+    'MERGE_METADATA_NAME',
     'NANOSECONDS_PER_SECOND',
     'PAGE_PATH',
     'Converter',
@@ -66,6 +68,7 @@ __all__ = [
     'is_auto_named',
     'is_indexed',
     'location_fix',
+    'merge_recordings',
     'number',
     'pose_in_frame',
     'register',

--- a/rosys/analysis/recording/__init__.py
+++ b/rosys/analysis/recording/__init__.py
@@ -38,13 +38,14 @@ from .mcap_recorder import (
     TopicSchema,
     is_auto_named,
 )
-from .merging import MERGE_METADATA_NAME, merge_recordings
+from .merging import MERGE_METADATA_NAME, METADATA_NAME, merge_recordings
 from .paths import DOWNLOAD_PATH, PAGE_PATH
 from .recordings_page_ import RecordingsPage
 
 __all__ = [
     'DOWNLOAD_PATH',
     'MERGE_METADATA_NAME',
+    'METADATA_NAME',
     'NANOSECONDS_PER_SECOND',
     'PAGE_PATH',
     'Converter',

--- a/rosys/analysis/recording/__init__.py
+++ b/rosys/analysis/recording/__init__.py
@@ -12,6 +12,8 @@ from .converters import (
     text,
 )
 from .foxglove import (
+    LogEntry,
+    McapLogHandler,
     add_pose_topic,
     battery_state,
     camera_calibration,
@@ -22,6 +24,7 @@ from .foxglove import (
     image_annotations,
     imu,
     location_fix,
+    log,
     pose_in_frame,
     transform_3d,
     velocity,
@@ -45,6 +48,8 @@ __all__ = [
     'NANOSECONDS_PER_SECOND',
     'PAGE_PATH',
     'Converter',
+    'LogEntry',
+    'McapLogHandler',
     'McapRecorder',
     'RecordingInfo',
     'RecordingSource',
@@ -68,6 +73,7 @@ __all__ = [
     'is_auto_named',
     'is_indexed',
     'location_fix',
+    'log',
     'merge_recordings',
     'number',
     'pose_in_frame',

--- a/rosys/analysis/recording/foxglove.py
+++ b/rosys/analysis/recording/foxglove.py
@@ -485,10 +485,11 @@ def log() -> Converter:
 class McapLogHandler(logging.Handler):
     """Writes what a logger logs into the recording, so a recording explains itself.
 
-    Attach it to the loggers whose lines belong in the recording, never to the root logger:
-    every library logging anywhere would end up in the file. Handling a record is a message
-    render plus an enqueue — the JSON encoding runs on the recorder's writer thread — and it
-    happens wherever the line is logged, which may be any thread.
+    Attach it to the loggers whose lines belong in the recording, the recorder's own included,
+    but never to the root logger: every library logging anywhere would end up in the file.
+    Handling a record is a message render plus an enqueue — the JSON encoding runs on the
+    recorder's writer thread — and it happens wherever the line is logged, which may be any
+    thread.
     """
 
     def __init__(self, recorder: McapRecorder, topic: str = '/log') -> None:
@@ -506,8 +507,6 @@ class McapLogHandler(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
         if not self._recorder.accepts(self._topic):
             return
-        if record.name == self._recorder.log.name:
-            return  # the recorder logs from inside its queue lock, so recording its own lines would deadlock
         try:
             entry = LogEntry(_log_level(record.levelno), record.getMessage(),
                              record.name, record.filename, record.lineno)

--- a/rosys/analysis/recording/foxglove.py
+++ b/rosys/analysis/recording/foxglove.py
@@ -11,9 +11,10 @@ lives in :mod:`.converters`.
 from __future__ import annotations
 
 import base64
+import logging
 import math
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ...geometry import Pose, Velocity
 from ...hardware.bms_state import BmsState
@@ -441,6 +442,90 @@ def imu() -> Converter:
         }
 
     return custom_message('ImuMeasurement', schema, build)
+
+
+# --------------------------------------------------------------------------- #
+# Log messages
+# --------------------------------------------------------------------------- #
+
+_FOXGLOVE_LOG_LEVELS = ((logging.CRITICAL, 5), (logging.ERROR, 4), (logging.WARNING, 3),
+                        (logging.INFO, 2), (logging.DEBUG, 1))  # foxglove.LogLevel; anything below DEBUG is UNKNOWN
+
+
+class LogEntry(NamedTuple):
+    """One log line, taken off a :class:`logging.LogRecord` before it is queued.
+
+    The message is rendered where the line is logged, so the recording holds what the line
+    said at that moment rather than what its arguments hold once the writer gets to it.
+    """
+    level: int
+    message: str
+    name: str
+    file: str
+    line: int
+
+
+def log() -> Converter:
+    """``LogEntry`` -> ``foxglove.Log`` (what Foxglove's Logs panel renders)."""
+    schema = {
+        'type': 'object',
+        'properties': {
+            'timestamp': _TIME_SCHEMA, 'level': {'type': 'integer'}, 'message': {'type': 'string'},
+            'name': {'type': 'string'}, 'file': {'type': 'string'}, 'line': {'type': 'integer'},
+        },
+    }
+
+    def build(entry: LogEntry, timestamp_ns: int) -> dict:
+        return {'timestamp': _foxglove_time(timestamp_ns), 'level': entry.level, 'message': entry.message,
+                'name': entry.name, 'file': entry.file, 'line': entry.line}
+
+    return custom_message('foxglove.Log', schema, build)
+
+
+class McapLogHandler(logging.Handler):
+    """Writes what a logger logs into the recording, so a recording explains itself.
+
+    Attach it to the loggers whose lines belong in the recording, never to the root logger:
+    every library logging anywhere would end up in the file. Handling a record is a message
+    render plus an enqueue — the JSON encoding runs on the recorder's writer thread — and it
+    happens wherever the line is logged, which may be any thread.
+    """
+
+    def __init__(self, recorder: McapRecorder, topic: str = '/log') -> None:
+        """Register the log topic on ``recorder``.
+
+        :param recorder: the recorder the log lines are written to.
+        :param topic: the topic the lines are recorded on.
+        """
+        super().__init__()
+        self._recorder = recorder
+        self._topic = topic
+        self._converter = log()
+        recorder.add_topic(topic, self._converter.schema)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if not self._recorder.accepts(self._topic):
+            return
+        if record.name == self._recorder.log.name:
+            return  # the recorder logs from inside its queue lock, so recording its own lines would deadlock
+        try:
+            entry = LogEntry(_log_level(record.levelno), record.getMessage(),
+                             record.name, record.filename, record.lineno)
+            self._recorder.log_message(self._topic, entry, encode=self._converter.encode)
+        except Exception:
+            self.handleError(record)  # recording a log line must never break the logging it records
+
+
+def _log_level(levelno: int) -> int:
+    """Map a Python log level onto foxglove's.
+
+    :param levelno: the numeric level of the log record.
+    :return: the foxglove log level, ``0`` (UNKNOWN) for anything below DEBUG.
+    """
+    for threshold, level in _FOXGLOVE_LOG_LEVELS:
+        if levelno >= threshold:
+            return level
+    return 0
 
 
 # --------------------------------------------------------------------------- #

--- a/rosys/analysis/recording/indexing.py
+++ b/rosys/analysis/recording/indexing.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 from mcap.exceptions import McapError
 from mcap.reader import make_reader
-from mcap.records import Channel, Header, Message, Schema
+from mcap.records import Channel, Header, Message, Metadata, Schema
 from mcap.stream_reader import StreamReader
 from mcap.writer import CompressionType, Writer
 from zstandard import ZstdError
@@ -39,8 +39,8 @@ def reindex(path: Path | str, *, chunk_size: int = 1_048_576) -> int:
     """Rewrite ``path`` in place with a summary index; return the recovered message count.
 
     Reads the file sequentially (tolerating a truncated tail from a crash) and
-    writes a fresh, indexed copy. Messages in the final unflushed chunk of a
-    crashed recording are unrecoverable.
+    writes a fresh, indexed copy, metadata records included. Messages in the final
+    unflushed chunk of a crashed recording are unrecoverable.
 
     Only read-side failures on the crashed tail are tolerated; any write-side
     failure (e.g. ENOSPC while the temp copy transiently doubles disk usage)
@@ -83,6 +83,8 @@ def reindex(path: Path | str, *, chunk_size: int = 1_048_576) -> int:
                     channels[record.id] = writer.register_channel(
                         schema_id=schemas.get(record.schema_id, 0), topic=record.topic,
                         message_encoding=record.message_encoding, metadata=record.metadata)
+                elif isinstance(record, Metadata):
+                    writer.add_metadata(record.name, record.metadata)
                 elif isinstance(record, Message) and record.channel_id in channels:
                     writer.add_message(
                         channel_id=channels[record.channel_id], log_time=record.log_time,

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import threading
 from collections.abc import Callable, Collection
 from datetime import UTC, datetime
@@ -43,6 +44,21 @@ _DEFAULT_PAYLOAD_BYTES = 1024
 """Assumed size of a payload whose footprint cannot be measured (a small sensor value)."""
 
 _DROP_WARNING_INTERVAL = 10.0  # seconds between 'queue full' warnings, so drops do not spam the log
+
+_AUTO_NAME = re.compile(r'\d{8}_\d{6}_\d{6}\.mcap')  # the timestamp names _open_new_file generates
+
+
+def is_auto_named(path: Path | str) -> bool:
+    """Whether a recording still carries its generated timestamp name.
+
+    Renaming a recording (see :meth:`McapRecorder.rename_recording`) marks it as worth
+    keeping: the disk budget deletes auto-named files first and renamed ones only when
+    those alone exceed the budget.
+
+    :param path: the recording file to test.
+    :return: ``True`` if the file name is a generated timestamp name.
+    """
+    return _AUTO_NAME.fullmatch(Path(path).name) is not None
 
 
 class _QueuedMessage(NamedTuple):
@@ -98,9 +114,11 @@ class RecordingSource(Protocol):
 class McapRecorder:
     """Records sensor data to MCAP files for replay and analysis in Foxglove Studio.
 
-    Supports automatic file rotation by size and disk budget enforcement. Peak disk usage is
-    ``max_total_size_mb + max_file_size_mb``: the budget is enforced only before a file is
-    opened, so the currently growing file can exceed it by up to one file's worth.
+    Supports automatic file rotation by size and duration, and disk budget enforcement.
+    Peak disk usage is ``max_total_size_mb + max_file_size_mb``: the budget is enforced only
+    before a file is opened, so the currently growing file can exceed it by up to one file's
+    worth. The budget deletes auto-named files (oldest first) before touching renamed ones,
+    so a recording renamed to be kept survives until kept files alone exceed the budget.
 
     Messages are enqueued from the event loop (cheap, non-blocking) and written to disk by a
     single background consumer via ``rosys.run.io_bound`` so that encoding, ZSTD compression
@@ -130,6 +148,7 @@ class McapRecorder:
         *,
         output_dir: Path | str = '~/.rosys/mcap',
         max_file_size_mb: float = 100,
+        max_file_duration: float | None = None,
         max_total_size_mb: float = 1000,
         chunk_size: int = 1_048_576,
         flush_interval: float = 1.0,
@@ -143,10 +162,15 @@ class McapRecorder:
 
         :param output_dir: directory recordings are written to (created if missing).
         :param max_file_size_mb: on-disk size at which the active file is rotated to a new one.
+        :param max_file_duration: seconds after which the active file is rotated to a new one
+            (default: no duration-based rotation). Checked as messages are written, so an idle
+            recording only rotates once data flows again.
         :param max_total_size_mb: disk budget for the directory; the oldest recordings are
-            deleted before a new file is opened to stay under it. Peak disk usage is therefore
-            ``max_total_size_mb + max_file_size_mb`` (the budget is enforced only before a file
-            is opened, so the growing file can exceed it by up to one file's worth).
+            deleted before a new file is opened to stay under it. Auto-named (timestamped)
+            files go first; renamed recordings are deleted only when they alone exceed the
+            budget. Peak disk usage is therefore ``max_total_size_mb + max_file_size_mb``
+            (the budget is enforced only before a file is opened, so the growing file can
+            exceed it by up to one file's worth).
         :param chunk_size: MCAP chunk size in bytes (larger chunks compress better and flush
             less often).
         :param flush_interval: seconds between background flushes of the queue to disk.
@@ -162,6 +186,7 @@ class McapRecorder:
         self.output_dir = Path(output_dir).expanduser()
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.max_file_size = int(max_file_size_mb * 1_048_576)
+        self.max_file_duration = max_file_duration
         self.max_total_size = int(max_total_size_mb * 1_048_576)
         self.chunk_size = chunk_size
         self.profile = profile
@@ -189,6 +214,8 @@ class McapRecorder:
         self._sources: list[RecordingSource] = []
         self._loop: asyncio.AbstractEventLoop | None = None  # captured at start for loop-safe emits
         self._message_count: int = 0
+        self._file_message_count: int = 0
+        self._file_started_at: float = 0.0
         self._dropped_message_count: int = 0
         self._last_drop_warning: float = float('-inf')
         self._is_recording: bool = False
@@ -311,7 +338,9 @@ class McapRecorder:
         The currently-recording file cannot be renamed (the writer holds it open).
         ``new_name`` is reduced to a bare filename and given a ``.mcap`` suffix;
         empty, whitespace-only or dots-only names are rejected (they would escape
-        the output directory) by returning ``None``.
+        the output directory) by returning ``None``. A renamed recording is deleted
+        by the disk budget only when renamed files alone exceed it (see
+        :func:`is_auto_named`).
 
         :param path: the recording to rename.
         :param new_name: the desired name (reduced to a bare ``.mcap`` filename).
@@ -443,6 +472,40 @@ class McapRecorder:
             if file_path is not None:
                 self.RECORDING_STOPPED.emit(file_path)
 
+    async def split(self) -> Path | None:
+        """Finalize the current file and continue recording into a fresh one.
+
+        Lets callers file away the data recorded so far (e.g. after a failure) without
+        interrupting the recording: the queue is drained and the file rotated off the event
+        loop, emitting ``RECORDING_STOPPED`` for the finalized file and ``RECORDING_STARTED``
+        for the new one. A file that holds no messages yet is left growing instead of being
+        churned into an empty recording.
+
+        :return: the finalized file, or ``None`` when not recording or nothing was recorded
+            into the current file yet.
+        """
+        if not self._is_recording:
+            return None
+        return await asyncio.to_thread(self._split)
+
+    def _split(self) -> Path | None:
+        """Drain the queue and rotate. Runs off the loop; takes ``_lock``.
+
+        :return: the finalized file, or ``None`` if the current file holds no messages or
+            the recorder hard-stopped during the drain.
+        """
+        with self._lock:
+            with self._queue_lock:  # brief: only the swap, not the write
+                batch, self._queue = self._queue, []
+                self._queued_bytes = 0
+            self._write_messages(batch)
+            if self._writer is None or self._file_message_count == 0:
+                return None
+            finalized = self._file_path
+            if not self._rotate_file(dropped_on_failure=0):
+                return None
+        return finalized
+
     def log_message(self, topic: str, data: Any, *,
                     encode: Callable[[Any, int], bytes | None] | None = None,
                     timestamp_ns: int | None = None) -> None:
@@ -571,10 +634,15 @@ class McapRecorder:
                 publish_time=message.timestamp_ns,
             )
             self._message_count += 1
+            self._file_message_count += 1
             assert self._file is not None
-            if self._file.tell() >= self.max_file_size:
+            if self._file.tell() >= self.max_file_size or self._file_is_expired():
                 if not self._rotate_file(dropped_on_failure=len(batch) - index - 1):
                     return
+
+    def _file_is_expired(self) -> bool:
+        """Whether the current file has been open longer than ``max_file_duration``."""
+        return self.max_file_duration is not None and rosys.time() - self._file_started_at >= self.max_file_duration
 
     def warn_converter_failure(self, topic: str, stage: str) -> None:
         """Log a converter failure once per topic and stage, so one bad message never floods the log.
@@ -678,6 +746,8 @@ class McapRecorder:
         self._file = open(self._file_path, 'wb')  # pylint: disable=consider-using-with
         self._writer = Writer(self._file, compression=CompressionType.ZSTD, chunk_size=self.chunk_size)
         self._writer.start(profile=self.profile, library=self.library)
+        self._file_started_at = rosys.time()
+        self._file_message_count = 0
         self._topics.clear()
         # add_topic mutates _schemas lock-free from the loop, and start() may replace
         # _selected_topics; snapshot both so this writer-thread iteration cannot race them.
@@ -723,7 +793,7 @@ class McapRecorder:
             except FileNotFoundError:
                 continue  # vanished concurrently (e.g. deleted from the recordings page)
             file_stats.append((path, stat.st_size, stat.st_mtime))
-        file_stats.sort(key=lambda item: item[2])  # oldest first
+        file_stats.sort(key=lambda item: (not is_auto_named(item[0]), item[2]))  # auto-named oldest first, renamed last
         total = sum(size for _, size, _ in file_stats)
         while total > self.max_total_size and file_stats:
             oldest, size, _ = file_stats.pop(0)

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -16,29 +16,23 @@ from nicegui import Event, ui
 
 from ... import rosys
 from .indexing import is_indexed, reindex
+from .merging import METADATA_NAME, STAGING_GLOB, merge_into_place
 from .paths import PAGE_PATH
 
 NANOSECONDS_PER_SECOND = 1_000_000_000
 
 MAX_QUEUED_MESSAGES = 10_000
-"""Cap on the number of unwritten messages held in memory (see also :data:`MAX_QUEUED_BYTES`).
+"""Cap on the number of unwritten messages held in memory, a few seconds of backlog at a robot's topic mix.
 
-At the mix of high-rate topics a robot records (camera frames plus sensors) this is a few
-seconds of backlog, which comfortably absorbs a slow flush. A message-count cap alone does
-not bound memory, though: a queued camera frame holds a full uncompressed image (JPEG
-encoding is deferred to the writer), so 10k frames could be many gigabytes. The byte cap
-:data:`MAX_QUEUED_BYTES` bounds the actual footprint; whichever limit is hit first drops
-the oldest messages (see :meth:`McapRecorder.log_message`) so a stuck writer cannot grow
-the queue until the process runs out of memory.
+A count alone does not bound memory: a queued camera frame holds a full uncompressed image,
+so :data:`MAX_QUEUED_BYTES` caps the footprint too. Whichever limit is hit first drops the
+oldest messages, so a stuck writer cannot grow the queue until the process runs out of memory.
 """
 
 MAX_QUEUED_BYTES = 256 * 1_048_576
-"""Cap on the approximate memory footprint of unwritten messages (256 MB).
+"""Cap on the approximate memory footprint of unwritten messages (256 MB), see :data:`MAX_QUEUED_MESSAGES`.
 
-Enforced alongside :data:`MAX_QUEUED_MESSAGES`; the oldest messages are dropped when
-either limit is exceeded, so a stalled writer cannot grow the queue until the process runs
-out of memory. This matters on an 8 GB Jetson, where 10k raw VGA-to-HD camera frames would
-be tens of gigabytes — far past the count cap yet fatal to memory.
+On an 8 GB Jetson, 10k raw camera frames would be tens of gigabytes — far below the count cap, yet fatal.
 """
 
 _DEFAULT_PAYLOAD_BYTES = 1024
@@ -48,20 +42,14 @@ _DROP_WARNING_INTERVAL = 10.0  # seconds between 'queue full' warnings, so drops
 
 _TIMESTAMP_FORMAT = r'%Y%m%d_%H%M%S_%f'  # microseconds -> unique per run
 
+# part <part> of the run <timestamp> or <timestamp>_<name>, or a single unnumbered <timestamp>.mcap
 _OWN_NAME = re.compile(r'(?P<run>\d{8}_\d{6}_\d{6}(?:_.+)?)_(?P<part>\d{2,})\.mcap|\d{8}_\d{6}_\d{6}\.mcap')
-"""A file the recorder wrote: part ``<part>`` of the run ``<timestamp>`` or ``<timestamp>_<name>``, or a bare
-``<timestamp>.mcap`` recorded as a single unnumbered file."""
-
-METADATA_NAME = 'recording'  # the MCAP metadata record holding the caller's context as JSON
 
 
 def is_auto_named(path: Path | str) -> bool:
-    """Whether a recording is one the recorder wrote itself.
+    """Whether a recording is one the recorder wrote itself: ``<run>_<part>.mcap``, the run named by its start.
 
-    The recorder names every part ``<run>_<part>.mcap``, the run starting with the time it
-    started, so any other name exists because someone or something made it deliberately — a
-    renamed recording, a merged run, a file preserved around a failure. The disk budget
-    deletes the recorder's own files first.
+    Any other name was given deliberately (a renamed, merged or preserved recording); the budget keeps it longer.
 
     :param path: the recording file to test.
     :return: ``True`` if the file name is one the recorder generated.
@@ -135,10 +123,8 @@ class McapRecorder:
     Supports automatic file rotation by size and duration, and disk budget enforcement.
     Peak disk usage is ``max_total_size_mb + max_file_size_mb``: the budget is enforced only
     before a file is opened, so the currently growing file can exceed it by up to one file's
-    worth. The budget deletes the recorder's own files (oldest first) before touching kept
-    ones — renamed, merged or otherwise filed-away recordings (see :func:`is_auto_named`).
-    Kept files have a bound of their own, ``max_kept_size_mb``, so they cannot squeeze the
-    rolling window of the recorder's own files down to nothing.
+    worth. The budget deletes the recorder's own files (oldest first) before kept ones (see
+    :func:`is_auto_named`), which have a bound of their own so they cannot eat the rolling window.
 
     Messages are enqueued from the event loop (cheap, non-blocking) and written to disk by a
     single background consumer via ``rosys.run.io_bound`` so that encoding, ZSTD compression
@@ -186,15 +172,11 @@ class McapRecorder:
         :param max_file_duration: seconds after which the active file is rotated to a new one
             (default: no duration-based rotation). Checked as messages are written, so an idle
             recording only rotates once data flows again.
-        :param max_total_size_mb: disk budget for the directory; the oldest recordings are
-            deleted before a new file is opened to stay under it. The recorder's own
-            numbered files go first; kept recordings are deleted only when they alone
-            exceed the budget. Peak disk usage is therefore ``max_total_size_mb + max_file_size_mb``
-            (the budget is enforced only before a file is opened, so the growing file can
-            exceed it by up to one file's worth).
-        :param max_kept_size_mb: bound for the kept recordings within the budget; beyond it the
-            oldest kept ones are deleted before a new file is opened. The newest kept recording
-            is spared however large it is: it is the one just filed away.
+        :param max_total_size_mb: disk budget for the directory; the oldest recordings are deleted before
+            a new file is opened to stay under it, the recorder's own numbered files first. Peak disk usage
+            is therefore ``max_total_size_mb + max_file_size_mb``, as the growing file is not counted.
+        :param max_kept_size_mb: bound for kept recordings within the budget; beyond it the oldest are
+            deleted, sparing the newest (the one just filed away) however large it is.
         :param chunk_size: MCAP chunk size in bytes (larger chunks compress better and flush
             less often).
         :param flush_interval: seconds between background flushes of the queue to disk.
@@ -251,8 +233,9 @@ class McapRecorder:
         self._warned_topics: set[str] = set()
         self._warned_converter_topics: set[tuple[str, str]] = set()
         self._disk_stats = _DiskStats(0, 0, 0)
+        self._merging: set[str] = set()
 
-        self._cleanup_orphaned_reindex_files()
+        self._remove_orphaned_temporary_files()
         if auto_start:
             rosys.on_startup(self.start)
         rosys.on_repeat(self._flush, flush_interval)
@@ -307,6 +290,11 @@ class McapRecorder:
     def current_recording(self) -> Path | None:
         """The file currently being written (unindexed until stopped), else None."""
         return self._file_path if self._is_recording else None
+
+    @property
+    def merging(self) -> frozenset[str]:
+        """The names of the recordings being merged right now (see :meth:`merge`)."""
+        return frozenset(self._merging)
 
     def accepts(self, topic: str) -> bool:
         """Whether a message on ``topic`` would currently be recorded.
@@ -364,17 +352,14 @@ class McapRecorder:
     def rename_recording(self, path: Path | str, new_name: str) -> Path | None:
         """Rename a recording within the output directory; returns the new path or None.
 
-        The currently-recording file cannot be renamed (the writer holds it open).
-        ``new_name`` is reduced to a bare filename and given a ``.mcap`` suffix;
-        empty, whitespace-only or dots-only names are rejected (they would escape
-        the output directory) by returning ``None``. A renamed recording counts as kept
-        (see :func:`is_auto_named` and ``max_kept_size_mb``).
+        The currently-recording file cannot be renamed (the writer holds it open). Empty,
+        whitespace-only or dots-only names would escape the output directory and are rejected.
+        A renamed recording counts as kept (see :func:`is_auto_named`).
 
         :param path: the recording to rename.
         :param new_name: the desired name (reduced to a bare ``.mcap`` filename).
         :return: the new path, or ``None`` if the rename was rejected or the target exists.
-        :raises ValueError: if the new name reads as one of the recorder's own files, which the
-            disk budget would delete first.
+        :raises ValueError: if the new name reads as one of the recorder's own files.
         """
         path = Path(path)
         if path.parent != self.output_dir or not path.exists() or path == self.current_recording:
@@ -414,6 +399,45 @@ class McapRecorder:
             recovered = await rosys.run.io_bound(reindex, path)
             if recovered is not None:
                 self.log.info('reindexed %s (%d messages recovered)', path.name, recovered)
+
+    async def merge(self, sources: list[Path], name: str, *, start_time_ns: int = 0) -> Path | None:
+        """Merge finished recordings into the kept recording ``<name>.mcap``, deleting them once it is in place.
+
+        Runs off the loop; a failed merge leaves the sources untouched (see :func:`~.merging.merge_into_place`),
+        a source that cannot be deleted afterwards is only logged.
+
+        :param sources: finished recordings in the output directory, oldest first.
+        :param name: the name of the merged recording, without ``.mcap``.
+        :param start_time_ns: messages logged before this time are dropped (default: keep all).
+        :return: the merged recording, or ``None`` if no message was left to merge (the sources are kept).
+        :raises ValueError: if ``name`` is no plain file name or reads as the recorder's own, or a
+            source is no finished recording in the output directory.
+        :raises FileExistsError: if ``<name>.mcap`` exists or is being merged already.
+        :raises RuntimeError: if the app shut down before the merge ran; the sources are kept.
+        """
+        _check_file_name(name)
+        target = self.output_dir / f'{name}.mcap'
+        if is_auto_named(target):
+            raise ValueError(f'{target.name} reads as a file the recorder wrote itself, which its budget deletes first')
+        if not sources or any(source.parent != self.output_dir or source == self.current_recording
+                              for source in sources):
+            raise ValueError('only finished recordings in the output directory can be merged')
+        if name in self._merging or target.exists():
+            raise FileExistsError(f'{target.name} exists or is being merged already')
+        self._merging.add(name)
+        try:
+            result = await rosys.run.io_bound(merge_into_place, sources, target, start_time_ns=start_time_ns)
+        finally:
+            self._merging.discard(name)
+        if result is None:
+            raise RuntimeError('the merge did not run, the app is shutting down')
+        count, undeleted = result
+        if not count:
+            return None
+        self.log.info('merged %d recordings into %s (%d messages)', len(sources), target.name, count)
+        if undeleted:
+            self.log.warning('merged into %s, but could not delete %s', target.name, [path.name for path in undeleted])
+        return target
 
     def add_topic(self, topic: str, schema: TopicSchema) -> None:
         """Register a topic with its schema and encoding.
@@ -487,11 +511,7 @@ class McapRecorder:
         with self._queue_lock:  # drop any backlog left by a previously aborted recording
             self._queue.clear()
             self._queued_bytes = 0
-        # Budget enforcement and opening the file run on the loop here because start must
-        # synchronously establish the recording before returning (callers read
-        # current_recording and receive RECORDING_STARTED immediately). start is a rare
-        # user/lifecycle action; the hot periodic-flush path enforces the budget off the
-        # loop in the io_bound writer (see _write_batch -> _write_messages -> _rotate).
+        # on the loop: callers read current_recording right after start; rotations enforce it off the loop
         self._enforce_disk_budget()
         with self._lock:
             self._open_new_file()
@@ -510,9 +530,8 @@ class McapRecorder:
         the MCAP file, which can take seconds for a large backlog; it runs on a worker thread
         via :func:`asyncio.to_thread` — deliberately not ``rosys.run.io_bound``, which refuses
         work once the app is stopping (and ``stop`` is wired to ``rosys.on_shutdown``) — so it
-        never blocks the event loop. ``start()`` is refused until the drain is done. A final
-        part without messages (e.g. from rapid toggling) is discarded; otherwise
-        ``RECORDING_STOPPED`` is emitted on the loop with the finalized path.
+        never blocks the event loop; ``start()`` is refused meanwhile. A final part without
+        messages is discarded, otherwise ``RECORDING_STOPPED`` is emitted with its path.
         """
         if not self._is_recording:
             return
@@ -567,13 +586,10 @@ class McapRecorder:
     def _enforce_queue_cap(self) -> bool:
         """Drop the oldest queued messages when the disk cannot keep up. Caller holds ``_queue_lock``.
 
-        Bounds memory by both message count (:attr:`max_queued_messages`) and approximate
-        payload bytes (:attr:`max_queued_bytes`) — a queued camera frame is a full
-        uncompressed image, so the count cap alone would not stop the queue from growing to
-        many gigabytes. The oldest messages are dropped until the queue is under both limits.
+        The oldest messages are dropped until the queue is under both :attr:`max_queued_messages`
+        and :attr:`max_queued_bytes` (see :data:`MAX_QUEUED_BYTES`).
 
-        :return: whether the drop is due to be logged, at most once per ``_DROP_WARNING_INTERVAL``
-            so a persistent stall does not flood the log.
+        :return: whether the drop is due to be logged, at most once per ``_DROP_WARNING_INTERVAL``.
         """
         if len(self._queue) <= self.max_queued_messages and self._queued_bytes <= self.max_queued_bytes:
             return False
@@ -609,12 +625,10 @@ class McapRecorder:
     def _drain_and_close(self) -> tuple[Path | None, int]:
         """Write everything still queued and finalize the file. Runs off the loop; takes ``_lock``.
 
-        Used by ``stop()``. The final drain may rotate, so the finalized path is read after
-        writing. ``_close_file`` runs in a ``finally`` so even a raising write still finalizes
-        (never leaks) the open file.
+        The final drain may rotate, so the path is read after writing; ``_close_file`` runs in a
+        ``finally`` so even a raising write still finalizes the open file.
 
-        :return: the path of the finalized file (``None`` if no file was open) and the number of
-            messages it holds.
+        :return: the finalized file (``None`` if none was open) and the number of messages it holds.
         """
         with self._lock:
             try:
@@ -844,19 +858,19 @@ class McapRecorder:
             path.unlink(missing_ok=True)
             self.log.info('deleted old recording: %s (freed %.1f MB)', path.name, size / 1_048_576)
 
-    def _cleanup_orphaned_reindex_files(self) -> None:
-        """Remove reindex temp files left by a crash mid-rebuild. Run once at construction, never during operation.
+    def _remove_orphaned_temporary_files(self) -> None:
+        """Remove reindex and merge temp files left by a crash. Run once at construction, never during operation.
 
-        A live reindex writes to the same ``*.mcap.reindex-*`` name; deleting it mid-run would
-        destroy the recovery, so this must not run from the periodic disk-budget path. Orphans
-        are otherwise invisible to the budget, scan and UI (they do not match the ``*.mcap`` glob).
+        Deleting one mid-run would destroy the result, so this never runs from the disk-budget path.
+        Orphans are otherwise invisible to the budget, scan and UI (they do not match ``*.mcap``).
         """
-        for path in self.output_dir.glob('*.mcap.reindex*'):
-            try:
-                path.unlink()
-                self.log.warning('removed orphaned reindex temp file: %s', path.name)
-            except OSError:
-                pass
+        for pattern in ('*.mcap.reindex*', STAGING_GLOB):
+            for path in self.output_dir.glob(pattern):
+                try:
+                    path.unlink()
+                    self.log.warning('removed orphaned temporary file: %s', path.name)
+                except OSError:
+                    pass
 
     def developer_ui(self) -> None:
         """Developer panel: auto-refreshing stats, start/stop buttons, and a topic selection.

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -241,6 +241,7 @@ class McapRecorder:
         self._dropped_message_count: int = 0
         self._last_drop_warning: float = float('-inf')
         self._is_recording: bool = False
+        self._is_stopping: bool = False  # stop() is finalizing the last part; start() is refused meanwhile
         self._warned_topics: set[str] = set()
         self._warned_converter_topics: set[tuple[str, str]] = set()
         self._disk_stats = _DiskStats(0, 0, 0)
@@ -454,11 +455,15 @@ class McapRecorder:
             ``<run>_02.mcap``, ... as they rotate, so they sort and read as a unit.
         :param metadata: written into every part of this run as a JSON metadata record, so a
             part carries the context it was recorded in.
-        :return: the name of the run, or ``None`` if a recording is already running.
+        :return: the name of the run, or ``None`` if a recording is already running or the
+            previous one is still being finalized.
         :raises ValueError: if ``name`` is not a plain file name.
         :raises TypeError: if ``metadata`` cannot be serialized to JSON.
         """
         if self._is_recording:
+            return None
+        if self._is_stopping:
+            self.log.warning('not starting a recording while the previous one is still being finalized')
             return None
         if name is not None:
             _check_file_name(name)
@@ -500,21 +505,27 @@ class McapRecorder:
         the MCAP file, which can take seconds for a large backlog; it runs on a worker thread
         via :func:`asyncio.to_thread` — deliberately not ``rosys.run.io_bound``, which refuses
         work once the app is stopping (and ``stop`` is wired to ``rosys.on_shutdown``) — so it
-        never blocks the event loop. An empty recording (e.g. from rapid toggling) is discarded;
-        otherwise ``RECORDING_STOPPED`` is emitted on the loop with the finalized path.
+        never blocks the event loop. ``start()`` is refused until the drain is done. A final
+        part without messages (e.g. from rapid toggling) is discarded; otherwise
+        ``RECORDING_STOPPED`` is emitted on the loop with the finalized path.
         """
         if not self._is_recording:
             return
         self._is_recording = False
-        self._stop_sources()
-        file_path = await asyncio.to_thread(self._drain_and_close)
-        if file_path is not None and self._message_count == 0:
-            file_path.unlink(missing_ok=True)  # discard empty recordings (e.g. from rapid toggling)
+        self._is_stopping = True
+        try:
+            self._stop_sources()
+            file_path, file_message_count = await asyncio.to_thread(self._drain_and_close)
+        finally:
+            self._is_stopping = False
+        if file_path is None:
+            return
+        if file_message_count == 0:
+            file_path.unlink(missing_ok=True)
             self.log.info('discarded empty recording: %s', file_path.name)
         else:
-            self.log.info('stopped MCAP recording (%d messages total)', self._message_count)
-            if file_path is not None:
-                self.RECORDING_STOPPED.emit(file_path)
+            self.log.info('stopped MCAP recording: %s', file_path.name)
+            self.RECORDING_STOPPED.emit(file_path)
 
     def log_message(self, topic: str, data: Any, *,
                     encode: Callable[[Any, int], bytes | None] | None = None,
@@ -542,36 +553,40 @@ class McapRecorder:
         with self._queue_lock:  # microsecond hold; never blocks behind a write
             self._queue.append(_QueuedMessage(topic, data, encode, timestamp_ns, size))
             self._queued_bytes += size
-            self._enforce_queue_cap()
+            warn = self._enforce_queue_cap()
+        if warn:  # outside the lock: a log handler may record the line, which enqueues again
+            self.log.warning('recording queue full (cap %d messages / %d MB); dropping oldest — disk cannot keep up '
+                             '(%d dropped so far)', self.max_queued_messages, self.max_queued_bytes // 1_048_576,
+                             self._dropped_message_count)
 
-    def _enforce_queue_cap(self) -> None:
+    def _enforce_queue_cap(self) -> bool:
         """Drop the oldest queued messages when the disk cannot keep up. Caller holds ``_queue_lock``.
 
         Bounds memory by both message count (:attr:`max_queued_messages`) and approximate
         payload bytes (:attr:`max_queued_bytes`) — a queued camera frame is a full
         uncompressed image, so the count cap alone would not stop the queue from growing to
-        many gigabytes. The oldest messages are dropped until the queue is under both limits;
-        the drop is logged at most once per ``_DROP_WARNING_INTERVAL`` so a persistent stall
-        does not flood the log.
+        many gigabytes. The oldest messages are dropped until the queue is under both limits.
+
+        :return: whether the drop is due to be logged, at most once per ``_DROP_WARNING_INTERVAL``
+            so a persistent stall does not flood the log.
         """
         if len(self._queue) <= self.max_queued_messages and self._queued_bytes <= self.max_queued_bytes:
-            return
+            return False
         drop = max(0, len(self._queue) - self.max_queued_messages)
         freed = sum(self._queue[i].size for i in range(drop))
         while drop < len(self._queue) and self._queued_bytes - freed > self.max_queued_bytes:
             freed += self._queue[drop].size
             drop += 1
         if drop == 0:
-            return
+            return False
         del self._queue[:drop]
         self._queued_bytes -= freed
         self._dropped_message_count += drop
         now = rosys.time()
-        if now - self._last_drop_warning >= _DROP_WARNING_INTERVAL:
-            self.log.warning('recording queue full (cap %d messages / %d MB); dropping oldest — disk cannot keep up '
-                             '(%d dropped so far)', self.max_queued_messages, self.max_queued_bytes // 1_048_576,
-                             self._dropped_message_count)
-            self._last_drop_warning = now
+        if now - self._last_drop_warning < _DROP_WARNING_INTERVAL:
+            return False
+        self._last_drop_warning = now
+        return True
 
     async def _flush(self) -> None:
         if not self._is_recording or not self._queue:
@@ -586,14 +601,15 @@ class McapRecorder:
                 self._queued_bytes = 0
             self._write_messages(batch)
 
-    def _drain_and_close(self) -> Path | None:
+    def _drain_and_close(self) -> tuple[Path | None, int]:
         """Write everything still queued and finalize the file. Runs off the loop; takes ``_lock``.
 
         Used by ``stop()``. The final drain may rotate, so the finalized path is read after
         writing. ``_close_file`` runs in a ``finally`` so even a raising write still finalizes
         (never leaks) the open file.
 
-        :return: the path of the finalized file, or ``None`` if no file was open.
+        :return: the path of the finalized file (``None`` if no file was open) and the number of
+            messages it holds.
         """
         with self._lock:
             try:
@@ -602,9 +618,9 @@ class McapRecorder:
                     self._queued_bytes = 0
                 self._write_messages(batch)
             finally:
-                file_path = self._file_path
+                file_path = None if self._file is None else self._file_path
                 self._close_file()
-        return file_path
+        return file_path, self._file_message_count
 
     def _write_messages(self, batch: list[_QueuedMessage]) -> None:
         """Encode and write a batch of messages. Caller must hold ``_lock``; runs on the writer thread.
@@ -634,6 +650,10 @@ class McapRecorder:
                 continue
             if data is None:
                 continue  # converter chose to skip this value
+            assert self._file is not None
+            if self._file.tell() >= self.max_file_size or self._file_is_expired():  # rotate only for a message
+                if not self._rotate_file(dropped_on_failure=len(batch) - index):
+                    return
             if message.topic not in self._topics:
                 self._register_topic(message.topic, schema)
             assert self._writer is not None
@@ -645,10 +665,6 @@ class McapRecorder:
             )
             self._message_count += 1
             self._file_message_count += 1
-            assert self._file is not None
-            if self._file.tell() >= self.max_file_size or self._file_is_expired():
-                if not self._rotate_file(dropped_on_failure=len(batch) - index - 1):
-                    return
 
     def _file_is_expired(self) -> bool:
         """Whether the current file has been open longer than ``max_file_duration``."""

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -45,7 +46,11 @@ _DEFAULT_PAYLOAD_BYTES = 1024
 
 _DROP_WARNING_INTERVAL = 10.0  # seconds between 'queue full' warnings, so drops do not spam the log
 
-_AUTO_NAME = re.compile(r'\d{8}_\d{6}_\d{6}\.mcap')  # the timestamp names _open_new_file generates
+_AUTO_NAME = re.compile(r'\d{8}_\d{6}(_\w+)*\.mcap')  # the timestamped names _open_new_file generates
+
+TIMESTAMP_FORMAT = r'%Y%m%d_%H%M%S_%f'  # microseconds -> unique per recording
+
+METADATA_NAME = 'recording'  # the MCAP metadata record holding the caller's context as JSON
 
 
 def is_auto_named(path: Path | str) -> bool:
@@ -212,6 +217,9 @@ class McapRecorder:
         self._lock = threading.Lock()  # serializes writer access; may be held for a full write
         self._queue_lock = threading.Lock()  # guards queue mutation only; held for microseconds
         self._sources: list[RecordingSource] = []
+        self._session_name: str | None = None
+        self._session_metadata: dict | None = None
+        self._part_index: int = 0
         self._loop: asyncio.AbstractEventLoop | None = None  # captured at start for loop-safe emits
         self._message_count: int = 0
         self._file_message_count: int = 0
@@ -413,7 +421,8 @@ class McapRecorder:
         if self._is_recording:
             source.start()
 
-    def start(self, topics: Collection[str] | None = None) -> None:
+    def start(self, topics: Collection[str] | None = None, *,
+              name: str | None = None, metadata: dict | None = None) -> None:
         """Start a new recording.
 
         :param topics: record only these topics; all others are dropped (default: record
@@ -421,6 +430,11 @@ class McapRecorder:
             recording started is picked up as soon as it exists. The selection lasts for
             this recording; the next ``start()`` records everything again unless a new
             selection is passed.
+        :param name: base name for this recording's files, which are numbered
+            ``<name>_01.mcap``, ``<name>_02.mcap``, ... as they rotate, so the files of one
+            recording sort and read as a unit (default: a timestamp).
+        :param metadata: written into every file of this recording as a JSON metadata
+            record, so a segment carries the context it was recorded in.
         """
         if self._is_recording:
             return
@@ -429,6 +443,9 @@ class McapRecorder:
         except RuntimeError:
             self._loop = None  # started outside a running loop (e.g. a synchronous test)
         self._selected_topics = set(topics) if topics is not None else None
+        self._session_name = name or datetime.now(tz=UTC).strftime(TIMESTAMP_FORMAT)
+        self._session_metadata = metadata
+        self._part_index = 0
         self._message_count = 0
         self._dropped_message_count = 0
         with self._queue_lock:  # drop any backlog left by a previously aborted recording
@@ -741,11 +758,14 @@ class McapRecorder:
     def _open_new_file(self) -> None:
         if self._file is not None:  # never overwrite or leak a still-open file (defensive against a double open)
             self._close_file()
-        timestamp = datetime.now(tz=UTC).strftime('%Y%m%d_%H%M%S_%f')  # microseconds -> unique per file
-        self._file_path = self.output_dir / f'{timestamp}.mcap'
+        self._part_index += 1
+        name = self._session_name or datetime.now(tz=UTC).strftime(TIMESTAMP_FORMAT)
+        self._file_path = self.output_dir / f'{name}_{self._part_index:02d}.mcap'
         self._file = open(self._file_path, 'wb')  # pylint: disable=consider-using-with
         self._writer = Writer(self._file, compression=CompressionType.ZSTD, chunk_size=self.chunk_size)
         self._writer.start(profile=self.profile, library=self.library)
+        if self._session_metadata is not None:  # per file: a rotated segment must carry it too
+            self._writer.add_metadata(METADATA_NAME, {'json': json.dumps(self._session_metadata)})
         self._file_started_at = rosys.time()
         self._file_message_count = 0
         self._topics.clear()

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -46,9 +46,11 @@ _DEFAULT_PAYLOAD_BYTES = 1024
 
 _DROP_WARNING_INTERVAL = 10.0  # seconds between 'queue full' warnings, so drops do not spam the log
 
-_AUTO_NAME = re.compile(r'\d{8}_\d{6}(_\w+)*_\d+\.mcap')  # the numbered names _open_new_file generates
+_TIMESTAMP_FORMAT = r'%Y%m%d_%H%M%S_%f'  # microseconds -> unique per run
 
-TIMESTAMP_FORMAT = r'%Y%m%d_%H%M%S_%f'  # microseconds -> unique per recording
+_OWN_NAME = re.compile(r'(?P<run>\d{8}_\d{6}_\d{6}(?:_.+)?)_(?P<part>\d{2,})\.mcap|\d{8}_\d{6}_\d{6}\.mcap')
+"""A file the recorder wrote: part ``<part>`` of the run ``<timestamp>`` or ``<timestamp>_<name>``, or a bare
+``<timestamp>.mcap`` recorded as a single unnumbered file."""
 
 METADATA_NAME = 'recording'  # the MCAP metadata record holding the caller's context as JSON
 
@@ -56,15 +58,25 @@ METADATA_NAME = 'recording'  # the MCAP metadata record holding the caller's con
 def is_auto_named(path: Path | str) -> bool:
     """Whether a recording is one the recorder wrote itself.
 
-    Every file the recorder writes ends in a part number, so a name without one exists
-    because someone or something made it deliberately — a renamed recording, a merged
-    run, a file preserved around a failure. The disk budget deletes the recorder's own
-    files first and those kept files only when they alone exceed the budget.
+    The recorder names every part ``<run>_<part>.mcap``, the run starting with the time it
+    started, so any other name exists because someone or something made it deliberately — a
+    renamed recording, a merged run, a file preserved around a failure. The disk budget
+    deletes the recorder's own files first.
 
     :param path: the recording file to test.
     :return: ``True`` if the file name is one the recorder generated.
     """
-    return _AUTO_NAME.fullmatch(Path(path).name) is not None
+    return _OWN_NAME.fullmatch(Path(path).name) is not None
+
+
+def _check_file_name(name: str) -> None:
+    """Refuse a name that is not a plain file name, so no recording lands outside the output directory.
+
+    :param name: the name to check.
+    :raises ValueError: if the name is empty, whitespace or dots only, or contains a path separator.
+    """
+    if Path(name).name != name or not name.strip('.').strip():
+        raise ValueError(f'not a plain file name: {name!r}')
 
 
 class _QueuedMessage(NamedTuple):
@@ -219,8 +231,8 @@ class McapRecorder:
         self._lock = threading.Lock()  # serializes writer access; may be held for a full write
         self._queue_lock = threading.Lock()  # guards queue mutation only; held for microseconds
         self._sources: list[RecordingSource] = []
-        self._session_name: str | None = None
-        self._session_metadata: dict | None = None
+        self._run_name: str = ''
+        self._run_metadata: str | None = None  # JSON, serialized once at start
         self._part_index: int = 0
         self._loop: asyncio.AbstractEventLoop | None = None  # captured at start for loop-safe emits
         self._message_count: int = 0
@@ -355,6 +367,8 @@ class McapRecorder:
         :param path: the recording to rename.
         :param new_name: the desired name (reduced to a bare ``.mcap`` filename).
         :return: the new path, or ``None`` if the rename was rejected or the target exists.
+        :raises ValueError: if the new name reads as one of the recorder's own files, which the
+            disk budget would delete first.
         """
         path = Path(path)
         if path.parent != self.output_dir or not path.exists() or path == self.current_recording:
@@ -367,6 +381,9 @@ class McapRecorder:
             target = target.with_suffix('.mcap')
         if target == path:
             return None
+        if is_auto_named(target):
+            raise ValueError(f'{target.name} reads as a file the recorder wrote itself, '
+                             'which its disk budget deletes first')
         try:
             os.link(path, target)  # atomic: fails if the target exists, so a racing rename cannot clobber a recording
         except OSError:
@@ -424,7 +441,7 @@ class McapRecorder:
             source.start()
 
     def start(self, topics: Collection[str] | None = None, *,
-              name: str | None = None, metadata: dict | None = None) -> None:
+              name: str | None = None, metadata: dict | None = None) -> str | None:
         """Start a new recording.
 
         :param topics: record only these topics; all others are dropped (default: record
@@ -432,21 +449,28 @@ class McapRecorder:
             recording started is picked up as soon as it exists. The selection lasts for
             this recording; the next ``start()`` records everything again unless a new
             selection is passed.
-        :param name: base name for this recording's files, which are numbered
-            ``<name>_01.mcap``, ``<name>_02.mcap``, ... as they rotate, so the files of one
-            recording sort and read as a unit (default: a timestamp).
-        :param metadata: written into every file of this recording as a JSON metadata
-            record, so a segment carries the context it was recorded in.
+        :param name: appended to the start time to name the run, ``<timestamp>_<name>``
+            (default: the start time alone). The run's parts are numbered ``<run>_01.mcap``,
+            ``<run>_02.mcap``, ... as they rotate, so they sort and read as a unit.
+        :param metadata: written into every part of this run as a JSON metadata record, so a
+            part carries the context it was recorded in.
+        :return: the name of the run, or ``None`` if a recording is already running.
+        :raises ValueError: if ``name`` is not a plain file name.
+        :raises TypeError: if ``metadata`` cannot be serialized to JSON.
         """
         if self._is_recording:
-            return
+            return None
+        if name is not None:
+            _check_file_name(name)
+        run_metadata = json.dumps(metadata) if metadata is not None else None
         try:
             self._loop = asyncio.get_running_loop()  # captured for loop-safe emits from the writer thread
         except RuntimeError:
             self._loop = None  # started outside a running loop (e.g. a synchronous test)
         self._selected_topics = set(topics) if topics is not None else None
-        self._session_name = name or datetime.now(tz=UTC).strftime(TIMESTAMP_FORMAT)
-        self._session_metadata = metadata
+        timestamp = datetime.now(tz=UTC).strftime(_TIMESTAMP_FORMAT)
+        self._run_name = f'{timestamp}_{name}' if name is not None else timestamp
+        self._run_metadata = run_metadata
         self._part_index = 0
         self._message_count = 0
         self._dropped_message_count = 0
@@ -467,6 +491,7 @@ class McapRecorder:
             source.start()
         self.log.info('started MCAP recording: %s', self._file_path)
         self.RECORDING_STARTED.emit(self._file_path)
+        return self._run_name
 
     async def stop(self) -> None:
         """Stop recording, drain the queue, and finalize the file off the event loop.
@@ -727,13 +752,12 @@ class McapRecorder:
         if self._file is not None:  # never overwrite or leak a still-open file (defensive against a double open)
             self._close_file()
         self._part_index += 1
-        name = self._session_name or datetime.now(tz=UTC).strftime(TIMESTAMP_FORMAT)
-        self._file_path = self.output_dir / f'{name}_{self._part_index:02d}.mcap'
+        self._file_path = self.output_dir / f'{self._run_name}_{self._part_index:02d}.mcap'
         self._file = open(self._file_path, 'wb')  # pylint: disable=consider-using-with
         self._writer = Writer(self._file, compression=CompressionType.ZSTD, chunk_size=self.chunk_size)
         self._writer.start(profile=self.profile, library=self.library)
-        if self._session_metadata is not None:  # per file: a rotated segment must carry it too
-            self._writer.add_metadata(METADATA_NAME, {'json': json.dumps(self._session_metadata)})
+        if self._run_metadata is not None:  # per part: a rotated part must carry it too
+            self._writer.add_metadata(METADATA_NAME, {'json': self._run_metadata})
         self._file_started_at = rosys.time()
         self._file_message_count = 0
         self._topics.clear()

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -46,7 +46,7 @@ _DEFAULT_PAYLOAD_BYTES = 1024
 
 _DROP_WARNING_INTERVAL = 10.0  # seconds between 'queue full' warnings, so drops do not spam the log
 
-_AUTO_NAME = re.compile(r'\d{8}_\d{6}(_\w+)*\.mcap')  # the timestamped names _open_new_file generates
+_AUTO_NAME = re.compile(r'\d{8}_\d{6}(_\w+)*_\d+\.mcap')  # the numbered names _open_new_file generates
 
 TIMESTAMP_FORMAT = r'%Y%m%d_%H%M%S_%f'  # microseconds -> unique per recording
 
@@ -54,14 +54,15 @@ METADATA_NAME = 'recording'  # the MCAP metadata record holding the caller's con
 
 
 def is_auto_named(path: Path | str) -> bool:
-    """Whether a recording still carries its generated timestamp name.
+    """Whether a recording is one the recorder wrote itself.
 
-    Renaming a recording (see :meth:`McapRecorder.rename_recording`) marks it as worth
-    keeping: the disk budget deletes auto-named files first and renamed ones only when
-    those alone exceed the budget.
+    Every file the recorder writes ends in a part number, so a name without one exists
+    because someone or something made it deliberately — a renamed recording, a merged
+    run, a file preserved around a failure. The disk budget deletes the recorder's own
+    files first and those kept files only when they alone exceed the budget.
 
     :param path: the recording file to test.
-    :return: ``True`` if the file name is a generated timestamp name.
+    :return: ``True`` if the file name is one the recorder generated.
     """
     return _AUTO_NAME.fullmatch(Path(path).name) is not None
 
@@ -122,8 +123,9 @@ class McapRecorder:
     Supports automatic file rotation by size and duration, and disk budget enforcement.
     Peak disk usage is ``max_total_size_mb + max_file_size_mb``: the budget is enforced only
     before a file is opened, so the currently growing file can exceed it by up to one file's
-    worth. The budget deletes auto-named files (oldest first) before touching renamed ones,
-    so a recording renamed to be kept survives until kept files alone exceed the budget.
+    worth. The budget deletes the recorder's own files (oldest first) before touching kept
+    ones, so a recording filed away to be kept survives until kept files alone exceed the
+    budget.
 
     Messages are enqueued from the event loop (cheap, non-blocking) and written to disk by a
     single background consumer via ``rosys.run.io_bound`` so that encoding, ZSTD compression
@@ -171,9 +173,9 @@ class McapRecorder:
             (default: no duration-based rotation). Checked as messages are written, so an idle
             recording only rotates once data flows again.
         :param max_total_size_mb: disk budget for the directory; the oldest recordings are
-            deleted before a new file is opened to stay under it. Auto-named (timestamped)
-            files go first; renamed recordings are deleted only when they alone exceed the
-            budget. Peak disk usage is therefore ``max_total_size_mb + max_file_size_mb``
+            deleted before a new file is opened to stay under it. The recorder's own
+            numbered files go first; kept recordings are deleted only when they alone
+            exceed the budget. Peak disk usage is therefore ``max_total_size_mb + max_file_size_mb``
             (the budget is enforced only before a file is opened, so the growing file can
             exceed it by up to one file's worth).
         :param chunk_size: MCAP chunk size in bytes (larger chunks compress better and flush
@@ -347,7 +349,7 @@ class McapRecorder:
         ``new_name`` is reduced to a bare filename and given a ``.mcap`` suffix;
         empty, whitespace-only or dots-only names are rejected (they would escape
         the output directory) by returning ``None``. A renamed recording is deleted
-        by the disk budget only when renamed files alone exceed it (see
+        by the disk budget only when kept files alone exceed it (see
         :func:`is_auto_named`).
 
         :param path: the recording to rename.
@@ -813,7 +815,7 @@ class McapRecorder:
             except FileNotFoundError:
                 continue  # vanished concurrently (e.g. deleted from the recordings page)
             file_stats.append((path, stat.st_size, stat.st_mtime))
-        file_stats.sort(key=lambda item: (not is_auto_named(item[0]), item[2]))  # auto-named oldest first, renamed last
+        file_stats.sort(key=lambda item: (not is_auto_named(item[0]), item[2]))  # own files oldest first, kept last
         total = sum(size for _, size, _ in file_stats)
         while total > self.max_total_size and file_stats:
             oldest, size, _ = file_stats.pop(0)

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -136,8 +136,9 @@ class McapRecorder:
     Peak disk usage is ``max_total_size_mb + max_file_size_mb``: the budget is enforced only
     before a file is opened, so the currently growing file can exceed it by up to one file's
     worth. The budget deletes the recorder's own files (oldest first) before touching kept
-    ones, so a recording filed away to be kept survives until kept files alone exceed the
-    budget.
+    ones — renamed, merged or otherwise filed-away recordings (see :func:`is_auto_named`).
+    Kept files have a bound of their own, ``max_kept_size_mb``, so they cannot squeeze the
+    rolling window of the recorder's own files down to nothing.
 
     Messages are enqueued from the event loop (cheap, non-blocking) and written to disk by a
     single background consumer via ``rosys.run.io_bound`` so that encoding, ZSTD compression
@@ -169,6 +170,7 @@ class McapRecorder:
         max_file_size_mb: float = 100,
         max_file_duration: float | None = None,
         max_total_size_mb: float = 1000,
+        max_kept_size_mb: float = 500,
         chunk_size: int = 1_048_576,
         flush_interval: float = 1.0,
         profile: str = 'rosys',
@@ -190,6 +192,9 @@ class McapRecorder:
             exceed the budget. Peak disk usage is therefore ``max_total_size_mb + max_file_size_mb``
             (the budget is enforced only before a file is opened, so the growing file can
             exceed it by up to one file's worth).
+        :param max_kept_size_mb: bound for the kept recordings within the budget; beyond it the
+            oldest kept ones are deleted before a new file is opened. The newest kept recording
+            is spared however large it is: it is the one just filed away.
         :param chunk_size: MCAP chunk size in bytes (larger chunks compress better and flush
             less often).
         :param flush_interval: seconds between background flushes of the queue to disk.
@@ -207,6 +212,7 @@ class McapRecorder:
         self.max_file_size = int(max_file_size_mb * 1_048_576)
         self.max_file_duration = max_file_duration
         self.max_total_size = int(max_total_size_mb * 1_048_576)
+        self.max_kept_size = int(max_kept_size_mb * 1_048_576)
         self.chunk_size = chunk_size
         self.profile = profile
         self.library = library
@@ -361,9 +367,8 @@ class McapRecorder:
         The currently-recording file cannot be renamed (the writer holds it open).
         ``new_name`` is reduced to a bare filename and given a ``.mcap`` suffix;
         empty, whitespace-only or dots-only names are rejected (they would escape
-        the output directory) by returning ``None``. A renamed recording is deleted
-        by the disk budget only when kept files alone exceed it (see
-        :func:`is_auto_named`).
+        the output directory) by returning ``None``. A renamed recording counts as kept
+        (see :func:`is_auto_named` and ``max_kept_size_mb``).
 
         :param path: the recording to rename.
         :param new_name: the desired name (reduced to a bare ``.mcap`` filename).
@@ -814,20 +819,30 @@ class McapRecorder:
         self._emit_on_loop(self.RECORDING_STARTED.emit, self._file_path)
 
     def _enforce_disk_budget(self) -> None:
-        file_stats: list[tuple[Path, int, float]] = []
+        """Delete the oldest recordings until kept files fit ``max_kept_size`` and all fit ``max_total_size``."""
+        own: list[tuple[Path, int, float]] = []
+        kept: list[tuple[Path, int, float]] = []
         for path in self.output_dir.glob('*.mcap'):
             try:
                 stat = path.stat()
             except FileNotFoundError:
                 continue  # vanished concurrently (e.g. deleted from the recordings page)
-            file_stats.append((path, stat.st_size, stat.st_mtime))
-        file_stats.sort(key=lambda item: (not is_auto_named(item[0]), item[2]))  # own files oldest first, kept last
-        total = sum(size for _, size, _ in file_stats)
-        while total > self.max_total_size and file_stats:
-            oldest, size, _ = file_stats.pop(0)
-            oldest.unlink(missing_ok=True)
-            total -= size
-            self.log.info('deleted old recording: %s (freed %.1f MB)', oldest.name, size / 1_048_576)
+            (own if is_auto_named(path) else kept).append((path, stat.st_size, stat.st_mtime))
+        own.sort(key=lambda item: item[2])
+        kept.sort(key=lambda item: item[2])
+        deleted: list[tuple[Path, int, float]] = []
+        kept_size = sum(size for _, size, _ in kept)
+        while kept_size > self.max_kept_size and len(kept) > 1:  # the newest kept file is the one just filed away
+            deleted.append(kept.pop(0))
+            kept_size -= deleted[-1][1]
+        remaining = own + kept
+        total = sum(size for _, size, _ in remaining)
+        while total > self.max_total_size and remaining:
+            deleted.append(remaining.pop(0))
+            total -= deleted[-1][1]
+        for path, size, _ in deleted:
+            path.unlink(missing_ok=True)
+            self.log.info('deleted old recording: %s (freed %.1f MB)', path.name, size / 1_048_576)
 
     def _cleanup_orphaned_reindex_files(self) -> None:
         """Remove reindex temp files left by a crash mid-rebuild. Run once at construction, never during operation.

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -491,40 +491,6 @@ class McapRecorder:
             if file_path is not None:
                 self.RECORDING_STOPPED.emit(file_path)
 
-    async def split(self) -> Path | None:
-        """Finalize the current file and continue recording into a fresh one.
-
-        Lets callers file away the data recorded so far (e.g. after a failure) without
-        interrupting the recording: the queue is drained and the file rotated off the event
-        loop, emitting ``RECORDING_STOPPED`` for the finalized file and ``RECORDING_STARTED``
-        for the new one. A file that holds no messages yet is left growing instead of being
-        churned into an empty recording.
-
-        :return: the finalized file, or ``None`` when not recording or nothing was recorded
-            into the current file yet.
-        """
-        if not self._is_recording:
-            return None
-        return await asyncio.to_thread(self._split)
-
-    def _split(self) -> Path | None:
-        """Drain the queue and rotate. Runs off the loop; takes ``_lock``.
-
-        :return: the finalized file, or ``None`` if the current file holds no messages or
-            the recorder hard-stopped during the drain.
-        """
-        with self._lock:
-            with self._queue_lock:  # brief: only the swap, not the write
-                batch, self._queue = self._queue, []
-                self._queued_bytes = 0
-            self._write_messages(batch)
-            if self._writer is None or self._file_message_count == 0:
-                return None
-            finalized = self._file_path
-            if not self._rotate_file(dropped_on_failure=0):
-                return None
-        return finalized
-
     def log_message(self, topic: str, data: Any, *,
                     encode: Callable[[Any, int], bytes | None] | None = None,
                     timestamp_ns: int | None = None) -> None:

--- a/rosys/analysis/recording/mcap_recorder.py
+++ b/rosys/analysis/recording/mcap_recorder.py
@@ -202,9 +202,9 @@ class McapRecorder:
         self.max_queued_bytes = int(max_queued_bytes)
 
         self.RECORDING_STARTED = Event[Path]()
-        """a recording file has been opened (argument: path); emitted per file, including on size rotation"""
+        """a recording file has been opened (argument: path); emitted per file, including on every rotation"""
         self.RECORDING_STOPPED = Event[Path]()
-        """a recording file has been finalized (argument: path); emitted per file, including on size rotation"""
+        """a recording file has been finalized (argument: path); emitted per file, including on every rotation"""
 
         self._declared_topics: set[str] = set()
         self._selected_topics: set[str] | None = None
@@ -819,7 +819,7 @@ class McapRecorder:
 
         Emits ``RECORDING_STOPPED`` for the finalized file and ``RECORDING_STARTED`` for the
         new one, loop-safely, so per-file consumers (upload/post-processing) see every file of
-        a long session — not just the first and last. The events are therefore per-file.
+        a long run — not just the first and last. The events are therefore per-file.
         """
         assert self._file is not None
         finalized = self._file_path

--- a/rosys/analysis/recording/merging.py
+++ b/rosys/analysis/recording/merging.py
@@ -1,17 +1,62 @@
 """Merge MCAP recordings into one file, keeping the context they were recorded in."""
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
+from uuid import uuid4
 
 from mcap.reader import make_reader
-from mcap.records import Metadata
+from mcap.records import Chunk, DataEnd, Metadata
 from mcap.stream_reader import StreamReader
 from mcap.writer import CompressionType, Writer
 
-from .mcap_recorder import METADATA_NAME
+from .indexing import is_indexed, reindex
+
+METADATA_NAME = 'recording'
+"""Metadata record holding the caller's context of a recording as JSON."""
 
 MERGE_METADATA_NAME = 'merge'
 """Metadata record describing the merge itself, so a merged file says how it came to be."""
+
+STAGING_GLOB = '*.mcap.merge-*'
+"""The files a merge writes before the result takes its name; not ``*.mcap``, so no listing shows them."""
+
+
+def merge_into_place(sources: list[Path], target: Path, *, start_time_ns: int = 0) -> tuple[int, list[Path]]:
+    """Merge ``sources`` into ``target`` and delete them once the merged file is in place.
+
+    Unindexed sources (e.g. left by a crash) are reindexed first. The merge writes to a staging
+    file beside ``target`` and only a finished file takes the target name, refusing an existing
+    one, so an interrupted or failed merge leaves the sources untouched.
+
+    Blocking I/O and ZSTD recompression; call via ``rosys.run.io_bound``.
+
+    :param sources: the recordings to merge, oldest first.
+    :param target: the file the merged recording takes.
+    :param start_time_ns: messages logged before this time are dropped (default: keep all).
+    :return: the number of messages merged, ``0`` leaving no target and the sources in place, and
+        the sources that could not be deleted.
+    :raises FileExistsError: if ``target`` exists; the sources are kept.
+    """
+    for source in sources:
+        if not is_indexed(source):
+            reindex(source)
+    staging = target.with_name(f'{target.name}.merge-{uuid4().hex}')
+    try:
+        count = merge_recordings(sources, staging, start_time_ns=start_time_ns)
+        if count:
+            os.link(staging, target)  # atomic: fails if the target exists, so no recording is overwritten
+    finally:
+        staging.unlink(missing_ok=True)
+    if not count:
+        return 0, []
+    undeleted: list[Path] = []
+    for source in sources:
+        try:
+            source.unlink(missing_ok=True)
+        except OSError:
+            undeleted.append(source)
+    return count, undeleted
 
 
 def merge_recordings(sources: list[Path], target: Path, *, start_time_ns: int = 0) -> int:
@@ -19,9 +64,10 @@ def merge_recordings(sources: list[Path], target: Path, *, start_time_ns: int = 
 
     The metadata of the sources is carried over, so a merged recording still says which
     robot, run and mission it belongs to. Identical records are written once; sources
-    from different runs each keep their own.
+    from different runs each keep their own, and so do the merges a merged source went through.
 
-    Blocking I/O and ZSTD recompression; call via ``rosys.run.io_bound``.
+    Every source needs its summary index (see :func:`~.indexing.reindex`). Blocking I/O and
+    ZSTD recompression; call via ``rosys.run.io_bound``.
 
     :param sources: the recordings to merge, oldest first.
     :param target: the file to write.
@@ -29,8 +75,8 @@ def merge_recordings(sources: list[Path], target: Path, *, start_time_ns: int = 
     :return: the number of messages written.
     """
     count = 0
-    schema_ids: dict[str, int] = {}
-    channel_ids: dict[str, int] = {}
+    schema_ids: dict[tuple[str, str, bytes], int] = {}
+    channel_ids: dict[tuple[str, str, int], int] = {}
     with open(target, 'wb') as file:
         writer = Writer(file, compression=CompressionType.ZSTD)
         writer.start(profile='rosys', library='rosys-merge')
@@ -44,13 +90,17 @@ def merge_recordings(sources: list[Path], target: Path, *, start_time_ns: int = 
         for source in sources:
             with open(source, 'rb') as stream:
                 for schema, channel, message in make_reader(stream).iter_messages(start_time=start_time_ns):
-                    if schema is not None and schema.name not in schema_ids:
-                        schema_ids[schema.name] = writer.register_schema(schema.name, schema.encoding, schema.data)
-                    if channel.topic not in channel_ids:
-                        schema_id = schema_ids[schema.name] if schema is not None else 0
-                        channel_ids[channel.topic] = writer.register_channel(
+                    schema_id = 0
+                    if schema is not None:
+                        schema_key = (schema.name, schema.encoding, bytes(schema.data))
+                        if schema_key not in schema_ids:
+                            schema_ids[schema_key] = writer.register_schema(schema.name, schema.encoding, schema.data)
+                        schema_id = schema_ids[schema_key]
+                    channel_key = (channel.topic, channel.message_encoding, schema_id)
+                    if channel_key not in channel_ids:
+                        channel_ids[channel_key] = writer.register_channel(
                             channel.topic, channel.message_encoding, schema_id)
-                    writer.add_message(channel_ids[channel.topic], message.log_time, message.data,
+                    writer.add_message(channel_ids[channel_key], message.log_time, message.data,
                                        message.publish_time)
                     count += 1
         writer.finish()
@@ -58,23 +108,39 @@ def merge_recordings(sources: list[Path], target: Path, *, start_time_ns: int = 
 
 
 def _collected_metadata(sources: list[Path]) -> dict[str, dict[str, str]]:
-    """The distinct metadata records of ``sources``, keyed by the name they are written under.
+    """The distinct context and merge records of ``sources``, named for the merged file.
 
-    Read with the streaming reader, which does not need the summary index a file gets on
-    finishing, so an unfinished recording can be merged too. Sources sharing a record
-    contribute it once; differing ones are numbered apart.
+    A file carries its records ahead of its first chunk, so the scan stops there without
+    decompressing any data. Context records are numbered ``recording``, ``recording_2``, ...;
+    the merges a source went through keep their records as ``merge_2``, ``merge_3``, ...,
+    leaving ``merge`` to the merge at hand.
 
     :param sources: the recordings to read.
     :return: the records to write into the merged file.
     """
-    collected: dict[str, dict[str, str]] = {}
+    found: dict[str, list[dict[str, str]]] = {METADATA_NAME: [], MERGE_METADATA_NAME: []}
     for source in sources:
         with open(source, 'rb') as stream:
-            for record in StreamReader(stream).records:
-                if not isinstance(record, Metadata) or record.name != METADATA_NAME:
+            for record in StreamReader(stream, emit_chunks=True).records:
+                if isinstance(record, (Chunk, DataEnd)):
+                    break
+                if not isinstance(record, Metadata):
                     continue
-                if record.metadata in collected.values():
-                    break  # already carried over by an earlier source
-                collected[f'{record.name}_{len(collected) + 1}' if collected else record.name] = record.metadata
-                break  # the recorder writes its record once, at the top of the file
+                records = found.get(_base_name(record.name))
+                if records is not None and record.metadata not in records:
+                    records.append(record.metadata)
+    collected = {METADATA_NAME if index == 0 else f'{METADATA_NAME}_{index + 1}': payload
+                 for index, payload in enumerate(found[METADATA_NAME])}
+    collected.update({f'{MERGE_METADATA_NAME}_{index + 2}': payload
+                      for index, payload in enumerate(found[MERGE_METADATA_NAME])})
     return collected
+
+
+def _base_name(name: str) -> str:
+    """The name a numbered record was numbered from, e.g. ``recording`` for ``recording_2``.
+
+    :param name: the name of a metadata record.
+    :return: the name without its number.
+    """
+    base, _, number = name.rpartition('_')
+    return base if base and number.isdigit() else name

--- a/rosys/analysis/recording/merging.py
+++ b/rosys/analysis/recording/merging.py
@@ -1,0 +1,80 @@
+"""Merge MCAP recordings into one file, keeping the context they were recorded in."""
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from mcap.reader import make_reader
+from mcap.records import Metadata
+from mcap.stream_reader import StreamReader
+from mcap.writer import CompressionType, Writer
+
+from .mcap_recorder import METADATA_NAME
+
+MERGE_METADATA_NAME = 'merge'
+"""Metadata record describing the merge itself, so a merged file says how it came to be."""
+
+
+def merge_recordings(sources: list[Path], target: Path, *, start_time_ns: int = 0) -> int:
+    """Write the messages of ``sources`` (in the given order) into ``target``.
+
+    The metadata of the sources is carried over, so a merged recording still says which
+    robot, run and mission it belongs to. Identical records are written once; sources
+    from different runs each keep their own.
+
+    Blocking I/O and ZSTD recompression; call via ``rosys.run.io_bound``.
+
+    :param sources: the recordings to merge, oldest first.
+    :param target: the file to write.
+    :param start_time_ns: messages logged before this time are dropped (default: keep all).
+    :return: the number of messages written.
+    """
+    count = 0
+    schema_ids: dict[str, int] = {}
+    channel_ids: dict[str, int] = {}
+    with open(target, 'wb') as file:
+        writer = Writer(file, compression=CompressionType.ZSTD)
+        writer.start(profile='rosys', library='rosys-merge')
+        for name, payload in _collected_metadata(sources).items():
+            writer.add_metadata(name, payload)
+        writer.add_metadata(MERGE_METADATA_NAME, {'json': json.dumps({
+            'merged_at': datetime.now(tz=UTC).isoformat(),
+            'sources': [source.name for source in sources],
+            'trimmed': bool(start_time_ns),
+        })})
+        for source in sources:
+            with open(source, 'rb') as stream:
+                for schema, channel, message in make_reader(stream).iter_messages(start_time=start_time_ns):
+                    if schema is not None and schema.name not in schema_ids:
+                        schema_ids[schema.name] = writer.register_schema(schema.name, schema.encoding, schema.data)
+                    if channel.topic not in channel_ids:
+                        schema_id = schema_ids[schema.name] if schema is not None else 0
+                        channel_ids[channel.topic] = writer.register_channel(
+                            channel.topic, channel.message_encoding, schema_id)
+                    writer.add_message(channel_ids[channel.topic], message.log_time, message.data,
+                                       message.publish_time)
+                    count += 1
+        writer.finish()
+    return count
+
+
+def _collected_metadata(sources: list[Path]) -> dict[str, dict[str, str]]:
+    """The distinct metadata records of ``sources``, keyed by the name they are written under.
+
+    Read with the streaming reader, which does not need the summary index a file gets on
+    finishing, so an unfinished recording can be merged too. Sources sharing a record
+    contribute it once; differing ones are numbered apart.
+
+    :param sources: the recordings to read.
+    :return: the records to write into the merged file.
+    """
+    collected: dict[str, dict[str, str]] = {}
+    for source in sources:
+        with open(source, 'rb') as stream:
+            for record in StreamReader(stream).records:
+                if not isinstance(record, Metadata) or record.name != METADATA_NAME:
+                    continue
+                if record.metadata in collected.values():
+                    break  # already carried over by an earlier source
+                collected[f'{record.name}_{len(collected) + 1}' if collected else record.name] = record.metadata
+                break  # the recorder writes its record once, at the top of the file
+    return collected

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -14,7 +14,7 @@ from .mcap_recorder import McapRecorder, RecordingInfo
 from .merging import merge_recordings
 from .paths import DOWNLOAD_PATH, PAGE_PATH
 
-SCROLLBAR_WIDTH = '10px'  # Quasar's vertical thumb; the buttons would sit under it otherwise
+RIGHT_INSET = 'var(--nicegui-default-padding)'  # clears Quasar's 10 px thumb and keeps the page's rhythm
 
 _MAX_TIMEZONE_OFFSET_MINUTES = 24 * 60  # reject offsets beyond ±24 h from untrusted client JavaScript
 
@@ -234,7 +234,7 @@ class RecordingsPage:
                 await reload()
 
         with ui.column().classes('w-full gap-2'):
-            with ui.row().classes('w-full items-center gap-2').style(f'padding-right: {SCROLLBAR_WIDTH}'):
+            with ui.row().classes('w-full items-center gap-2').style(f'padding-right: {RIGHT_INSET}'):
                 date_input = ui.date_input('Date range', range_input=True, on_change=recordings_list.refresh)
                 ui.space()
                 reindex_button = ui.button(icon='build', on_click=_reindex) \
@@ -244,7 +244,7 @@ class RecordingsPage:
                 ui.button(icon='refresh', on_click=reload).props('flat dense')
             # the page already insets its content; the scroll area would add a second one, only for the list
             # Quasar swaps in the active style once a thumb shows, so both carry the same padding
-            content_padding = f'padding-left: 0; padding-right: {SCROLLBAR_WIDTH}'
+            content_padding = f'padding-left: 0; padding-right: {RIGHT_INSET}'
             with ui.scroll_area().classes('w-full') \
                     .props(f'content-style="{content_padding}" content-active-style="{content_padding}"') \
                     .style('max-height: 75vh'):

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from datetime import UTC, date, datetime, timedelta, timezone
 from pathlib import Path
@@ -10,16 +11,21 @@ from nicegui import app, ui
 
 from ... import rosys
 from .mcap_recorder import McapRecorder, RecordingInfo
+from .merging import merge_recordings
 from .paths import DOWNLOAD_PATH, PAGE_PATH
 
 _MAX_TIMEZONE_OFFSET_MINUTES = 24 * 60  # reject offsets beyond ±24 h from untrusted client JavaScript
+
+_RUN_PART = re.compile(r'(?P<run>.+_run\d+)_\d+\.mcap')  # one part of a run, e.g. 20260911_052815_run0002_01.mcap
 
 
 class RecordingsPage:
     """Lists the MCAP recordings for download and deletion.
 
-    The list refreshes whenever the recorder starts a new recording or stops one,
-    can be filtered by date, and offers rebuilding the index of crash-orphaned
+    A long recording rotates into many files, so the parts of one run are listed as a
+    single entry that expands into its parts; a file without a run name stays a row of
+    its own. The list refreshes whenever the recorder starts a new recording or stops
+    one, can be filtered by date, and offers rebuilding the index of crash-orphaned
     (unindexed) recordings. All filesystem access (glob, stat, index check) runs
     off the event loop via ``rosys.run.io_bound``; the render reads only a cached
     snapshot, so opening the page never blocks the loop on disk I/O.
@@ -66,6 +72,9 @@ class RecordingsPage:
             recorded = datetime.fromtimestamp(info.mtime, tz=local_tz).date()
             return start <= recorded <= end
 
+        expanded_runs: set[str] = set()  # survives the refresh, which redraws the whole list
+        merging_runs: set[str] = set()
+
         @ui.refreshable
         def recordings_list() -> None:
             reindex_button.set_enabled(any(not info.indexed and not info.is_live for info in infos))
@@ -74,11 +83,60 @@ class RecordingsPage:
                 ui.label('No recordings.').classes('text-grey p-4')
                 return
             with ui.column().classes('w-full gap-1'):
-                for info in visible:
-                    _recording_row(info)
+                for key, parts in _group_by_run(visible):
+                    if key is None or len(parts) == 1:
+                        _recording_row(parts[0])
+                    else:
+                        _run_row(key, parts)
 
-        def _recording_row(info: RecordingInfo) -> None:
-            modified = datetime.fromtimestamp(info.mtime, tz=local_tz).strftime('%Y-%m-%d %H:%M:%S')
+        def _run_row(key: str, parts: list[RecordingInfo]) -> None:
+            """Render the files of one run as one entry that expands into its parts.
+
+            The entry keeps the shape of a single recording's row, so a run and a lone
+            recording sit on the same edges; only the parts inside are indented.
+
+            :param key: the name the run's files share.
+            :param parts: the run's files, newest first.
+            """
+            first = datetime.fromtimestamp(min(part.mtime for part in parts), tz=local_tz)
+            last = datetime.fromtimestamp(max(part.mtime for part in parts), tz=local_tz)
+            size = sum(part.size for part in parts)
+            is_expanded = key in expanded_runs
+
+            def toggle() -> None:
+                expanded_runs.symmetric_difference_update({key})
+                recordings_list.refresh()
+
+            with ui.row().classes('w-full items-center justify-between border-b py-1'):
+                with ui.column().classes('gap-0'):
+                    with ui.row().classes('items-center gap-1'):
+                        ui.label(key).classes('font-mono')
+                        if any(part.is_live for part in parts):
+                            ui.badge('recording').props('color=red')
+                    ui.label(f'{first:%Y-%m-%d %H:%M:%S} - {last:%H:%M:%S} · '
+                             f'{size / 1_048_576:.1f} MB · {len(parts)} parts').classes('text-xs text-grey')
+                with ui.row().classes('gap-1'):
+                    if key in merging_runs:
+                        ui.spinner(size='sm').tooltip('merging this run into one recording')
+                    elif not any(part.is_live for part in parts):
+                        ui.button(icon='merge', on_click=lambda k=key, p=list(parts): _start_merge(k, p)) \
+                            .props('flat dense').tooltip('merge this run into one recording')
+                    ui.button(icon='expand_less' if is_expanded else 'expand_more', on_click=toggle) \
+                        .props('flat dense').tooltip('show the files of this run')
+            if is_expanded:
+                with ui.column().classes('w-full gap-1 pl-8'):
+                    for part in parts:
+                        _recording_row(part, with_date=False)
+
+        def _recording_row(info: RecordingInfo, *, with_date: bool = True) -> None:
+            """Render one recording.
+
+            :param info: the recording to render.
+            :param with_date: whether to date the row; the parts of a run carry the date in
+                their group entry and only need the time of day.
+            """
+            modified = datetime.fromtimestamp(info.mtime, tz=local_tz) \
+                .strftime('%Y-%m-%d %H:%M:%S' if with_date else '%H:%M:%S')
             with ui.row().classes('w-full items-center justify-between border-b py-1'):
                 with ui.column().classes('gap-0'):
                     with ui.row().classes('items-center gap-1'):
@@ -99,6 +157,42 @@ class RecordingsPage:
                         download.tooltip('available once the recording is stopped or reindexed')
                     if not info.is_live:  # the live file cannot be deleted (writer holds it open)
                         ui.button(icon='delete', on_click=lambda p=info.path: _delete(p)).props('flat dense color=red')
+
+        def _start_merge(key: str, parts: list[RecordingInfo]) -> None:
+            """Merge a run in the background, so closing the page does not cancel it.
+
+            :param key: the run whose files are merged.
+            :param parts: the run's files.
+            """
+            merging_runs.add(key)
+            recordings_list.refresh()
+            rosys.background_tasks.create(_merge_run(key, parts), name=f'merge {key}')
+
+        async def _merge_run(key: str, parts: list[RecordingInfo]) -> None:
+            """Write the run's files into one recording and drop the parts once it is written.
+
+            The merge writes beside the recordings under a name the list ignores, and only a
+            finished file takes the target name, so a merge in progress never shows up as a
+            recording and an interruption leaves the parts untouched.
+
+            :param key: the run whose files are merged.
+            :param parts: the run's files.
+            """
+            target = recorder.output_dir / f'{key}.mcap'
+            unfinished = recorder.output_dir / f'{key}.mcap.part'  # not a *.mcap, so the list ignores it
+            sources = sorted(part.path for part in parts)
+            try:
+                count = await rosys.run.io_bound(merge_recordings, sources, unfinished)
+                if not count:
+                    raise RuntimeError('the merge wrote no messages')
+                await rosys.run.io_bound(_replace_sources, unfinished, target, sources)
+                rosys.notify(f'Merged {len(sources)} files into {target.name}', type='positive')
+            except Exception as e:
+                unfinished.unlink(missing_ok=True)
+                rosys.notify(f'Could not merge {key}: {e}', type='negative')
+            finally:
+                merging_runs.discard(key)
+                await reload()
 
         async def reload() -> None:
             infos[:] = await rosys.run.io_bound(recorder.scan_recordings) or []  # None on shutdown
@@ -177,6 +271,41 @@ class RecordingsPage:
         ui.timer(2.0, sync_if_changed)
 
 
+def _group_by_run(infos: list[RecordingInfo]) -> list[tuple[str | None, list[RecordingInfo]]]:
+    """Group the files that belong to the same run, keeping the given order.
+
+    A run's files are the ones the recorder numbered apart while rotating; every
+    other file (an old recording, a preserved failure, a renamed one) forms an
+    entry of its own.
+
+    :param infos: the recordings to group, in display order.
+    :return: one entry per run key, each with the run's files in the given order;
+        ``None`` as the key for a file that belongs to no run.
+    """
+    entries: list[tuple[str | None, list[RecordingInfo]]] = []
+    runs: dict[str, list[RecordingInfo]] = {}
+    for info in infos:
+        key = _run_key(info.path)
+        if key is None:
+            entries.append((None, [info]))
+        elif key in runs:
+            runs[key].append(info)
+        else:
+            runs[key] = [info]
+            entries.append((key, runs[key]))
+    return entries
+
+
+def _run_key(path: Path) -> str | None:
+    """The name the files of one run share — everything up to the part number.
+
+    :param path: the recording to read the run key off.
+    :return: the shared name, or ``None`` if the file is not a numbered part of a run.
+    """
+    match = _RUN_PART.fullmatch(path.name)
+    return match.group('run') if match is not None else None
+
+
 def _download_response(recorder: McapRecorder, name: str) -> Response:
     """Build the HTTP response for a recording download request.
 
@@ -235,3 +364,18 @@ async def _confirm_dialog(message: str) -> bool:
             ui.button('Cancel', on_click=lambda: dialog.submit(False)).props('flat')
             ui.button('OK', on_click=lambda: dialog.submit(True))
     return bool(await dialog)
+
+
+def _replace_sources(unfinished: Path, target: Path, sources: list[Path]) -> None:
+    """Put the merged recording in place and drop the files it was made of.
+
+    The rename happens before the deletion, so an interruption leaves the sources
+    untouched rather than a gap.
+
+    :param unfinished: the file the merge wrote.
+    :param target: the name the merged recording takes.
+    :param sources: the recordings the merge consumed.
+    """
+    unfinished.replace(target)
+    for path in sources:
+        path.unlink(missing_ok=True)

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -14,6 +14,8 @@ from .mcap_recorder import McapRecorder, RecordingInfo
 from .merging import merge_recordings
 from .paths import DOWNLOAD_PATH, PAGE_PATH
 
+SCROLLBAR_WIDTH = '10px'  # Quasar's vertical thumb; the buttons would sit under it otherwise
+
 _MAX_TIMEZONE_OFFSET_MINUTES = 24 * 60  # reject offsets beyond ±24 h from untrusted client JavaScript
 
 _RUN_PART = re.compile(r'(?P<run>.+_run\d+)_\d+\.mcap')  # one part of a run, e.g. 20260911_052815_run0002_01.mcap
@@ -232,7 +234,7 @@ class RecordingsPage:
                 await reload()
 
         with ui.column().classes('w-full gap-2'):
-            with ui.row().classes('w-full items-center gap-2'):
+            with ui.row().classes('w-full items-center gap-2').style(f'padding-right: {SCROLLBAR_WIDTH}'):
                 date_input = ui.date_input('Date range', range_input=True, on_change=recordings_list.refresh)
                 ui.space()
                 reindex_button = ui.button(icon='build', on_click=_reindex) \
@@ -241,7 +243,8 @@ class RecordingsPage:
                     .props('flat dense color=red').tooltip('delete all recordings')
                 ui.button(icon='refresh', on_click=reload).props('flat dense')
             # the page already insets its content; the scroll area would add a second one, only for the list
-            content_padding = 'padding-left: 0; padding-right: 0'  # Quasar swaps in the active style once a thumb shows
+            # Quasar swaps in the active style once a thumb shows, so both carry the same padding
+            content_padding = f'padding-left: 0; padding-right: {SCROLLBAR_WIDTH}'
             with ui.scroll_area().classes('w-full') \
                     .props(f'content-style="{content_padding}" content-active-style="{content_padding}"') \
                     .style('max-height: 75vh'):

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -146,7 +146,9 @@ class RecordingsPage:
                 ui.button(icon='delete_sweep', on_click=_delete_all) \
                     .props('flat dense color=red').tooltip('delete all recordings')
                 ui.button(icon='refresh', on_click=reload).props('flat dense')
-            with ui.scroll_area().classes('w-full').style('max-height: 75vh'):
+            with ui.scroll_area().classes('w-full') \
+                    .props('content-style="padding: 0"') \
+                    .style('max-height: 75vh'):  # the page already pads; a second inset misaligns the list
                 recordings_list()
 
         def _change_token() -> tuple[tuple[Path, ...], Path | None]:

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -137,8 +137,11 @@ class RecordingsPage:
                     rosys.notify(f'Could not rename {path.name} (name already in use or invalid)', type='negative')
                 await reload()
 
-        with ui.column().classes('w-full gap-2'):  # one column, so controls and list keep the same insets
-            with ui.row().classes('w-full items-center gap-2'):
+        with ui.column().classes('w-full gap-2'):
+            # the scroll area pads its content, so the controls take the same inset and both edges line up
+            with ui.row().classes('w-full items-center gap-2') \
+                    .style('padding-left: var(--nicegui-default-padding); '
+                           'padding-right: var(--nicegui-default-padding)'):
                 date_input = ui.date_input('Date range', range_input=True, on_change=recordings_list.refresh)
                 ui.space()
                 reindex_button = ui.button(icon='build', on_click=_reindex) \
@@ -146,9 +149,7 @@ class RecordingsPage:
                 ui.button(icon='delete_sweep', on_click=_delete_all) \
                     .props('flat dense color=red').tooltip('delete all recordings')
                 ui.button(icon='refresh', on_click=reload).props('flat dense')
-            with ui.scroll_area().classes('w-full') \
-                    .props('content-style="padding: 0"') \
-                    .style('max-height: 75vh'):  # the page already pads; a second inset misaligns the list
+            with ui.scroll_area().classes('w-full').style('max-height: 75vh'):
                 recordings_list()
 
         def _change_token() -> tuple[tuple[Path, ...], Path | None]:

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import re
+import asyncio
 from collections.abc import Callable
 from datetime import UTC, date, datetime, timedelta, timezone
 from pathlib import Path
@@ -10,27 +10,24 @@ from fastapi.responses import FileResponse, JSONResponse, Response
 from nicegui import app, ui
 
 from ... import rosys
-from .mcap_recorder import McapRecorder, RecordingInfo
-from .merging import merge_recordings
+from .mcap_recorder import _OWN_NAME, McapRecorder, RecordingInfo
 from .paths import DOWNLOAD_PATH, PAGE_PATH
 
 RIGHT_INSET = 'var(--nicegui-default-padding)'  # clears Quasar's 10 px thumb and keeps the page's rhythm
 
 _MAX_TIMEZONE_OFFSET_MINUTES = 24 * 60  # reject offsets beyond ±24 h from untrusted client JavaScript
 
-_RUN_PART = re.compile(r'(?P<run>.+_run\d+)_\d+\.mcap')  # one part of a run, e.g. 20260911_052815_run0002_01.mcap
-
 
 class RecordingsPage:
     """Lists the MCAP recordings for download and deletion.
 
     A long recording rotates into many files, so the parts of one run are listed as a
-    single entry that expands into its parts; a file without a run name stays a row of
-    its own. The list refreshes whenever the recorder starts a new recording or stops
-    one, can be filtered by date, and offers rebuilding the index of crash-orphaned
-    (unindexed) recordings. All filesystem access (glob, stat, index check) runs
-    off the event loop via ``rosys.run.io_bound``; the render reads only a cached
-    snapshot, so opening the page never blocks the loop on disk I/O.
+    single entry that expands into its parts and can be merged into one recording; any
+    other file stays a row of its own. The list refreshes whenever the recorder starts a
+    new recording or stops one, can be filtered by date, and offers rebuilding the index
+    of crash-orphaned (unindexed) recordings. All filesystem access (glob, stat, index
+    check) runs off the event loop via ``rosys.run.io_bound``; the render reads only a
+    cached snapshot, so opening the page never blocks the loop on disk I/O.
 
     A download endpoint at ``DOWNLOAD_PATH/{name}`` serves finished recordings over
     HTTP (basename only, refusing the live file with 409 and missing files with 404),
@@ -75,53 +72,55 @@ class RecordingsPage:
             return start <= recorded <= end
 
         expanded_runs: set[str] = set()  # survives the refresh, which redraws the whole list
-        merging_runs: set[str] = set()
+        shown_merges: set[str] = set()  # merges in progress as last rendered, so the sync notices another client's
 
         @ui.refreshable
         def recordings_list() -> None:
             reindex_button.set_enabled(any(not info.indexed and not info.is_live for info in infos))
-            visible = [info for info in infos if _in_range(info)]
-            if not visible:
+            shown_merges.clear()
+            shown_merges.update(recorder.merging)
+            entries = [(run, parts) for run, parts in _group_by_run(infos) if any(_in_range(part) for part in parts)]
+            if not entries:
                 ui.label('No recordings.').classes('text-grey p-4')
                 return
             with ui.column().classes('w-full gap-1'):
-                for key, parts in _group_by_run(visible):
-                    if key is None or len(parts) == 1:
+                for run, parts in entries:
+                    if run is None or len(parts) == 1:
                         _recording_row(parts[0])
                     else:
-                        _run_row(key, parts)
+                        _run_row(run, parts)
 
-        def _run_row(key: str, parts: list[RecordingInfo]) -> None:
+        def _run_row(run: str, parts: list[RecordingInfo]) -> None:
             """Render the files of one run as one entry that expands into its parts.
 
             The entry keeps the shape of a single recording's row, so a run and a lone
             recording sit on the same edges; only the parts inside are indented.
 
-            :param key: the name the run's files share.
+            :param run: the name the run's files share.
             :param parts: the run's files, newest first.
             """
             first = datetime.fromtimestamp(min(part.mtime for part in parts), tz=local_tz)
             last = datetime.fromtimestamp(max(part.mtime for part in parts), tz=local_tz)
             size = sum(part.size for part in parts)
-            is_expanded = key in expanded_runs
+            is_expanded = run in expanded_runs
 
             def toggle() -> None:
-                expanded_runs.symmetric_difference_update({key})
+                expanded_runs.symmetric_difference_update({run})
                 recordings_list.refresh()
 
             with ui.row().classes('w-full items-center justify-between border-b py-1'):
                 with ui.column().classes('gap-0'):
                     with ui.row().classes('items-center gap-1'):
-                        ui.label(key).classes('font-mono')
+                        ui.label(run).classes('font-mono')
                         if any(part.is_live for part in parts):
                             ui.badge('recording').props('color=red')
                     ui.label(f'{first:%Y-%m-%d %H:%M:%S} - {last:%H:%M:%S} · '
                              f'{size / 1_048_576:.1f} MB · {len(parts)} parts').classes('text-xs text-grey')
                 with ui.row().classes('gap-1'):
-                    if key in merging_runs:
+                    if _merged_name(run) in recorder.merging:
                         ui.spinner(size='sm').tooltip('merging this run into one recording')
                     elif not any(part.is_live for part in parts):
-                        ui.button(icon='merge', on_click=lambda k=key, p=list(parts): _start_merge(k, p)) \
+                        ui.button(icon='merge', on_click=lambda r=run, p=list(parts): _merge_run(r, p)) \
                             .props('flat dense').tooltip('merge this run into one recording')
                     ui.button(icon='expand_less' if is_expanded else 'expand_more', on_click=toggle) \
                         .props('flat dense').tooltip('show the files of this run')
@@ -160,41 +159,32 @@ class RecordingsPage:
                     if not info.is_live:  # the live file cannot be deleted (writer holds it open)
                         ui.button(icon='delete', on_click=lambda p=info.path: _delete(p)).props('flat dense color=red')
 
-        def _start_merge(key: str, parts: list[RecordingInfo]) -> None:
+        async def _merge_run(run: str, parts: list[RecordingInfo]) -> None:
             """Merge a run in the background, so closing the page does not cancel it.
 
-            :param key: the run whose files are merged.
-            :param parts: the run's files.
+            :param run: the run whose files are merged.
+            :param parts: the run's files, newest first.
             """
-            merging_runs.add(key)
+            rosys.background_tasks.create(_merge(run, [part.path for part in reversed(parts)]), name=f'merge {run}')
+            await asyncio.sleep(0)  # lets the merge claim its name, so the list shows it in progress
             recordings_list.refresh()
-            rosys.background_tasks.create(_merge_run(key, parts), name=f'merge {key}')
 
-        async def _merge_run(key: str, parts: list[RecordingInfo]) -> None:
-            """Write the run's files into one recording and drop the parts once it is written.
+        async def _merge(run: str, sources: list[Path]) -> None:
+            """Merge the run's files and tell how it went.
 
-            The merge writes beside the recordings under a name the list ignores, and only a
-            finished file takes the target name, so a merge in progress never shows up as a
-            recording and an interruption leaves the parts untouched.
-
-            :param key: the run whose files are merged.
-            :param parts: the run's files.
+            :param run: the run whose files are merged.
+            :param sources: the run's files, oldest first.
             """
-            target = recorder.output_dir / f'{key}_merged.mcap'  # never reads as one of the recorder's own files
-            unfinished = recorder.output_dir / f'{key}.mcap.part'  # not a *.mcap, so the list ignores it
-            sources = sorted(part.path for part in parts)
             try:
-                count = await rosys.run.io_bound(merge_recordings, sources, unfinished)
-                if not count:
-                    raise RuntimeError('the merge wrote no messages')
-                await rosys.run.io_bound(_replace_sources, unfinished, target, sources)
-                rosys.notify(f'Merged {len(sources)} files into {target.name}', type='positive')
+                target = await recorder.merge(sources, _merged_name(run))
             except Exception as e:
-                unfinished.unlink(missing_ok=True)
-                rosys.notify(f'Could not merge {key}: {e}', type='negative')
-            finally:
-                merging_runs.discard(key)
-                await reload()
+                rosys.notify(f'Could not merge {run}: {e}', type='negative')
+            else:
+                if target is None:
+                    rosys.notify(f'Nothing to merge in {run}', type='warning')
+                else:
+                    rosys.notify(f'Merged {len(sources)} files into {target.name}', type='positive')
+            await reload()
 
         async def reload() -> None:
             infos[:] = await rosys.run.io_bound(recorder.scan_recordings) or []  # None on shutdown
@@ -252,12 +242,12 @@ class RecordingsPage:
                     .style('max-height: 75vh'):
                 recordings_list()
 
-        def _change_token() -> tuple[tuple[Path, ...], Path | None]:
-            """A cheap change token — the recording paths plus the live file.
+        def _change_token() -> tuple[tuple[Path, ...], Path | None, frozenset[str]]:
+            """A cheap change token — the recording paths, the live file and the merges in progress.
 
             Both accessors glob the output directory, so this runs off the event loop.
             """
-            return tuple(recorder.recordings), recorder.current_recording
+            return tuple(recorder.recordings), recorder.current_recording, recorder.merging
 
         async def sync_if_changed() -> None:
             # Picks up start/stop, size-based rotation, and external add/remove. The
@@ -270,7 +260,7 @@ class RecordingsPage:
             if token is None:
                 return  # recorder shut down mid-scan
             live = next((info.path for info in infos if info.is_live), None)
-            if token != (tuple(info.path for info in infos), live):
+            if token != (tuple(info.path for info in infos), live, frozenset(shown_merges)):
                 await reload()
 
         ui.timer(0.1, reload, once=True)  # populate the snapshot off the loop after the page is built
@@ -278,38 +268,36 @@ class RecordingsPage:
 
 
 def _group_by_run(infos: list[RecordingInfo]) -> list[tuple[str | None, list[RecordingInfo]]]:
-    """Group the files that belong to the same run, keeping the given order.
+    """Group the files that belong to the same run, keeping the order of their newest file.
 
-    A run's files are the ones the recorder numbered apart while rotating; every
-    other file (an old recording, a preserved failure, a renamed one) forms an
-    entry of its own.
+    A run's files are the parts the recorder numbered apart while rotating; every other
+    file (a renamed, merged or preserved recording) forms an entry of its own.
 
     :param infos: the recordings to group, in display order.
-    :return: one entry per run key, each with the run's files in the given order;
-        ``None`` as the key for a file that belongs to no run.
+    :return: one entry per run with its parts, the highest part number first; ``None`` as the
+        run for a file that belongs to no run.
     """
     entries: list[tuple[str | None, list[RecordingInfo]]] = []
-    runs: dict[str, list[RecordingInfo]] = {}
+    runs: dict[str, list[tuple[int, RecordingInfo]]] = {}
     for info in infos:
-        key = _run_key(info.path)
-        if key is None:
+        match = _OWN_NAME.fullmatch(info.path.name)
+        if match is None or match.group('run') is None:
             entries.append((None, [info]))
-        elif key in runs:
-            runs[key].append(info)
-        else:
-            runs[key] = [info]
-            entries.append((key, runs[key]))
+            continue
+        run = match.group('run')
+        if run not in runs:
+            runs[run] = []
+            entries.append((run, []))
+        runs[run].append((int(match.group('part')), info))
+    for run, parts in entries:
+        if run is not None:
+            parts.extend(info for _, info in sorted(runs[run], key=lambda numbered: numbered[0], reverse=True))
     return entries
 
 
-def _run_key(path: Path) -> str | None:
-    """The name the files of one run share — everything up to the part number.
-
-    :param path: the recording to read the run key off.
-    :return: the shared name, or ``None`` if the file is not a numbered part of a run.
-    """
-    match = _RUN_PART.fullmatch(path.name)
-    return match.group('run') if match is not None else None
+def _merged_name(run: str) -> str:
+    """The name a run takes once merged, which never reads as one of the recorder's own files."""
+    return f'{run}_merged'
 
 
 def _download_response(recorder: McapRecorder, name: str) -> Response:
@@ -370,18 +358,3 @@ async def _confirm_dialog(message: str) -> bool:
             ui.button('Cancel', on_click=lambda: dialog.submit(False)).props('flat')
             ui.button('OK', on_click=lambda: dialog.submit(True))
     return bool(await dialog)
-
-
-def _replace_sources(unfinished: Path, target: Path, sources: list[Path]) -> None:
-    """Put the merged recording in place and drop the files it was made of.
-
-    The rename happens before the deletion, so an interruption leaves the sources
-    untouched rather than a gap.
-
-    :param unfinished: the file the merge wrote.
-    :param target: the name the merged recording takes.
-    :param sources: the recordings the merge consumed.
-    """
-    unfinished.replace(target)
-    for path in sources:
-        path.unlink(missing_ok=True)

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -180,7 +180,7 @@ class RecordingsPage:
             :param key: the run whose files are merged.
             :param parts: the run's files.
             """
-            target = recorder.output_dir / f'{key}.mcap'
+            target = recorder.output_dir / f'{key}_merged.mcap'  # never reads as one of the recorder's own files
             unfinished = recorder.output_dir / f'{key}.mcap.part'  # not a *.mcap, so the list ignores it
             sources = sorted(part.path for part in parts)
             try:
@@ -228,9 +228,11 @@ class RecordingsPage:
                     ui.button('Rename', on_click=lambda: dialog.submit(name_input.value))
             new_name = await dialog
             if new_name:
-                renamed = await rosys.run.io_bound(recorder.rename_recording, path, new_name)  # off the loop
-                if renamed is None:
-                    rosys.notify(f'Could not rename {path.name} (name already in use or invalid)', type='negative')
+                try:
+                    if await rosys.run.io_bound(recorder.rename_recording, path, new_name) is None:  # off the loop
+                        raise ValueError('name already in use or invalid')
+                except ValueError as e:
+                    rosys.notify(f'Could not rename {path.name}: {e}', type='negative')
                 await reload()
 
         with ui.column().classes('w-full gap-2'):

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -137,16 +137,17 @@ class RecordingsPage:
                     rosys.notify(f'Could not rename {path.name} (name already in use or invalid)', type='negative')
                 await reload()
 
-        with ui.row().classes('w-full items-center gap-2'):
-            date_input = ui.date_input('Date range', range_input=True, on_change=recordings_list.refresh)
-            ui.space()
-            reindex_button = ui.button(icon='build', on_click=_reindex) \
-                .props('flat dense').tooltip('rebuild the index of unindexed recordings')
-            ui.button(icon='delete_sweep', on_click=_delete_all) \
-                .props('flat dense color=red').tooltip('delete all recordings')
-            ui.button(icon='refresh', on_click=reload).props('flat dense')
-        with ui.scroll_area().classes('w-full').style('max-height: 75vh'):
-            recordings_list()
+        with ui.column().classes('w-full gap-2'):  # one column, so controls and list keep the same insets
+            with ui.row().classes('w-full items-center gap-2'):
+                date_input = ui.date_input('Date range', range_input=True, on_change=recordings_list.refresh)
+                ui.space()
+                reindex_button = ui.button(icon='build', on_click=_reindex) \
+                    .props('flat dense').tooltip('rebuild the index of unindexed recordings')
+                ui.button(icon='delete_sweep', on_click=_delete_all) \
+                    .props('flat dense color=red').tooltip('delete all recordings')
+                ui.button(icon='refresh', on_click=reload).props('flat dense')
+            with ui.scroll_area().classes('w-full').style('max-height: 75vh'):
+                recordings_list()
 
         def _change_token() -> tuple[tuple[Path, ...], Path | None]:
             """A cheap change token — the recording paths plus the live file.

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -241,8 +241,9 @@ class RecordingsPage:
                     .props('flat dense color=red').tooltip('delete all recordings')
                 ui.button(icon='refresh', on_click=reload).props('flat dense')
             # the page already insets its content; the scroll area would add a second one, only for the list
+            content_padding = 'padding-left: 0; padding-right: 0'  # Quasar swaps in the active style once a thumb shows
             with ui.scroll_area().classes('w-full') \
-                    .props('content-style="padding-left: 0; padding-right: 0"') \
+                    .props(f'content-style="{content_padding}" content-active-style="{content_padding}"') \
                     .style('max-height: 75vh'):
                 recordings_list()
 

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -138,10 +138,7 @@ class RecordingsPage:
                 await reload()
 
         with ui.column().classes('w-full gap-2'):
-            # the scroll area pads its content, so the controls take the same inset and both edges line up
-            with ui.row().classes('w-full items-center gap-2') \
-                    .style('padding-left: var(--nicegui-default-padding); '
-                           'padding-right: var(--nicegui-default-padding)'):
+            with ui.row().classes('w-full items-center gap-2'):
                 date_input = ui.date_input('Date range', range_input=True, on_change=recordings_list.refresh)
                 ui.space()
                 reindex_button = ui.button(icon='build', on_click=_reindex) \
@@ -149,7 +146,10 @@ class RecordingsPage:
                 ui.button(icon='delete_sweep', on_click=_delete_all) \
                     .props('flat dense color=red').tooltip('delete all recordings')
                 ui.button(icon='refresh', on_click=reload).props('flat dense')
-            with ui.scroll_area().classes('w-full').style('max-height: 75vh'):
+            # the page already insets its content; the scroll area would add a second one, only for the list
+            with ui.scroll_area().classes('w-full') \
+                    .props('content-style="padding-left: 0; padding-right: 0"') \
+                    .style('max-height: 75vh'):
                 recordings_list()
 
         def _change_token() -> tuple[tuple[Path, ...], Path | None]:

--- a/rosys/analysis/recording/recordings_page_.py
+++ b/rosys/analysis/recording/recordings_page_.py
@@ -13,7 +13,7 @@ from ... import rosys
 from .mcap_recorder import _OWN_NAME, McapRecorder, RecordingInfo
 from .paths import DOWNLOAD_PATH, PAGE_PATH
 
-RIGHT_INSET = 'var(--nicegui-default-padding)'  # clears Quasar's 10 px thumb and keeps the page's rhythm
+_RIGHT_INSET = 'var(--nicegui-default-padding)'  # clears Quasar's 10 px thumb and keeps the page's rhythm
 
 _MAX_TIMEZONE_OFFSET_MINUTES = 24 * 60  # reject offsets beyond ±24 h from untrusted client JavaScript
 
@@ -226,7 +226,7 @@ class RecordingsPage:
                 await reload()
 
         with ui.column().classes('w-full gap-2'):
-            with ui.row().classes('w-full items-center gap-2').style(f'padding-right: {RIGHT_INSET}'):
+            with ui.row().classes('w-full items-center gap-2').style(f'padding-right: {_RIGHT_INSET}'):
                 date_input = ui.date_input('Date range', range_input=True, on_change=recordings_list.refresh)
                 ui.space()
                 reindex_button = ui.button(icon='build', on_click=_reindex) \
@@ -236,7 +236,7 @@ class RecordingsPage:
                 ui.button(icon='refresh', on_click=reload).props('flat dense')
             # the page already insets its content; the scroll area would add a second one, only for the list
             # Quasar swaps in the active style once a thumb shows, so both carry the same padding
-            content_padding = f'padding-left: 0; padding-right: {RIGHT_INSET}'
+            content_padding = f'padding-left: 0; padding-right: {_RIGHT_INSET}'
             with ui.scroll_area().classes('w-full') \
                     .props(f'content-style="{content_padding}" content-active-style="{content_padding}"') \
                     .style('max-height: 75vh'):
@@ -250,7 +250,7 @@ class RecordingsPage:
             return tuple(recorder.recordings), recorder.current_recording, recorder.merging
 
         async def sync_if_changed() -> None:
-            # Picks up start/stop, size-based rotation, and external add/remove. The
+            # Picks up start/stop, rotation, merges and external add/remove. The
             # change token globs the directory, so it is computed off the loop (matching
             # the class docstring); only an actual change triggers the fuller stat/index
             # scan in reload(). A client-scoped timer (auto-removed on disconnect) avoids

--- a/tests/test_mcap_converters.py
+++ b/tests/test_mcap_converters.py
@@ -878,15 +878,21 @@ async def test_log_levels_map_onto_foxglove(mcap_dir: Path) -> None:
     assert [message['level'] for _, message in _read(_only_file(mcap_dir))] == [1, 2, 3, 4, 5]
 
 
-async def test_the_recorders_own_log_stays_out_of_the_recording(mcap_dir: Path) -> None:
-    """The recorder logs from inside its queue lock, so recording its own lines would deadlock it."""
+async def test_the_recorders_own_warning_about_a_full_queue_is_recorded(mcap_dir: Path) -> None:
+    """The recorder's own lines are recorded too, the one it logs while dropping queued messages included."""
     recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
-    recorder.log.setLevel(logging.DEBUG)
-    recorder.log.addHandler(McapLogHandler(recorder))
+    recorder.max_queued_messages = 3
+    handler = McapLogHandler(recorder)
+    recorder.log.addHandler(handler)
+    recorder.add_topic('/test', TopicSchema('Test', b'{}', 'jsonschema', 'json'))
     recorder.start()
+    try:
+        for _ in range(5):
+            recorder.log_message('/test', b'{}')
+        await recorder.stop()
+    finally:
+        recorder.log.removeHandler(handler)
 
-    recorder.log_message('/unknown', b'{}')  # makes the recorder log about the unknown topic
-    await recorder.stop()
-    recorder.log.handlers.clear()
-
-    assert not list(mcap_dir.glob('*.mcap'))  # nothing recorded at all -> the empty recording was discarded
+    log_lines = [message['message'] for schema_name, message in _read(_only_file(mcap_dir))
+                 if schema_name == 'foxglove.Log']
+    assert any(line.startswith('recording queue full') for line in log_lines)

--- a/tests/test_mcap_converters.py
+++ b/tests/test_mcap_converters.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import logging
 import math
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,6 +14,7 @@ from nicegui.page import page
 
 from rosys.analysis.recording import (
     Converter,
+    McapLogHandler,
     McapRecorder,
     TopicSchema,
     add_event_topic,
@@ -829,3 +831,62 @@ async def test_event_subscription_survives_client_deletion(mcap_dir: Path) -> No
 
     _, message = _read(_only_file(mcap_dir))[0]
     assert message['pose']['position']['x'] == 3.0
+
+
+def _recording_logger(recorder: McapRecorder) -> logging.Logger:
+    """A logger whose lines the given recorder records, with no handler left from an earlier test.
+
+    :param recorder: the recorder the log handler writes to.
+    :return: the logger to log through.
+    """
+    logger = logging.getLogger('rosys.test.recording')
+    logger.setLevel(logging.DEBUG)
+    logger.handlers.clear()
+    logger.addHandler(McapLogHandler(recorder))
+    return logger
+
+
+async def test_log_lines_are_recorded(mcap_dir: Path) -> None:
+    """A line logged while the handler is attached lands in the recording as a foxglove.Log message."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    logger = _recording_logger(recorder)
+    recorder.start()
+
+    logger.warning('found %d weeds', 3)
+    await recorder.stop()
+    logger.handlers.clear()
+
+    schema_name, message = _read(_only_file(mcap_dir))[0]
+    assert schema_name == 'foxglove.Log'
+    assert message['message'] == 'found 3 weeds'
+    assert message['level'] == 3  # foxglove WARNING
+    assert message['name'] == 'rosys.test.recording'
+    assert message['file'] == 'test_mcap_converters.py'
+
+
+async def test_log_levels_map_onto_foxglove(mcap_dir: Path) -> None:
+    """Foxglove colours and filters a line by its level, so every Python level needs its counterpart."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    logger = _recording_logger(recorder)
+    recorder.start()
+
+    for level in (logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR, logging.CRITICAL):
+        logger.log(level, 'a line')
+    await recorder.stop()
+    logger.handlers.clear()
+
+    assert [message['level'] for _, message in _read(_only_file(mcap_dir))] == [1, 2, 3, 4, 5]
+
+
+async def test_the_recorders_own_log_stays_out_of_the_recording(mcap_dir: Path) -> None:
+    """The recorder logs from inside its queue lock, so recording its own lines would deadlock it."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    recorder.log.setLevel(logging.DEBUG)
+    recorder.log.addHandler(McapLogHandler(recorder))
+    recorder.start()
+
+    recorder.log_message('/unknown', b'{}')  # makes the recorder log about the unknown topic
+    await recorder.stop()
+    recorder.log.handlers.clear()
+
+    assert not list(mcap_dir.glob('*.mcap'))  # nothing recorded at all -> the empty recording was discarded

--- a/tests/test_mcap_merging.py
+++ b/tests/test_mcap_merging.py
@@ -1,0 +1,267 @@
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from mcap.reader import make_reader
+from mcap.writer import Writer
+
+import rosys
+from rosys.analysis.recording import (
+    MERGE_METADATA_NAME,
+    METADATA_NAME,
+    McapRecorder,
+    TopicSchema,
+    is_auto_named,
+    merge_recordings,
+)
+from rosys.analysis.recording.merging import merge_into_place
+
+NS = 1_000_000_000
+
+
+def _schema(properties: dict | None = None) -> TopicSchema:
+    body = {'type': 'object', 'properties': properties or {'value': {'type': 'number'}}}
+    return TopicSchema('Test', json.dumps(body).encode(), 'jsonschema', 'json')
+
+
+def _recorder(mcap_dir: Path) -> McapRecorder:
+    recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    return recorder
+
+
+async def _record(recorder: McapRecorder, parts: list[list[int]], **start_arguments) -> list[Path]:
+    """Record one run whose parts hold the given values, letting a rotation separate them.
+
+    :param recorder: the recorder to record with.
+    :param parts: the values of each part, in recording order.
+    :param start_arguments: passed on to ``start()``.
+    :return: the parts of the run, oldest first.
+    """
+    run = recorder.start(**start_arguments)
+    for index, values in enumerate(parts):
+        if index:
+            rosys.set_time(rosys.time() + 61)
+        for value in values:
+            recorder.log_message('/test', json.dumps({'value': value}).encode())
+        await recorder._flush()
+    await recorder.stop()
+    return sorted(recorder.output_dir.glob(f'{run}_[0-9]*.mcap'))
+
+
+def _values(path: Path) -> list:
+    with open(path, 'rb') as f:
+        return [json.loads(message.data)['value'] for _, _, message in make_reader(f).iter_messages()]
+
+
+def _records(path: Path) -> dict[str, dict]:
+    """Read every metadata record of a recording.
+
+    :param path: the MCAP file to read.
+    :return: the decoded JSON payload of each record, by record name.
+    """
+    with open(path, 'rb') as f:
+        return {record.name: json.loads(record.metadata['json']) for record in make_reader(f).iter_metadata()}
+
+
+def _files(mcap_dir: Path) -> set[str]:
+    return {path.name for path in mcap_dir.iterdir()}
+
+
+async def test_a_merged_recording_keeps_the_context_of_its_sources(mcap_dir: Path) -> None:
+    """Merging must not strip the metadata; the merged file is the one people send around."""
+    parts = await _record(_recorder(mcap_dir), [[0], [1]], metadata={'mission': 'Implement Demo', 'run_id': 42})
+
+    target = mcap_dir / 'merged.mcap'
+    count = merge_recordings(parts, target)
+
+    assert count == 2
+    assert _values(target) == [0, 1]
+    assert _records(target)[METADATA_NAME] == {'mission': 'Implement Demo', 'run_id': 42}
+
+
+async def test_a_merged_recording_says_how_it_came_to_be(mcap_dir: Path) -> None:
+    """The merge leaves its own record, so nobody wonders where a file came from."""
+    parts = await _record(_recorder(mcap_dir), [[0]])
+
+    target = mcap_dir / 'merged.mcap'
+    merge_recordings(parts, target)
+
+    assert _records(target)[MERGE_METADATA_NAME]['sources'] == [parts[0].name]
+    assert _records(target)[MERGE_METADATA_NAME]['trimmed'] is False
+
+
+async def test_a_merge_can_start_at_a_given_time(mcap_dir: Path) -> None:
+    """Messages before the start time are left out, and the merge record says it was trimmed."""
+    recorder = _recorder(mcap_dir)
+    started_at = rosys.time()
+    parts = await _record(recorder, [[0, 1], [2, 3]])
+
+    target = mcap_dir / 'merged.mcap'
+    count = merge_recordings(parts, target, start_time_ns=int((started_at + 30) * NS))
+
+    assert count == 2
+    assert _values(target) == [2, 3]
+    assert _records(target)[MERGE_METADATA_NAME]['trimmed'] is True
+
+
+async def test_runs_with_different_metadata_each_keep_their_record(mcap_dir: Path) -> None:
+    """A merge across runs keeps the context of every run, numbered apart."""
+    recorder = _recorder(mcap_dir)
+    first = await _record(recorder, [[0]], metadata={'run_id': 1})
+    second = await _record(recorder, [[1]], metadata={'run_id': 2})
+
+    target = mcap_dir / 'merged.mcap'
+    merge_recordings(first + second, target)
+
+    records = _records(target)
+    assert records[METADATA_NAME] == {'run_id': 1}
+    assert records[f'{METADATA_NAME}_2'] == {'run_id': 2}
+
+
+async def test_merging_merged_recordings_keeps_every_context(mcap_dir: Path) -> None:
+    """A merged file merged again still names every run it holds and every merge it went through."""
+    recorder = _recorder(mcap_dir)
+    first = await recorder.merge(await _record(recorder, [[0], [1]], metadata={'run_id': 1}), 'first')
+    second = await recorder.merge(await _record(recorder, [[2]], metadata={'run_id': 2}), 'second')
+    assert first is not None and second is not None
+
+    both = await recorder.merge([first, second], 'both')
+
+    assert both is not None
+    assert _values(both) == [0, 1, 2]
+    records = _records(both)
+    assert [records[name] for name in sorted(records) if name.startswith(METADATA_NAME)] == \
+        [{'run_id': 1}, {'run_id': 2}]
+    assert records[MERGE_METADATA_NAME]['sources'] == ['first.mcap', 'second.mcap']
+    assert sorted(len(records[name]['sources']) for name in records if name.startswith(f'{MERGE_METADATA_NAME}_')) \
+        == [1, 2]
+
+
+async def test_a_topic_keeps_the_schema_each_source_recorded_it_with(mcap_dir: Path) -> None:
+    """The same topic recorded before and after a schema change stays readable in both forms."""
+    recorder = _recorder(mcap_dir)
+    before = await _record(recorder, [[0]])
+    recorder.add_topic('/test', _schema({'value': {'type': 'integer'}}))
+    after = await _record(recorder, [[1]])
+
+    target = mcap_dir / 'merged.mcap'
+    merge_recordings(before + after, target)
+
+    with open(target, 'rb') as f:
+        schemas = [json.loads(schema.data)['properties']['value']['type']
+                   for schema, _, _ in make_reader(f).iter_messages()]
+    assert schemas == ['number', 'integer']
+
+
+async def test_a_run_merges_into_a_kept_recording_that_replaces_its_parts(mcap_dir: Path) -> None:
+    """The merged run is one kept file; its parts are gone once it is in place."""
+    recorder = _recorder(mcap_dir)
+    parts = await _record(recorder, [[0], [1], [2]], name='mission')
+
+    target = await recorder.merge(parts, 'mission_merged')
+
+    assert target == mcap_dir / 'mission_merged.mcap'
+    assert _files(mcap_dir) == {'mission_merged.mcap'}
+    assert _values(target) == [0, 1, 2]
+    assert not is_auto_named(target)
+
+
+async def test_a_run_with_an_unindexed_part_can_be_merged(mcap_dir: Path) -> None:
+    """A part left without its index by a crash is reindexed and merged with its context."""
+    recorder = _recorder(mcap_dir)
+    [part] = await _record(recorder, [[0]], metadata={'run_id': 1})
+    unfinished = part.with_name(part.name.replace('_01.mcap', '_02.mcap'))
+    with open(unfinished, 'wb') as f:
+        writer = Writer(f, chunk_size=1)  # every message closes a chunk, so all of them are on disk
+        writer.start()
+        writer.add_metadata(METADATA_NAME, {'json': json.dumps({'run_id': 1, 'crashed': True})})
+        channel = writer.register_channel('/test', 'json', writer.register_schema('Test', 'jsonschema', b'{}'))
+        log_time = int((rosys.time() + 1) * NS)
+        writer.add_message(channel, log_time=log_time, data=b'{"value": 1}', publish_time=log_time)
+        # never finished, as after a crash: no summary index
+
+    target = await recorder.merge([part, unfinished], 'merged')
+
+    assert target is not None
+    assert _values(target) == [0, 1]
+    assert _records(target)[f'{METADATA_NAME}_2'] == {'run_id': 1, 'crashed': True}
+
+
+async def test_a_second_merge_into_the_same_name_is_refused(mcap_dir: Path) -> None:
+    """Two clients merging the same run at once cannot write into the same file."""
+    recorder = _recorder(mcap_dir)
+    parts = await _record(recorder, [[0], [1]])
+
+    first, second = await asyncio.gather(recorder.merge(parts, 'merged'), recorder.merge(parts, 'merged'),
+                                         return_exceptions=True)
+
+    assert first == mcap_dir / 'merged.mcap'
+    assert isinstance(second, FileExistsError)
+    assert _values(mcap_dir / 'merged.mcap') == [0, 1]
+    assert recorder.merging == frozenset()
+
+
+async def test_a_merge_never_overwrites_a_recording(mcap_dir: Path) -> None:
+    """An existing recording under the merged name stays as it is, and so do the sources."""
+    recorder = _recorder(mcap_dir)
+    parts = await _record(recorder, [[0], [1]])
+    existing = mcap_dir / 'merged.mcap'
+    existing.write_bytes(b'a recording of its own')
+
+    with pytest.raises(FileExistsError):
+        await recorder.merge(parts, 'merged')
+    with pytest.raises(FileExistsError):
+        merge_into_place(parts, existing)
+
+    assert existing.read_bytes() == b'a recording of its own'
+    assert _files(mcap_dir) == {existing.name, *(part.name for part in parts)}
+
+
+async def test_a_failed_merge_keeps_its_sources(mcap_dir: Path) -> None:
+    """Sources go only once the merged file is in place; a merge that fails leaves them be."""
+    recorder = _recorder(mcap_dir)
+    parts = await _record(recorder, [[0], [1]])
+    vanished = parts[-1].with_name(parts[-1].name.replace('_02.mcap', '_03.mcap'))
+
+    with pytest.raises(FileNotFoundError):
+        await recorder.merge([*parts, vanished], 'merged')
+
+    assert _files(mcap_dir) == {part.name for part in parts}
+
+
+async def test_a_merge_with_nothing_left_to_merge_keeps_its_sources(mcap_dir: Path) -> None:
+    """A start time after the last message merges nothing, so no file is written and the sources stay."""
+    recorder = _recorder(mcap_dir)
+    parts = await _record(recorder, [[0], [1]])
+
+    target = await recorder.merge(parts, 'merged', start_time_ns=int((rosys.time() + 3600) * NS))
+
+    assert target is None
+    assert _files(mcap_dir) == {part.name for part in parts}
+
+
+@pytest.mark.parametrize('name', ['20260911_120000_123456_merged_01', '../merged', 'sub/merged'])
+async def test_a_merged_name_must_be_a_kept_file_name(mcap_dir: Path, name: str) -> None:
+    """A merged recording cannot land outside the directory or read as a file the budget deletes first."""
+    recorder = _recorder(mcap_dir)
+    parts = await _record(recorder, [[0], [1]])
+
+    with pytest.raises(ValueError):
+        await recorder.merge(parts, name)
+
+    assert _files(mcap_dir) == {part.name for part in parts}
+
+
+async def test_the_live_recording_cannot_be_merged(mcap_dir: Path) -> None:
+    """The file being written is no finished recording yet."""
+    recorder = _recorder(mcap_dir)
+    recorder.start()
+    live = recorder.current_recording
+    assert live is not None
+
+    with pytest.raises(ValueError):
+        await recorder.merge([live], 'merged')
+
+    await recorder.stop()

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from mcap.reader import make_reader
 
+import rosys
 from rosys.analysis.recording import McapRecorder, TopicSchema
 
 NS = 1_000_000_000
@@ -667,3 +668,80 @@ async def test_start_deletes_old_recordings_over_budget(mcap_dir: Path) -> None:
     remaining = {path.name for path in mcap_dir.glob('*.mcap')}
     assert 'old_0.mcap' not in remaining  # oldest deleted to satisfy the budget
     assert 'old_2.mcap' in remaining  # newest kept
+
+
+async def test_duration_based_rotation(mcap_dir: Path) -> None:
+    """A file older than max_file_duration is rotated as soon as the next message is written."""
+    recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start()
+
+    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    await recorder._flush()
+    rosys.set_time(rosys.time() + 61)
+    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=61 * NS)
+    recorder.log_message('/test', _json({'value': 2}), timestamp_ns=62 * NS)
+    await recorder.stop()
+
+    files = sorted(mcap_dir.glob('*.mcap'))
+    assert len(files) == 2, f'Expected duration rotation, got {len(files)} file(s)'
+    assert sum(_message_count(path) for path in files) == 3
+
+
+async def test_split_finalizes_current_file_and_keeps_recording(mcap_dir: Path) -> None:
+    """split() files away everything recorded so far and the recording continues seamlessly."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start()
+    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=NS)
+
+    finalized = await recorder.split()
+
+    assert finalized is not None
+    assert _values(finalized) == [0, 1]
+    assert recorder.is_recording
+    assert recorder.current_recording is not None
+    assert recorder.current_recording != finalized
+
+    recorder.log_message('/test', _json({'value': 2}), timestamp_ns=2 * NS)
+    await recorder.stop()
+    second = next(path for path in mcap_dir.glob('*.mcap') if path != finalized)
+    assert _values(second) == [2]
+
+
+async def test_split_without_messages_keeps_the_growing_file(mcap_dir: Path) -> None:
+    """split() refuses to churn an empty file into an empty recording."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start()
+    live = recorder.current_recording
+
+    assert await recorder.split() is None
+    assert recorder.is_recording
+    assert recorder.current_recording == live
+
+
+async def test_split_while_stopped_returns_none(mcap_dir: Path) -> None:
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    assert await recorder.split() is None
+
+
+async def test_disk_budget_deletes_renamed_recordings_last(mcap_dir: Path) -> None:
+    """The budget evicts auto-named files (oldest first) before touching a renamed recording."""
+    kept = mcap_dir / 'failure_20200101_000000_000000.mcap'
+    kept.write_bytes(os.urandom(60 * 1024))
+    os.utime(kept, (0, 0))  # the oldest file of all, yet renamed -> deleted last
+    for i in range(2):
+        path = mcap_dir / f'2020010{i + 1}_000000_000000.mcap'
+        path.write_bytes(os.urandom(60 * 1024))
+        os.utime(path, (i + 1, i + 1))
+    recorder = McapRecorder(output_dir=mcap_dir, max_total_size_mb=0.12, auto_start=False)  # ~126 KiB budget
+
+    recorder.start()
+    await recorder.stop()  # empty -> new file discarded
+
+    remaining = {path.name for path in mcap_dir.glob('*.mcap')}
+    assert kept.name in remaining
+    assert '20200101_000000_000000.mcap' not in remaining  # oldest auto-named file paid for the budget
+    assert '20200102_000000_000000.mcap' in remaining

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -689,15 +689,15 @@ async def test_duration_based_rotation(mcap_dir: Path) -> None:
 
 
 @pytest.mark.parametrize('kept_name', ['weeding on the north field.mcap',  # renamed by hand
-                                       '20200101_000000_run0001.mcap',  # the merged file of a run
-                                       '20200101_000000_run0001_failure.mcap'])  # preserved around a failure
+                                       '20200101_000000_000000_run0001_merged.mcap',  # the merged file of a run
+                                       '20200101_000000_000000_run0001_failure.mcap'])  # preserved around a failure
 async def test_disk_budget_deletes_kept_recordings_last(mcap_dir: Path, kept_name: str) -> None:
     """The budget evicts the recorder's own numbered files (oldest first) before anything kept."""
     kept = mcap_dir / kept_name
     kept.write_bytes(os.urandom(60 * 1024))
     os.utime(kept, (0, 0))  # the oldest file of all, yet not the recorder's own -> deleted last
     for i in range(2):
-        path = mcap_dir / f'20200101_000000_run0002_0{i + 1}.mcap'
+        path = mcap_dir / f'20200101_000000_000000_run0002_0{i + 1}.mcap'
         path.write_bytes(os.urandom(60 * 1024))
         os.utime(path, (i + 1, i + 1))
     recorder = McapRecorder(output_dir=mcap_dir, max_total_size_mb=0.12, auto_start=False)  # ~126 KiB budget
@@ -707,8 +707,28 @@ async def test_disk_budget_deletes_kept_recordings_last(mcap_dir: Path, kept_nam
 
     remaining = {path.name for path in mcap_dir.glob('*.mcap')}
     assert kept.name in remaining
-    assert '20200101_000000_run0002_01.mcap' not in remaining  # the oldest of the recorder's own paid for the budget
-    assert '20200101_000000_run0002_02.mcap' in remaining
+    assert '20200101_000000_000000_run0002_01.mcap' not in remaining  # the oldest own file paid for the budget
+    assert '20200101_000000_000000_run0002_02.mcap' in remaining
+
+
+_LONG_NAME = '_'.join(['word'] * 60)
+
+
+@pytest.mark.parametrize(('name', 'own'), [
+    ('20260911_120000_123456_01.mcap', True),  # a run without a name
+    ('20260911_120000_123456_mission_01.mcap', True),
+    ('20260911_120000_123456_mission_05_100.mcap', True),  # the name may end in digits, the part is last
+    (f'20260911_120000_123456_{_LONG_NAME}_01.mcap', True),
+    ('20260911_120000_123456.mcap', True),  # a single unnumbered file
+    ('20260911_120000_123456_mission_merged.mcap', False),
+    ('20260911_120000_123456_mission_failure.mcap', False),
+    (f'20260911_120000_123456_{_LONG_NAME}.mcap', False),
+    ('mission_01.mcap', False),  # numbered, but not by the recorder
+    ('weeding on the north field.mcap', False),
+])
+def test_the_recorders_own_files_are_told_apart_by_name(name: str, own: bool) -> None:
+    """Only the names the recorder generates count as its own, however long the run name gets."""
+    assert is_auto_named(name) is own
 
 
 def _metadata(path: Path) -> dict:
@@ -723,19 +743,20 @@ def _metadata(path: Path) -> dict:
 
 
 async def test_the_files_of_one_recording_share_a_name_and_are_numbered(mcap_dir: Path) -> None:
-    """Rotation keeps the caller's name and numbers the parts, so a run reads as a unit."""
+    """The run is named after its start time and the caller's name, and rotation numbers its parts."""
     recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
     recorder.add_topic('/test', _schema())
-    recorder.start(name='20260911_054956_run0042')
+    run = recorder.start(name='run0042')
 
     recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
     await recorder._flush()
     rosys.set_time(rosys.time() + 61)
     recorder.log_message('/test', _json({'value': 1}), timestamp_ns=61 * NS)
+    recorder.log_message('/test', _json({'value': 2}), timestamp_ns=62 * NS)
     await recorder.stop()
 
-    assert [path.name for path in sorted(mcap_dir.glob('*.mcap'))] == \
-        ['20260911_054956_run0042_01.mcap', '20260911_054956_run0042_02.mcap']
+    assert run is not None and run.endswith('_run0042')
+    assert [path.name for path in sorted(mcap_dir.glob('*.mcap'))] == [f'{run}_01.mcap', f'{run}_02.mcap']
 
 
 async def test_every_file_of_a_recording_carries_the_metadata(mcap_dir: Path) -> None:
@@ -758,13 +779,80 @@ async def test_every_file_of_a_recording_carries_the_metadata(mcap_dir: Path) ->
 
 async def test_a_named_recording_stays_within_the_disk_budget(mcap_dir: Path) -> None:
     """A name from the caller does not turn its files into keepers the budget spares."""
-    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
-    recorder.add_topic('/test', _schema())
-    recorder.start(name='20260911_054956_run0042')
-    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    kept = mcap_dir / 'weeding on the north field.mcap'
+    kept.write_bytes(os.urandom(60 * 1024))
+    os.utime(kept, (0, 0))
+    recorder = McapRecorder(output_dir=mcap_dir, max_total_size_mb=0.12, auto_start=False)  # ~126 KiB budget
+    recorder.add_topic('/test', _schema('Test', {'payload': {'type': 'string'}}))
+    recorder.start(name='mission')
+    for i in range(70):  # incompressible, so the part outgrows what the kept file leaves of the budget
+        recorder.log_message('/test', _json({'payload': os.urandom(1024).hex()}), timestamp_ns=i * NS)
+    await recorder.stop()
+    mission = recorder.recordings[0]
+
+    recorder.start()
     await recorder.stop()
 
-    assert all(is_auto_named(path) for path in mcap_dir.glob('*.mcap'))
+    assert not mission.exists()
+    assert kept.exists()
+
+
+async def test_a_recording_cannot_be_renamed_into_one_of_the_recorders_own_names(mcap_dir: Path) -> None:
+    """A renamed file is kept on purpose, so a name the budget would delete first is refused."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start()
+    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=NS)
+    await recorder.stop()
+    path = recorder.recordings[0]
+
+    with pytest.raises(ValueError):
+        recorder.rename_recording(path, '20260911_120000_123456_backup_02')
+
+    assert recorder.recordings == [path]
+
+
+@pytest.mark.parametrize('name', ['../escaped', 'sub/run', '..', '   ', ''])
+def test_a_run_name_cannot_leave_the_output_directory(mcap_dir: Path, name: str) -> None:
+    """A name that is no plain file name is refused before any file is opened."""
+    recorder = McapRecorder(output_dir=mcap_dir / 'recordings', auto_start=False)
+
+    with pytest.raises(ValueError):
+        recorder.start(name=name)
+
+    assert not recorder.is_recording
+    assert not list(mcap_dir.rglob('*.mcap'))
+
+
+async def test_the_metadata_is_taken_as_it_was_at_start(mcap_dir: Path) -> None:
+    """Changing the caller's dict after start does not change the parts written later."""
+    recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    metadata = {'mission': 'Implement Demo'}
+    recorder.start(metadata=metadata)
+    metadata['mission'] = 'something else'
+
+    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    await recorder._flush()
+    rosys.set_time(rosys.time() + 61)
+    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=61 * NS)
+    recorder.log_message('/test', _json({'value': 2}), timestamp_ns=62 * NS)
+    await recorder.stop()
+
+    files = sorted(mcap_dir.glob('*.mcap'))
+    assert len(files) == 2
+    assert [_metadata(path) for path in files] == [{'mission': 'Implement Demo'}] * 2
+
+
+def test_metadata_that_is_no_json_is_refused_at_start(mcap_dir: Path) -> None:
+    """Metadata the recorder could not write fails the start, not a later rotation."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+
+    with pytest.raises(TypeError):
+        recorder.start(metadata={'when': object()})
+
+    assert not recorder.is_recording
+    assert not list(mcap_dir.glob('*.mcap'))
 
 
 async def test_a_merged_recording_keeps_the_context_of_its_sources(mcap_dir: Path) -> None:

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -7,7 +7,7 @@ import pytest
 from mcap.reader import make_reader
 
 import rosys
-from rosys.analysis.recording import McapRecorder, TopicSchema
+from rosys.analysis.recording import McapRecorder, TopicSchema, is_auto_named
 
 NS = 1_000_000_000
 
@@ -745,3 +745,59 @@ async def test_disk_budget_deletes_renamed_recordings_last(mcap_dir: Path) -> No
     assert kept.name in remaining
     assert '20200101_000000_000000.mcap' not in remaining  # oldest auto-named file paid for the budget
     assert '20200102_000000_000000.mcap' in remaining
+
+
+def _metadata(path: Path) -> dict:
+    """Read the recording's metadata record back.
+
+    :param path: the MCAP file to read.
+    :return: the decoded JSON payload, or an empty dict when the file carries none.
+    """
+    with open(path, 'rb') as f:
+        records = [record for record in make_reader(f).iter_metadata() if record.name == 'recording']
+    return json.loads(records[0].metadata['json']) if records else {}
+
+
+async def test_the_files_of_one_recording_share_a_name_and_are_numbered(mcap_dir: Path) -> None:
+    """Rotation keeps the caller's name and numbers the parts, so a run reads as a unit."""
+    recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start(name='20260911_054956_run0042')
+
+    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    await recorder._flush()
+    rosys.set_time(rosys.time() + 61)
+    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=61 * NS)
+    await recorder.stop()
+
+    assert [path.name for path in sorted(mcap_dir.glob('*.mcap'))] == \
+        ['20260911_054956_run0042_01.mcap', '20260911_054956_run0042_02.mcap']
+
+
+async def test_every_file_of_a_recording_carries_the_metadata(mcap_dir: Path) -> None:
+    """A rotated segment is as self-explaining as the first one."""
+    recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start(name='run', metadata={'mission': 'Implement Demo', 'run_id': 42})
+
+    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    await recorder._flush()
+    rosys.set_time(rosys.time() + 61)
+    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=61 * NS)
+    await recorder.stop()
+
+    files = sorted(mcap_dir.glob('*.mcap'))
+    assert len(files) == 2
+    for path in files:
+        assert _metadata(path) == {'mission': 'Implement Demo', 'run_id': 42}
+
+
+async def test_a_named_recording_stays_within_the_disk_budget(mcap_dir: Path) -> None:
+    """A name from the caller does not turn its files into keepers the budget spares."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start(name='20260911_054956_run0042')
+    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    await recorder.stop()
+
+    assert all(is_auto_named(path) for path in mcap_dir.glob('*.mcap'))

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -8,7 +8,7 @@ import pytest
 from mcap.reader import make_reader
 
 import rosys
-from rosys.analysis.recording import MERGE_METADATA_NAME, McapRecorder, TopicSchema, is_auto_named, merge_recordings
+from rosys.analysis.recording import METADATA_NAME, McapRecorder, TopicSchema, is_auto_named
 
 NS = 1_000_000_000
 
@@ -609,15 +609,16 @@ async def test_failed_rotation_stops_recording_without_silent_loss(mcap_dir: Pat
     assert sum(_message_count(f) for f in files) == recorder.message_count
 
 
-def test_startup_removes_orphaned_reindex_temp_files(mcap_dir: Path) -> None:
-    """A reindex temp file left by a crash is cleared when a recorder is created; real recordings are kept."""
+@pytest.mark.parametrize('orphan_name', ['recording.mcap.reindex-deadbeef', 'recording.mcap.merge-deadbeef'])
+def test_startup_removes_orphaned_temporary_files(mcap_dir: Path, orphan_name: str) -> None:
+    """A reindex or merge temp file left by a crash is cleared when a recorder is created; real recordings are kept."""
     (mcap_dir / 'recording.mcap').write_bytes(b'a real recording')
-    orphan = mcap_dir / 'recording.mcap.reindex-deadbeef'
-    orphan.write_bytes(b'partial reindex output')
+    orphan = mcap_dir / orphan_name
+    orphan.write_bytes(b'partial output')
 
     McapRecorder(output_dir=mcap_dir, auto_start=False)
 
-    assert not orphan.exists()  # the orphaned reindex temp file was removed at startup
+    assert not orphan.exists()
     assert (mcap_dir / 'recording.mcap').exists()  # the real recording is untouched
 
 
@@ -757,7 +758,7 @@ def _metadata(path: Path) -> dict:
     :return: the decoded JSON payload, or an empty dict when the file carries none.
     """
     with open(path, 'rb') as f:
-        records = [record for record in make_reader(f).iter_metadata() if record.name == 'recording']
+        records = [record for record in make_reader(f).iter_metadata() if record.name == METADATA_NAME]
     return json.loads(records[0].metadata['json']) if records else {}
 
 
@@ -917,42 +918,3 @@ def test_metadata_that_is_no_json_is_refused_at_start(mcap_dir: Path) -> None:
 
     assert not recorder.is_recording
     assert not list(mcap_dir.glob('*.mcap'))
-
-
-async def test_a_merged_recording_keeps_the_context_of_its_sources(mcap_dir: Path) -> None:
-    """Merging must not strip the metadata; the merged file is the one people send around."""
-    recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
-    recorder.add_topic('/test', _schema())
-    recorder.start(name='run', metadata={'mission': 'Implement Demo', 'run_id': 42})
-    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
-    await recorder._flush()
-    rosys.set_time(rosys.time() + 61)
-    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=61 * NS)
-    await recorder.stop()
-    sources = sorted(mcap_dir.glob('*.mcap'))
-
-    target = mcap_dir / 'merged.mcap'
-    count = merge_recordings(sources, target)
-
-    assert count == 2
-    assert _values(target) == [0, 1]
-    assert _metadata(target) == {'mission': 'Implement Demo', 'run_id': 42}
-
-
-async def test_a_merged_recording_says_how_it_came_to_be(mcap_dir: Path) -> None:
-    """The merge leaves its own record, so nobody wonders where a file came from."""
-    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
-    recorder.add_topic('/test', _schema())
-    recorder.start(name='run')
-    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
-    await recorder.stop()
-    source = next(iter(mcap_dir.glob('*.mcap')))
-
-    target = mcap_dir / 'merged.mcap'
-    merge_recordings([source], target)
-
-    with open(target, 'rb') as f:
-        records = {record.name: json.loads(record.metadata['json'])
-                   for record in make_reader(f).iter_metadata()}
-    assert records[MERGE_METADATA_NAME]['sources'] == [source.name]
-    assert records[MERGE_METADATA_NAME]['trimmed'] is False

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -727,13 +727,16 @@ async def test_split_while_stopped_returns_none(mcap_dir: Path) -> None:
     assert await recorder.split() is None
 
 
-async def test_disk_budget_deletes_renamed_recordings_last(mcap_dir: Path) -> None:
-    """The budget evicts auto-named files (oldest first) before touching a renamed recording."""
-    kept = mcap_dir / 'failure_20200101_000000_000000.mcap'
+@pytest.mark.parametrize('kept_name', ['weeding on the north field.mcap',  # renamed by hand
+                                       '20200101_000000_run0001.mcap',  # the merged file of a run
+                                       '20200101_000000_run0001_failure.mcap'])  # preserved around a failure
+async def test_disk_budget_deletes_kept_recordings_last(mcap_dir: Path, kept_name: str) -> None:
+    """The budget evicts the recorder's own numbered files (oldest first) before anything kept."""
+    kept = mcap_dir / kept_name
     kept.write_bytes(os.urandom(60 * 1024))
-    os.utime(kept, (0, 0))  # the oldest file of all, yet renamed -> deleted last
+    os.utime(kept, (0, 0))  # the oldest file of all, yet not the recorder's own -> deleted last
     for i in range(2):
-        path = mcap_dir / f'2020010{i + 1}_000000_000000.mcap'
+        path = mcap_dir / f'20200101_000000_run0002_0{i + 1}.mcap'
         path.write_bytes(os.urandom(60 * 1024))
         os.utime(path, (i + 1, i + 1))
     recorder = McapRecorder(output_dir=mcap_dir, max_total_size_mb=0.12, auto_start=False)  # ~126 KiB budget
@@ -743,8 +746,8 @@ async def test_disk_budget_deletes_renamed_recordings_last(mcap_dir: Path) -> No
 
     remaining = {path.name for path in mcap_dir.glob('*.mcap')}
     assert kept.name in remaining
-    assert '20200101_000000_000000.mcap' not in remaining  # oldest auto-named file paid for the budget
-    assert '20200102_000000_000000.mcap' in remaining
+    assert '20200101_000000_run0002_01.mcap' not in remaining  # the oldest of the recorder's own paid for the budget
+    assert '20200101_000000_run0002_02.mcap' in remaining
 
 
 def _metadata(path: Path) -> dict:

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -712,6 +712,24 @@ async def test_disk_budget_deletes_kept_recordings_last(mcap_dir: Path, kept_nam
     assert '20200101_000000_000000_run0002_02.mcap' in remaining
 
 
+async def test_kept_recordings_beyond_their_bound_roll_away_oldest_first(mcap_dir: Path) -> None:
+    """Kept files cannot eat the rolling window; the newest kept file stays however large it is."""
+    kept_sizes = {'oldest kept.mcap': 60, 'older kept.mcap': 60, 'newest kept.mcap': 150}  # KiB
+    own_names = ['20200101_000000_000000_01.mcap', '20200101_000000_000000_02.mcap']
+    for age, (name, size) in enumerate(kept_sizes.items()):
+        (mcap_dir / name).write_bytes(os.urandom(size * 1024))
+        os.utime(mcap_dir / name, (age, age))
+    for age, name in enumerate(own_names, start=len(kept_sizes)):
+        (mcap_dir / name).write_bytes(os.urandom(60 * 1024))
+        os.utime(mcap_dir / name, (age, age))
+    recorder = McapRecorder(output_dir=mcap_dir, max_total_size_mb=0.3, max_kept_size_mb=0.12, auto_start=False)
+
+    recorder.start()
+    await recorder.stop()  # empty -> new file discarded
+
+    assert {path.name for path in mcap_dir.glob('*.mcap')} == {'newest kept.mcap', *own_names}
+
+
 _LONG_NAME = '_'.join(['word'] * 60)
 
 

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -752,11 +753,56 @@ async def test_the_files_of_one_recording_share_a_name_and_are_numbered(mcap_dir
     await recorder._flush()
     rosys.set_time(rosys.time() + 61)
     recorder.log_message('/test', _json({'value': 1}), timestamp_ns=61 * NS)
-    recorder.log_message('/test', _json({'value': 2}), timestamp_ns=62 * NS)
     await recorder.stop()
 
     assert run is not None and run.endswith('_run0042')
     assert [path.name for path in sorted(mcap_dir.glob('*.mcap'))] == [f'{run}_01.mcap', f'{run}_02.mcap']
+
+
+async def test_a_rotation_leaves_no_part_without_messages(mcap_dir: Path) -> None:
+    """A part is opened only for a message to write into it, so no part of a run ends up empty."""
+    recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start()
+
+    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    await recorder._flush()
+    rosys.set_time(rosys.time() + 61)
+    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=61 * NS)
+    await recorder._flush()
+    rosys.set_time(rosys.time() + 61)
+    await recorder.stop()
+
+    assert [_values(path) for path in sorted(mcap_dir.glob('*.mcap'))] == [[0], [1]]
+
+
+async def test_a_start_while_the_previous_recording_is_finalized_is_refused(mcap_dir: Path) -> None:
+    """The finished recording stays intact and no second one begins behind its back."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    draining = threading.Event()
+    release = threading.Event()
+
+    def slow_encode(value: int, _timestamp_ns: int) -> bytes:
+        draining.set()
+        release.wait(timeout=5)
+        return _json({'value': value})
+
+    recorder.start(name='first')
+    for i in range(3):
+        recorder.log_message('/test', i, encode=slow_encode, timestamp_ns=i * NS)
+    stopping = asyncio.create_task(recorder.stop())
+    while not draining.is_set():
+        await asyncio.sleep(0.01)
+
+    run = recorder.start(name='second')
+    release.set()
+    await stopping
+
+    assert run is None
+    assert not recorder.is_recording
+    assert [(path.name.endswith('_first_01.mcap'), _values(path)) for path in recorder.recordings] == \
+        [(True, [0, 1, 2])]
 
 
 async def test_every_file_of_a_recording_carries_the_metadata(mcap_dir: Path) -> None:

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -688,45 +688,6 @@ async def test_duration_based_rotation(mcap_dir: Path) -> None:
     assert sum(_message_count(path) for path in files) == 3
 
 
-async def test_split_finalizes_current_file_and_keeps_recording(mcap_dir: Path) -> None:
-    """split() files away everything recorded so far and the recording continues seamlessly."""
-    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
-    recorder.add_topic('/test', _schema())
-    recorder.start()
-    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
-    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=NS)
-
-    finalized = await recorder.split()
-
-    assert finalized is not None
-    assert _values(finalized) == [0, 1]
-    assert recorder.is_recording
-    assert recorder.current_recording is not None
-    assert recorder.current_recording != finalized
-
-    recorder.log_message('/test', _json({'value': 2}), timestamp_ns=2 * NS)
-    await recorder.stop()
-    second = next(path for path in mcap_dir.glob('*.mcap') if path != finalized)
-    assert _values(second) == [2]
-
-
-async def test_split_without_messages_keeps_the_growing_file(mcap_dir: Path) -> None:
-    """split() refuses to churn an empty file into an empty recording."""
-    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
-    recorder.add_topic('/test', _schema())
-    recorder.start()
-    live = recorder.current_recording
-
-    assert await recorder.split() is None
-    assert recorder.is_recording
-    assert recorder.current_recording == live
-
-
-async def test_split_while_stopped_returns_none(mcap_dir: Path) -> None:
-    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
-    assert await recorder.split() is None
-
-
 @pytest.mark.parametrize('kept_name', ['weeding on the north field.mcap',  # renamed by hand
                                        '20200101_000000_run0001.mcap',  # the merged file of a run
                                        '20200101_000000_run0001_failure.mcap'])  # preserved around a failure

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -7,7 +7,7 @@ import pytest
 from mcap.reader import make_reader
 
 import rosys
-from rosys.analysis.recording import McapRecorder, TopicSchema, is_auto_named
+from rosys.analysis.recording import MERGE_METADATA_NAME, McapRecorder, TopicSchema, is_auto_named, merge_recordings
 
 NS = 1_000_000_000
 
@@ -801,3 +801,42 @@ async def test_a_named_recording_stays_within_the_disk_budget(mcap_dir: Path) ->
     await recorder.stop()
 
     assert all(is_auto_named(path) for path in mcap_dir.glob('*.mcap'))
+
+
+async def test_a_merged_recording_keeps_the_context_of_its_sources(mcap_dir: Path) -> None:
+    """Merging must not strip the metadata; the merged file is the one people send around."""
+    recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start(name='run', metadata={'mission': 'Implement Demo', 'run_id': 42})
+    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    await recorder._flush()
+    rosys.set_time(rosys.time() + 61)
+    recorder.log_message('/test', _json({'value': 1}), timestamp_ns=61 * NS)
+    await recorder.stop()
+    sources = sorted(mcap_dir.glob('*.mcap'))
+
+    target = mcap_dir / 'merged.mcap'
+    count = merge_recordings(sources, target)
+
+    assert count == 2
+    assert _values(target) == [0, 1]
+    assert _metadata(target) == {'mission': 'Implement Demo', 'run_id': 42}
+
+
+async def test_a_merged_recording_says_how_it_came_to_be(mcap_dir: Path) -> None:
+    """The merge leaves its own record, so nobody wonders where a file came from."""
+    recorder = McapRecorder(output_dir=mcap_dir, auto_start=False)
+    recorder.add_topic('/test', _schema())
+    recorder.start(name='run')
+    recorder.log_message('/test', _json({'value': 0}), timestamp_ns=0)
+    await recorder.stop()
+    source = next(iter(mcap_dir.glob('*.mcap')))
+
+    target = mcap_dir / 'merged.mcap'
+    merge_recordings([source], target)
+
+    with open(target, 'rb') as f:
+        records = {record.name: json.loads(record.metadata['json'])
+                   for record in make_reader(f).iter_metadata()}
+    assert records[MERGE_METADATA_NAME]['sources'] == [source.name]
+    assert records[MERGE_METADATA_NAME]['trimmed'] is False

--- a/tests/test_mcap_recorder.py
+++ b/tests/test_mcap_recorder.py
@@ -825,7 +825,7 @@ async def test_a_start_while_the_previous_recording_is_finalized_is_refused(mcap
 
 
 async def test_every_file_of_a_recording_carries_the_metadata(mcap_dir: Path) -> None:
-    """A rotated segment is as self-explaining as the first one."""
+    """A rotated part is as self-explaining as the first one."""
     recorder = McapRecorder(output_dir=mcap_dir, max_file_duration=60, auto_start=False)
     recorder.add_topic('/test', _schema())
     recorder.start(name='run', metadata={'mission': 'Implement Demo', 'run_id': 42})

--- a/tests/test_recordings_page.py
+++ b/tests/test_recordings_page.py
@@ -5,8 +5,8 @@ import pytest
 from fastapi import status
 from fastapi.responses import FileResponse, JSONResponse
 
-from rosys.analysis.recording import McapRecorder, TopicSchema
-from rosys.analysis.recording.recordings_page_ import _download_response
+from rosys.analysis.recording import McapRecorder, RecordingInfo, TopicSchema
+from rosys.analysis.recording.recordings_page_ import _download_response, _group_by_run, _replace_sources
 
 # The download endpoint is registered as a closure on the global nicegui ``app`` once per
 # RecordingsPage instance (path-matched first-registration-wins), and exercising it over HTTP
@@ -105,3 +105,60 @@ def test_download_404_for_name_with_nul_byte(recorder: McapRecorder) -> None:
 
     assert isinstance(response, JSONResponse)
     assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def _info(name: str, *, mtime: float = 0.0, size: int = 0) -> RecordingInfo:
+    """A snapshot of a recording, as the page's scan hands it to the grouping.
+
+    :param name: the file name the grouping reads the run key off.
+    :param mtime: the modification time shown in the list.
+    :param size: the file size shown in the list.
+    :return: the snapshot to group.
+    """
+    return RecordingInfo(Path(name), mtime, size, False, True)
+
+
+def test_the_parts_of_a_run_form_one_entry() -> None:
+    """The numbered files of one run are grouped under the name they share."""
+    parts = [_info('20260911_052815_run0002_02.mcap'), _info('20260911_052815_run0002_01.mcap')]
+
+    assert _group_by_run(parts) == [('20260911_052815_run0002', parts)]
+
+
+def test_runs_stay_apart_and_keep_their_order() -> None:
+    """Each run gets its own entry, in the order its newest file appears in the list."""
+    newer = _info('20260911_052815_run0002_01.mcap')
+    older = [_info('20260910_120000_run0001_02.mcap'), _info('20260910_120000_run0001_01.mcap')]
+
+    assert _group_by_run([newer, *older]) == [
+        ('20260911_052815_run0002', [newer]),
+        ('20260910_120000_run0001', older),
+    ]
+
+
+@pytest.mark.parametrize('name', ['failure_20260911_052815_123456.mcap',  # preserved around a failure
+                                  '20260911_052815_123456_01.mcap',  # recorded without a run name
+                                  '20260911_052815_run0002.mcap',  # the merged file of a run
+                                  'weeding on the north field.mcap'])  # renamed by hand
+def test_a_file_without_a_part_number_stays_on_its_own(name: str) -> None:
+    """Anything the recorder did not number apart as a run's part keeps its own entry."""
+    info = _info(name)
+
+    assert _group_by_run([info]) == [(None, [info])]
+
+
+def test_a_merge_only_takes_the_run_name_once_it_is_complete(tmp_path: Path) -> None:
+    """A merge in progress must not look like a recording, and the parts go only after it lands."""
+    unfinished = tmp_path / 'run.mcap.part'
+    unfinished.write_bytes(b'merged')
+    sources = [tmp_path / 'run_01.mcap', tmp_path / 'run_02.mcap']
+    for source in sources:
+        source.write_bytes(b'part')
+
+    assert sorted(path.name for path in tmp_path.glob('*.mcap')) == ['run_01.mcap', 'run_02.mcap']
+
+    _replace_sources(unfinished, tmp_path / 'run.mcap', sources)
+
+    assert (tmp_path / 'run.mcap').read_bytes() == b'merged'
+    assert not unfinished.exists()
+    assert not any(source.exists() for source in sources)

--- a/tests/test_recordings_page.py
+++ b/tests/test_recordings_page.py
@@ -110,7 +110,7 @@ def test_download_404_for_name_with_nul_byte(recorder: McapRecorder) -> None:
 def _info(name: str, *, mtime: float = 0.0, size: int = 0) -> RecordingInfo:
     """A snapshot of a recording, as the page's scan hands it to the grouping.
 
-    :param name: the file name the grouping reads the run key off.
+    :param name: the file name the grouping reads the run off.
     :param mtime: the modification time shown in the list.
     :param size: the file size shown in the list.
     :return: the snapshot to group.

--- a/tests/test_recordings_page.py
+++ b/tests/test_recordings_page.py
@@ -6,7 +6,7 @@ from fastapi import status
 from fastapi.responses import FileResponse, JSONResponse
 
 from rosys.analysis.recording import McapRecorder, RecordingInfo, TopicSchema
-from rosys.analysis.recording.recordings_page_ import _download_response, _group_by_run, _replace_sources
+from rosys.analysis.recording.recordings_page_ import _download_response, _group_by_run
 
 # The download endpoint is registered as a closure on the global nicegui ``app`` once per
 # RecordingsPage instance (path-matched first-registration-wins), and exercising it over HTTP
@@ -125,6 +125,23 @@ def test_the_parts_of_a_run_form_one_entry() -> None:
     assert _group_by_run(parts) == [('20260911_052815_000000_run0002', parts)]
 
 
+def test_a_run_recorded_without_a_name_forms_one_entry_too() -> None:
+    """A run named after its start time alone is grouped like a named one."""
+    parts = [_info('20260911_052815_123456_02.mcap'), _info('20260911_052815_123456_01.mcap')]
+
+    assert _group_by_run(parts) == [('20260911_052815_123456', parts)]
+
+
+def test_the_parts_of_a_run_are_ordered_by_their_number() -> None:
+    """Part 100 follows part 99, however the names sort as text or the files were touched."""
+    names = ['20260911_052815_000000_mission_100.mcap', '20260911_052815_000000_mission_09.mcap',
+             '20260911_052815_000000_mission_11.mcap']
+
+    [(_, parts)] = _group_by_run([_info(name) for name in names])
+
+    assert [part.path.name for part in parts] == [names[0], names[2], names[1]]
+
+
 def test_runs_stay_apart_and_keep_their_order() -> None:
     """Each run gets its own entry, in the order its newest file appears in the list."""
     newer = _info('20260911_052815_000000_run0002_01.mcap')
@@ -137,28 +154,11 @@ def test_runs_stay_apart_and_keep_their_order() -> None:
 
 
 @pytest.mark.parametrize('name', ['20260911_052815_000000_run0002_failure.mcap',  # preserved around a failure
-                                  '20260911_052815_123456_01.mcap',  # recorded without a run name
                                   '20260911_052815_000000_run0002_merged.mcap',  # the merged file of a run
+                                  '20260911_052815_123456.mcap',  # a single unnumbered file
                                   'weeding on the north field.mcap'])  # renamed by hand
 def test_a_file_without_a_part_number_stays_on_its_own(name: str) -> None:
     """Anything the recorder did not number apart as a run's part keeps its own entry."""
     info = _info(name)
 
     assert _group_by_run([info]) == [(None, [info])]
-
-
-def test_a_merge_only_takes_the_run_name_once_it_is_complete(tmp_path: Path) -> None:
-    """A merge in progress must not look like a recording, and the parts go only after it lands."""
-    unfinished = tmp_path / 'run.mcap.part'
-    unfinished.write_bytes(b'merged')
-    sources = [tmp_path / 'run_01.mcap', tmp_path / 'run_02.mcap']
-    for source in sources:
-        source.write_bytes(b'part')
-
-    assert sorted(path.name for path in tmp_path.glob('*.mcap')) == ['run_01.mcap', 'run_02.mcap']
-
-    _replace_sources(unfinished, tmp_path / 'run.mcap', sources)
-
-    assert (tmp_path / 'run.mcap').read_bytes() == b'merged'
-    assert not unfinished.exists()
-    assert not any(source.exists() for source in sources)

--- a/tests/test_recordings_page.py
+++ b/tests/test_recordings_page.py
@@ -120,25 +120,25 @@ def _info(name: str, *, mtime: float = 0.0, size: int = 0) -> RecordingInfo:
 
 def test_the_parts_of_a_run_form_one_entry() -> None:
     """The numbered files of one run are grouped under the name they share."""
-    parts = [_info('20260911_052815_run0002_02.mcap'), _info('20260911_052815_run0002_01.mcap')]
+    parts = [_info('20260911_052815_000000_run0002_02.mcap'), _info('20260911_052815_000000_run0002_01.mcap')]
 
-    assert _group_by_run(parts) == [('20260911_052815_run0002', parts)]
+    assert _group_by_run(parts) == [('20260911_052815_000000_run0002', parts)]
 
 
 def test_runs_stay_apart_and_keep_their_order() -> None:
     """Each run gets its own entry, in the order its newest file appears in the list."""
-    newer = _info('20260911_052815_run0002_01.mcap')
-    older = [_info('20260910_120000_run0001_02.mcap'), _info('20260910_120000_run0001_01.mcap')]
+    newer = _info('20260911_052815_000000_run0002_01.mcap')
+    older = [_info('20260910_120000_000000_run0001_02.mcap'), _info('20260910_120000_000000_run0001_01.mcap')]
 
     assert _group_by_run([newer, *older]) == [
-        ('20260911_052815_run0002', [newer]),
-        ('20260910_120000_run0001', older),
+        ('20260911_052815_000000_run0002', [newer]),
+        ('20260910_120000_000000_run0001', older),
     ]
 
 
-@pytest.mark.parametrize('name', ['20260911_052815_run0002_failure.mcap',  # preserved around a failure
+@pytest.mark.parametrize('name', ['20260911_052815_000000_run0002_failure.mcap',  # preserved around a failure
                                   '20260911_052815_123456_01.mcap',  # recorded without a run name
-                                  '20260911_052815_run0002.mcap',  # the merged file of a run
+                                  '20260911_052815_000000_run0002_merged.mcap',  # the merged file of a run
                                   'weeding on the north field.mcap'])  # renamed by hand
 def test_a_file_without_a_part_number_stays_on_its_own(name: str) -> None:
     """Anything the recorder did not number apart as a run's part keeps its own entry."""

--- a/tests/test_recordings_page.py
+++ b/tests/test_recordings_page.py
@@ -136,7 +136,7 @@ def test_runs_stay_apart_and_keep_their_order() -> None:
     ]
 
 
-@pytest.mark.parametrize('name', ['failure_20260911_052815_123456.mcap',  # preserved around a failure
+@pytest.mark.parametrize('name', ['20260911_052815_run0002_failure.mcap',  # preserved around a failure
                                   '20260911_052815_123456_01.mcap',  # recorded without a run name
                                   '20260911_052815_run0002.mcap',  # the merged file of a run
                                   'weeding on the north field.mcap'])  # renamed by hand


### PR DESCRIPTION
### Motivation

A recording that runs for hours was only half usable: it rotated into files whose
only connection was the clock, nothing in a file said what it was recorded during,
and the log lived somewhere else entirely. This makes a long recording something
you can still read a day later.

### Implementation

- Rotate by duration as well as size, cutting inside the writer so no message falls into the gap
- `start(name=..., metadata=...)`: the files of one recording share a name and number themselves as they rotate, and every one of them carries the caller's context as a JSON metadata record
- Distinguish what the recorder wrote itself from what exists deliberately: the disk budget rolls away its own numbered files first and keeps everything else
- `merge_recordings` joins recordings into one and carries their metadata over, adding a record describing the merge
- The recordings page groups the files of one run into a single entry and can merge a run in the background
- Record the log on a `/log` topic in the `foxglove.Log` schema, so the Logs panel shows the lines next to the data

<details>
<summary>Details</summary>

- `split()` is gone again: it was written for filing a recording away without interrupting it, and no caller ever wanted that.
- The merge writes beside the recordings under a name the listing ignores and only takes the target name once complete, so a merge in progress never appears as a half-written recording, and the sources are deleted only after the finished file is in place.
- The log handler drops records from the recorder's own logger. The recorder logs its "queue full" warning while holding the queue lock, so recording that line would re-enter the writer on the same thread and deadlock — under exactly the load where it matters.
- Measured on a Jetson in a downstream application: 500 MB rotation every eleven minutes at ~47 MB/min, a segment boundary indistinguishable from a normal sample interval, no dropped messages over a quarter of an hour, and a 540 MB merge in 39 s.

</details>

[※](https://zauberzeug.github.io/colophon/#m=claude-opus-5&t=Research%2C%20implementation%20and%20tests%20by%20the%20agent%3B%20scope%20and%20design%20decisions%20by%20the%20author.&p=agent&a=claude-code "claude-opus-5: Research, implementation and tests by the agent; scope and design decisions by the author.")
