### PR TITLE
Share one SSL context, add request timeouts and guard udev scans in the vision helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ detector/
 site/
 .nicegui/
 test.py
+
+.mypy_cache

--- a/rosys/vision/arkvision_rest_client.py
+++ b/rosys/vision/arkvision_rest_client.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import httpx
 
+from .http import new_async_client
+
 # The achievable frame rates depend on the sensor mode, which fixes a "base" frame rate.
 # (frequency, mode) -> base fps.  frequency: 0 = 50 Hz, 1 = 60 Hz.  See /imageSensorMode in the REST spec.
 SENSOR_MODE_BASE_FPS: dict[tuple[int, int], int] = {
@@ -39,7 +41,7 @@ class ArkVisionRestClient:
 
     async def _get(self, endpoint: str) -> dict[str, Any] | None:
         try:
-            async with httpx.AsyncClient() as client:
+            async with new_async_client() as client:
                 response = await client.get(f'{self.base_url}/{endpoint}', timeout=5)
             response.raise_for_status()
             return response.json()
@@ -49,7 +51,7 @@ class ArkVisionRestClient:
 
     async def _post(self, endpoint: str, data: dict[str, Any]) -> None:
         try:
-            async with httpx.AsyncClient() as client:
+            async with new_async_client() as client:
                 response = await client.post(f'{self.base_url}/{endpoint}', json=data, timeout=5)
             response.raise_for_status()
         except httpx.HTTPError as e:

--- a/rosys/vision/http.py
+++ b/rosys/vision/http.py
@@ -1,0 +1,21 @@
+import functools
+import ssl
+
+import httpx
+
+DEFAULT_TIMEOUT = 5.0
+"""Seconds without data before a camera connection counts as lost."""
+
+
+@functools.cache
+def _ssl_context() -> ssl.SSLContext:
+    """Build the SSL context once: constructing one costs tens of milliseconds of event loop time."""
+    return httpx.create_ssl_context()
+
+
+def new_async_client(*, timeout: float | None = DEFAULT_TIMEOUT, **kwargs) -> httpx.AsyncClient:
+    """Create an `httpx.AsyncClient` with a shared SSL context and an explicit timeout.
+
+    The timeout is explicit because a silent stream must end the request rather than wait forever.
+    """
+    return httpx.AsyncClient(verify=_ssl_context(), timeout=timeout, **kwargs)

--- a/rosys/vision/http.py
+++ b/rosys/vision/http.py
@@ -18,4 +18,5 @@ def new_async_client(*, timeout: float | None = DEFAULT_TIMEOUT, **kwargs) -> ht
 
     The timeout is explicit because a silent stream must end the request rather than wait forever.
     """
-    return httpx.AsyncClient(verify=_ssl_context(), timeout=timeout, **kwargs)
+def new_async_client(*, timeout: float | None = DEFAULT_TIMEOUT, **kwargs) -> httpx.AsyncClient:
+    """Create an `httpx.AsyncClient` with a shared SSL context and an explicit timeout. """

--- a/rosys/vision/http.py
+++ b/rosys/vision/http.py
@@ -18,5 +18,4 @@ def new_async_client(*, timeout: float | None = DEFAULT_TIMEOUT, **kwargs) -> ht
 
     The timeout is explicit because a silent stream must end the request rather than wait forever.
     """
-def new_async_client(*, timeout: float | None = DEFAULT_TIMEOUT, **kwargs) -> httpx.AsyncClient:
-    """Create an `httpx.AsyncClient` with a shared SSL context and an explicit timeout. """
+    return httpx.AsyncClient(verify=_ssl_context(), timeout=timeout, **kwargs)

--- a/rosys/vision/http.py
+++ b/rosys/vision/http.py
@@ -14,8 +14,5 @@ def _ssl_context() -> ssl.SSLContext:
 
 
 def new_async_client(*, timeout: float | None = DEFAULT_TIMEOUT, **kwargs) -> httpx.AsyncClient:
-    """Create an `httpx.AsyncClient` with a shared SSL context and an explicit timeout.
-
-    The timeout is explicit because a silent stream must end the request rather than wait forever.
-    """
+    """Create an `httpx.AsyncClient` with a shared SSL context and an explicit timeout."""
     return httpx.AsyncClient(verify=_ssl_context(), timeout=timeout, **kwargs)

--- a/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
@@ -4,6 +4,7 @@ import httpx
 
 from ... import rosys
 from ..camera_provider import CameraProvider
+from ..http import new_async_client
 from ..rtsp_camera.arp_scan import find_cameras
 from .mjpeg_camera import MjpegCamera
 from .vendors import VendorType, mac_to_vendor
@@ -54,7 +55,7 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera]):
                     httpx.DigestAuth(self.username, self.password)
                 url = f'http://{ip}/axis-cgi/videostatus.cgi'
                 try:
-                    async with httpx.AsyncClient() as client:
+                    async with new_async_client() as client:
                         response = await client.get(url, auth=authentication)
                 except httpx.HTTPError as e:
                     self.log.warning('Error while looking for cameras at axis router (%s): %s', url, e)

--- a/rosys/vision/openipc_zauberzeug_settings_interface.py
+++ b/rosys/vision/openipc_zauberzeug_settings_interface.py
@@ -19,6 +19,8 @@ from typing import Any
 
 import httpx
 
+from .http import new_async_client
+
 # Bitrate is in kbps on both sides: RoSys models kbps and divinus forwards mp4_bitrate
 # straight to the encoder, whose bitrate fields are kbps. Passed through unchanged.
 
@@ -38,7 +40,7 @@ class OpenIpcZauberzeugSettingsInterface:
 
     async def _request(self, path: str, **params: Any) -> dict[str, Any]:
         params = {key: value for key, value in params.items() if value is not None}
-        async with httpx.AsyncClient(auth=self._auth, timeout=REQUEST_TIMEOUT) as client:
+        async with new_async_client(auth=self._auth, timeout=REQUEST_TIMEOUT) as client:
             response = await client.get(f'{self.base_url}{path}', params=params)
             response.raise_for_status()
             return response.json()

--- a/rosys/vision/rtsp_camera/jovision_rtsp_interface.py
+++ b/rosys/vision/rtsp_camera/jovision_rtsp_interface.py
@@ -3,8 +3,9 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
-import httpx
 from httpx import QueryParams
+
+from ..http import new_async_client
 
 
 @dataclass
@@ -68,7 +69,7 @@ class JovisionInterface:
             cmd=json.dumps(cmd),
             _=int(time.time() * 1000),  # current time as a timestamp
         )
-        async with httpx.AsyncClient() as client:
+        async with new_async_client() as client:
             await client.get(self.settings_url, params=params)
 
     async def set_fps(self, stream_id: int, fps: int) -> None:
@@ -118,7 +119,7 @@ class JovisionInterface:
             cmd=json.dumps(cmd),
             _=int(time.time() * 1000),
         )
-        async with httpx.AsyncClient() as client:
+        async with new_async_client() as client:
             response = await client.get(self.settings_url, params=params)
 
         return [
@@ -152,7 +153,7 @@ class JovisionInterface:
         #     'cmd': json.dumps(cmd),
         #     '_': time.time() * 1000,
         # }
-        # async with httpx.AsyncClient() as client:
+        # async with new_async_client() as client:
         #     response = await client.get(self.settings_url, params=params)
 
         # for stream_id, stream in enumerate(response.json()['result']['all']):

--- a/rosys/vision/usb_camera/usb_camera_scanner.py
+++ b/rosys/vision/usb_camera/usb_camera_scanner.py
@@ -1,4 +1,15 @@
+import functools
+import threading
+
 import pyudev
+
+_udev_lock = threading.Lock()
+
+
+@functools.cache
+def _udev_context() -> pyudev.Context:
+    """Reuse a single context, because creating one costs several milliseconds."""
+    return pyudev.Context()
 
 
 def uid_from_device(device: pyudev.Device) -> str | None:
@@ -10,13 +21,21 @@ def uid_from_device(device: pyudev.Device) -> str | None:
     return '-'.join(parts) if all(parts) else device.get('DEVNAME') or None
 
 
+def _scan() -> list[tuple[str | None, str | None]]:
+    """List ``(uid, device node)`` of all video devices.
+
+    libudev keeps a non-atomic reference count on its context, so concurrent scans must not share it
+    unguarded. `pyudev.Device` objects hold a reference to that context and drop it when they are
+    garbage-collected, so none of them may leave the lock; only plain strings do.
+    """
+    with _udev_lock:
+        return [(uid_from_device(device), device.device_node)
+                for device in _udev_context().list_devices(subsystem='video4linux')]
+
+
 def scan_for_connected_devices() -> set[str]:
-    devices = pyudev.Context().list_devices()
-    video_device_ids = {uid_from_device(device) for device in devices if device.subsystem == 'video4linux'}
-    return {uid for uid in video_device_ids if uid is not None}
+    return {uid for uid, _ in _scan() if uid is not None}
 
 
 def device_nodes_from_uid(uid: str) -> set[str]:
-    devices = pyudev.Context().list_devices()
-    matching_devices = [device for device in devices if uid_from_device(device) == uid]
-    return {device.device_node for device in matching_devices if device.device_node is not None}
+    return {node for device_uid, node in _scan() if device_uid == uid and node is not None}

--- a/rosys/vision/usb_camera/usb_camera_scanner.py
+++ b/rosys/vision/usb_camera/usb_camera_scanner.py
@@ -22,12 +22,11 @@ def uid_from_device(device: pyudev.Device) -> str | None:
 
 
 def _scan() -> list[tuple[str | None, str | None]]:
-    """List ``(uid, device node)`` of all video devices.
+    """List ``(uid, device node)`` of all video devices."""
 
-    libudev keeps a non-atomic reference count on its context, so concurrent scans must not share it
-    unguarded. `pyudev.Device` objects hold a reference to that context and drop it when they are
-    garbage-collected, so none of them may leave the lock; only plain strings do.
-    """
+    # libudev keeps a non-atomic reference count on its context, so concurrent scans must not share it
+    # unguarded. `pyudev.Device` objects hold a reference to that context and drop it when they are
+    # garbage-collected, so none of them may leave the lock; only plain strings do.
     with _udev_lock:
         return [(uid_from_device(device), device.device_node)
                 for device in _udev_context().list_devices(subsystem='video4linux')]


### PR DESCRIPTION
> **Stack** (supersedes #423; review bottom-up, each PR is based on the one above it):
> 1. #470 — vision I/O helpers **(this PR)**
> 2. #471 — RTSP and MJPEG reconnection
> 3. #472 — USB and simulated reconnection

### Motivation

Groundwork for device-level camera reconnection (see the stack above).
This PR unifies all HTTP clients to simplify its usage in the later PRs and help share code in the various camera `Device` objects.
In addition to code duplication this caused two minor issues:

- Every `httpx.AsyncClient` built its own SSL context, which costs tens of milliseconds of event loop time per request, and most requests ran without a timeout, so a silent camera could hold a request forever.
- libudev keeps a non-atomic reference count on its context, so two scans sharing it unguarded can corrupt it; creating a fresh context per scan instead costs several milliseconds.

Neither change alters behavior on its own, which is why they are split out of the reconnection PRs.

### Implementation

- New `rosys/vision/http.py` with `new_async_client()`: one cached SSL context (`functools.cache`) and an explicit default timeout of 5 s.
  The Arkvision REST client, the MJPEG camera provider, the OpenIPC settings interface and the Jovision RTSP interface use it instead of constructing `httpx.AsyncClient` directly.
- `usb_camera_scanner.py` reuses a single cached `pyudev.Context` and runs every scan under a `threading.Lock`.
  Only plain `(uid, device node)` strings leave the lock, because `pyudev.Device` objects hold a reference to the context and drop it on garbage collection.
- `.gitignore` learns about `.mypy_cache` (a stale in-tree cache crashed mypy on this branch).

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5-1
