### PR TITLE
Reconnect RTSP and MJPEG cameras automatically at the device level

### DIFF
--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -13,6 +13,7 @@ from nicegui import Event
 from ... import rosys
 from ..image import Image
 from ..image_route import create_image_route
+from ..reconnect import MIN_RECONNECT_INTERVAL, clamp_reconnect_interval
 
 logger = logging.getLogger('rosys.vision.camera')
 
@@ -32,11 +33,14 @@ class Camera(abc.ABC):
                  streaming: bool | None = None,
                  polling_interval: float | None = None,
                  base_path_overwrite: str | None = None,
+                 reconnect_interval: float = 3.0,
                  **kwargs) -> None:
         super().__init__(**kwargs)
         self.id: str = id
         self.name = name or self.id
         self.connect_after_init = connect_after_init
+        self._reconnect_interval = MIN_RECONNECT_INTERVAL
+        self.reconnect_interval = reconnect_interval
         self.images: deque[Image] = deque(maxlen=Camera.IMAGE_HISTORY_LENGTH)
         self.base_path: str = f'images/{base_path_overwrite or id}'
 
@@ -53,6 +57,16 @@ class Camera(abc.ABC):
 
         if connect_after_init:
             rosys.on_startup(self.connect)
+        rosys.on_shutdown(self.disconnect)
+
+    @property
+    def reconnect_interval(self) -> float:
+        """Seconds the device waits before reopening a stream that ended."""
+        return self._reconnect_interval
+
+    @reconnect_interval.setter
+    def reconnect_interval(self, interval: float) -> None:
+        self._reconnect_interval = clamp_reconnect_interval(interval, logger)
 
     @property
     def streaming(self) -> bool:
@@ -88,6 +102,7 @@ class Camera(abc.ABC):
             'name': self.name,
             'connect_after_init': self.connect_after_init,
             'base_path_overwrite': base_path_id if base_path_id != self.id else None,
+            'reconnect_interval': self.reconnect_interval,
         }
 
     @classmethod
@@ -100,11 +115,21 @@ class Camera(abc.ABC):
 
     @property
     def is_connected(self) -> bool:
-        """To be interpreted as "ready to capture images"."""
+        """Whether the camera is currently streaming or capturing images."""
         return False
+
+    @property
+    def is_active(self) -> bool:
+        """Whether a connection is wanted, i.e. whether the camera keeps itself connected."""
+        return self.is_connected
+
+    @property
+    def is_reconnecting(self) -> bool:
+        return self.is_active and not self.is_connected
 
     @asynccontextmanager
     async def _device_connection(self) -> AsyncGenerator[None, None]:
+        """Serialize device creation and tear-down."""
         await self.device_connection_lock.acquire()
         try:
             yield
@@ -112,10 +137,14 @@ class Camera(abc.ABC):
             self.device_connection_lock.release()
 
     async def connect(self) -> None:  # noqa: B027
-        pass
+        """Create the self-healing device; it keeps retrying until ``disconnect()`` tears it down.
+
+        A camera without a device of its own, such as one replaying recorded images, needs no
+        implementation, so this is not abstract.
+        """
 
     async def disconnect(self) -> None:  # noqa: B027
-        pass
+        """Tear down the device, which also stops its reconnection attempts."""
 
     async def reconnect(self) -> None:
         await self.disconnect()

--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -137,11 +137,7 @@ class Camera(abc.ABC):
             self.device_connection_lock.release()
 
     async def connect(self) -> None:  # noqa: B027
-        """Create the self-healing device; it keeps retrying until ``disconnect()`` tears it down.
-
-        A camera without a device of its own, such as one replaying recorded images, needs no
-        implementation, so this is not abstract.
-        """
+        """Create the self-healing device; it keeps retrying until ``disconnect()`` tears it down."""
 
     async def disconnect(self) -> None:  # noqa: B027
         """Tear down the device, which also stops its reconnection attempts."""

--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -67,6 +67,10 @@ class Camera(abc.ABC):
     @reconnect_interval.setter
     def reconnect_interval(self, interval: float) -> None:
         self._reconnect_interval = clamp_reconnect_interval(interval, logger)
+        self._apply_reconnect_interval()
+
+    def _apply_reconnect_interval(self) -> None:  # noqa: B027
+        """Forward `reconnect_interval` to a live device."""
 
     @property
     def streaming(self) -> bool:

--- a/rosys/vision/camera_provider.py
+++ b/rosys/vision/camera_provider.py
@@ -83,4 +83,4 @@ class CameraProvider(Generic[T], persistence.Persistable, metaclass=abc.ABCMeta)
 
     @abc.abstractmethod
     async def update_device_list(self) -> None:
-        pass
+        """Add cameras for newly discovered devices and rebind known ones whose access has changed."""

--- a/rosys/vision/capture_device.py
+++ b/rosys/vision/capture_device.py
@@ -1,0 +1,174 @@
+import abc
+import asyncio
+import enum
+import logging
+from typing import ClassVar
+
+from nicegui import background_tasks
+
+from .. import rosys
+from .reconnect import MAX_RECONNECT_INTERVAL, clamp_reconnect_interval
+
+
+class CaptureState(enum.Enum):
+    """State of a self-healing capture loop."""
+    CONNECTING = enum.auto()    # loop alive, opening the stream or waiting to reconnect
+    STREAMING = enum.auto()     # stream open and delivering frames
+    REFUSED = enum.auto()       # camera answered without a stream; loop backs off before trying again
+    STOPPED = enum.auto()       # shutdown requested; loop gives up
+
+
+class CaptureDevice(abc.ABC):
+    """A camera device that keeps its own capture session alive.
+
+    The loop runs one session at a time and waits `reconnect_interval` after a session that ended,
+    until `shutdown()` tears it down. Subclasses supply the session in `_run_session()` and say how
+    the camera is reached; everything about staying alive lives here.
+    """
+
+    REFUSED_RECONNECT_INTERVAL: ClassVar[float] = MAX_RECONNECT_INTERVAL
+    """Wait between attempts while the camera answers something other than a stream.
+
+    It is reachable and has said no, so asking again sooner cannot change the answer, and a rejected
+    login or a rate limit only gets worse for being retried.
+    """
+
+    def __init__(self, *, name: str, log: logging.Logger, reconnect_interval: float = 3.0) -> None:
+        self._name = name
+        self.log = log
+        self.reconnect_interval = reconnect_interval
+        self._state = CaptureState.CONNECTING
+        self._capture_task: asyncio.Task | None = None
+        self._shutting_down = False
+
+    @property
+    def reconnect_interval(self) -> float:
+        return self._reconnect_interval
+
+    @reconnect_interval.setter
+    def reconnect_interval(self, interval: float) -> None:
+        self._reconnect_interval = clamp_reconnect_interval(interval, self.log)
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the camera is delivering frames right now."""
+        return self._state is CaptureState.STREAMING
+
+    @property
+    def is_active(self) -> bool:
+        """Whether the self-healing capture loop is alive (streaming or waiting to reconnect)."""
+        return self._capture_task is not None and not self._capture_task.done()
+
+    @property
+    def is_refused(self) -> bool:
+        """Whether the camera answered the last attempt with something other than a stream."""
+        return self._state is CaptureState.REFUSED
+
+    @abc.abstractmethod
+    async def _run_session(self) -> None:
+        """Run one capture session until it ends."""
+
+    async def _tear_down_session(self) -> None:  # noqa: B027
+        """Release whatever the running session holds, so `shutdown()` leaves nothing behind."""
+
+    def _retry_reason(self) -> str | None:
+        """Why the next attempt is being delayed, when the device knows better than "the stream ended"."""
+        return None
+
+    def _start_capture_task(self) -> None:
+        if self._shutting_down:
+            self.log.warning('[%s] not starting a capture loop while the device is being torn down', self._name)
+            return
+        if self.is_active:
+            self.log.warning('[%s] capture loop already running', self._name)
+            return
+        self._state = CaptureState.CONNECTING
+        self._capture_task = background_tasks.create(self._run_capture_task(), name=f'capture {self._name}')
+
+    def _keeps_running(self) -> bool:
+        """Whether the calling capture task should carry on.
+
+        A cancelled task can resume instead of ending, because the `rosys.run` helpers turn a
+        cancellation into a ``None`` result; after a restart `_capture_task` is a different task.
+        """
+        return self._state is not CaptureState.STOPPED and self._capture_task is asyncio.current_task()
+
+    def _set_state(self, state: CaptureState) -> None:
+        """Record the state of the calling capture task, ignoring a task that has been replaced.
+
+        Several tasks may share this attribute, so a task that no longer owns the loop must not
+        report its own progress, or its end, as the state of the loop that owns it.
+        """
+        if self._capture_task is not asyncio.current_task():
+            return
+        self._state = state
+
+    async def _run_capture_task(self) -> None:
+        try:
+            while self._keeps_running():
+                # every attempt starts fresh: an earlier rejection says nothing about this one
+                self._set_state(CaptureState.CONNECTING)
+                reason = 'stream ended'
+                try:
+                    await self._run_session()
+                except Exception as e:
+                    reason = self._describe_session_error(e)
+                finally:
+                    if self._state is CaptureState.STREAMING:
+                        self._set_state(CaptureState.CONNECTING)
+                if not self._keeps_running():
+                    break
+                delay = self._retry_interval
+                self.log.info('[%s] %s; retrying in %.1f s', self._name, self._retry_reason() or reason, delay)
+                await self._wait_before_retry(delay)
+        finally:
+            if self._capture_task is asyncio.current_task():
+                self._capture_task = None
+
+    def _describe_session_error(self, error: Exception) -> str:
+        """Turn an exception ending a session into a reason, logging a traceback only for a surprise."""
+        self.log.exception('[%s] capture session failed', self._name)
+        return f'capture session failed: {error}'
+
+    @property
+    def _retry_interval(self) -> float:
+        """How long to wait before the next session; a refusal backs off further than a lost stream."""
+        return self.REFUSED_RECONNECT_INTERVAL if self.is_refused else self.reconnect_interval
+
+    async def _wait_before_retry(self, delay: float) -> None:
+        await rosys.sleep(delay)
+
+    def restart_capture(self) -> None:
+        """Give up the running session and start a new one, e.g. after the camera moved."""
+        self._stop_capture_task()
+        self._start_capture_task()
+
+    def _stop_capture_task(self) -> None:
+        self._state = CaptureState.STOPPED
+        if self._capture_task is not None:
+            self._capture_task.cancel()
+            self._capture_task = None
+
+    async def shutdown(self) -> None:
+        """Stop the capture loop and release what the running session holds."""
+        self._state = CaptureState.STOPPED
+        self._shutting_down = True
+        try:
+            await self._tear_down_session()
+            await self._await_capture_task()
+        finally:
+            self._shutting_down = False
+
+    async def _await_capture_task(self) -> None:
+        task = self._capture_task
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=5)
+            except TimeoutError:
+                self.log.warning('[%s] timeout while waiting for capture task to cancel', self._name)
+            except asyncio.CancelledError:
+                if not task.cancelled():
+                    raise  # our own caller was cancelled, not the capture task
+        if self._capture_task is task:  # a restart may have started a new loop while we waited
+            self._capture_task = None

--- a/rosys/vision/capture_device.py
+++ b/rosys/vision/capture_device.py
@@ -71,8 +71,8 @@ class CaptureDevice(abc.ABC):
     async def _tear_down_session(self) -> None:  # noqa: B027
         """Release whatever the running session holds, so `shutdown()` leaves nothing behind."""
 
-    def _retry_reason(self) -> str | None:
-        """Why the next attempt is being delayed, when the device knows better than "the stream ended"."""
+    def _retry_reason(self) -> tuple[int, str] | None:
+        """Log level and reason for delaying the next attempt, when the device knows better than "the stream ended"."""
         return None
 
     def _start_capture_task(self) -> None:
@@ -119,7 +119,8 @@ class CaptureDevice(abc.ABC):
                 if not self._keeps_running():
                     break
                 delay = self._retry_interval
-                self.log.info('[%s] %s; retrying in %.1f s', self._name, self._retry_reason() or reason, delay)
+                level, reason = self._retry_reason() or (logging.INFO, reason)
+                self.log.log(level, '[%s] %s; retrying in %.1f s', self._name, reason, delay)
                 await rosys.sleep(delay)
         finally:
             if self._capture_task is asyncio.current_task():

--- a/rosys/vision/capture_device.py
+++ b/rosys/vision/capture_device.py
@@ -120,7 +120,7 @@ class CaptureDevice(abc.ABC):
                     break
                 delay = self._retry_interval
                 self.log.info('[%s] %s; retrying in %.1f s', self._name, self._retry_reason() or reason, delay)
-                await self._wait_before_retry(delay)
+                await rosys.sleep(delay)
         finally:
             if self._capture_task is asyncio.current_task():
                 self._capture_task = None
@@ -134,9 +134,6 @@ class CaptureDevice(abc.ABC):
     def _retry_interval(self) -> float:
         """How long to wait before the next session; a refusal backs off further than a lost stream."""
         return self.REFUSED_RECONNECT_INTERVAL if self.is_refused else self.reconnect_interval
-
-    async def _wait_before_retry(self, delay: float) -> None:
-        await rosys.sleep(delay)
 
     def restart_capture(self) -> None:
         """Give up the running session and start a new one, e.g. after the camera moved."""

--- a/rosys/vision/capture_device.py
+++ b/rosys/vision/capture_device.py
@@ -12,26 +12,17 @@ from .reconnect import MAX_RECONNECT_INTERVAL, clamp_reconnect_interval
 
 class CaptureState(enum.Enum):
     """State of a self-healing capture loop."""
-    CONNECTING = enum.auto()    # loop alive, opening the stream or waiting to reconnect
-    STREAMING = enum.auto()     # stream open and delivering frames
-    REFUSED = enum.auto()       # camera answered without a stream; loop backs off before trying again
-    STOPPED = enum.auto()       # shutdown requested; loop gives up
+    CONNECTING = enum.auto()  # includes waiting to reconnect
+    STREAMING = enum.auto()
+    REFUSED = enum.auto()  # camera answered without a stream; loop backs off before trying again
+    STOPPED = enum.auto()
 
 
 class CaptureDevice(abc.ABC):
-    """A camera device that keeps its own capture session alive.
-
-    The loop runs one session at a time and waits `reconnect_interval` after a session that ended,
-    until `shutdown()` tears it down. Subclasses supply the session in `_run_session()` and say how
-    the camera is reached; everything about staying alive lives here.
-    """
+    """A camera device that keeps its own capture session alive."""
 
     REFUSED_RECONNECT_INTERVAL: ClassVar[float] = MAX_RECONNECT_INTERVAL
-    """Wait between attempts while the camera answers something other than a stream.
-
-    It is reachable and has said no, so asking again sooner cannot change the answer, and a rejected
-    login or a rate limit only gets worse for being retried.
-    """
+    """Wait between attempts while the camera answers something other than a stream."""
 
     def __init__(self, *, name: str, log: logging.Logger, reconnect_interval: float = 3.0) -> None:
         self._name = name
@@ -72,7 +63,7 @@ class CaptureDevice(abc.ABC):
         """Release whatever the running session holds, so `shutdown()` leaves nothing behind."""
 
     def _retry_reason(self) -> tuple[int, str] | None:
-        """Log level and reason for delaying the next attempt, when the device knows better than "the stream ended"."""
+        """Log level and reason for delaying the next attempt, if the device knows one."""
         return None
 
     def _start_capture_task(self) -> None:
@@ -86,19 +77,12 @@ class CaptureDevice(abc.ABC):
         self._capture_task = background_tasks.create(self._run_capture_task(), name=f'capture {self._name}')
 
     def _keeps_running(self) -> bool:
-        """Whether the calling capture task should carry on.
-
-        A cancelled task can resume instead of ending, because the `rosys.run` helpers turn a
-        cancellation into a ``None`` result; after a restart `_capture_task` is a different task.
-        """
+        """Whether the calling capture task should carry on."""
+        # a cancelled task can resume: the rosys.run helpers turn a cancellation into a None result
         return self._state is not CaptureState.STOPPED and self._capture_task is asyncio.current_task()
 
     def _set_state(self, state: CaptureState) -> None:
-        """Record the state of the calling capture task, ignoring a task that has been replaced.
-
-        Several tasks may share this attribute, so a task that no longer owns the loop must not
-        report its own progress, or its end, as the state of the loop that owns it.
-        """
+        """Record the state of the calling capture task, ignoring a task that has been replaced."""
         if self._capture_task is not asyncio.current_task():
             return
         self._state = state
@@ -133,7 +117,6 @@ class CaptureDevice(abc.ABC):
 
     @property
     def _retry_interval(self) -> float:
-        """How long to wait before the next session; a refusal backs off further than a lost stream."""
         return self.REFUSED_RECONNECT_INTERVAL if self.is_refused else self.reconnect_interval
 
     def restart_capture(self) -> None:

--- a/rosys/vision/capture_device.py
+++ b/rosys/vision/capture_device.py
@@ -25,6 +25,9 @@ class CaptureDevice(abc.ABC):
     REFUSED_RECONNECT_INTERVAL: ClassVar[float] = MAX_RECONNECT_INTERVAL
     """Wait between attempts while the camera answers something other than a stream."""
 
+    CANCEL_TIMEOUT: ClassVar[float] = 5.0
+    """Seconds `shutdown()` waits for the capture task to end."""
+
     def __init__(self, *, name: str, log: logging.Logger,
                  on_connect: Callable[[], Awaitable | None] | None = None,
                  reconnect_interval: float = 3.0) -> None:
@@ -161,9 +164,11 @@ class CaptureDevice(abc.ABC):
         if task is not None and not task.done():
             task.cancel()
             try:
-                await asyncio.wait_for(asyncio.shield(task), timeout=5)
+                await asyncio.wait_for(asyncio.shield(task), timeout=self.CANCEL_TIMEOUT)
             except TimeoutError:
-                self.log.warning('[%s] timeout while waiting for capture task to cancel', self._name)
+                self.log.error('[%s] capture task did not end within %.1f s; it stays active',
+                               self._name, self.CANCEL_TIMEOUT)
+                return
             except asyncio.CancelledError:
                 if not task.cancelled():
                     raise  # our own caller was cancelled, not the capture task

--- a/rosys/vision/capture_device.py
+++ b/rosys/vision/capture_device.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 import enum
 import logging
+from collections.abc import Awaitable, Callable
 from typing import ClassVar
 
 from nicegui import background_tasks
@@ -24,9 +25,12 @@ class CaptureDevice(abc.ABC):
     REFUSED_RECONNECT_INTERVAL: ClassVar[float] = MAX_RECONNECT_INTERVAL
     """Wait between attempts while the camera answers something other than a stream."""
 
-    def __init__(self, *, name: str, log: logging.Logger, reconnect_interval: float = 3.0) -> None:
+    def __init__(self, *, name: str, log: logging.Logger,
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
         self._name = name
         self.log = log
+        self._on_connect = on_connect
         self.reconnect_interval = reconnect_interval
         self._state = CaptureState.CONNECTING
         self._capture_task: asyncio.Task | None = None
@@ -65,6 +69,21 @@ class CaptureDevice(abc.ABC):
     def _retry_reason(self) -> tuple[int, str] | None:
         """Log level and reason for delaying the next attempt, if the device knows one."""
         return None
+
+    async def _enter_streaming(self) -> None:
+        """Enter STREAMING and notify the owner."""
+        self._set_state(CaptureState.STREAMING)
+        await self._invoke_on_connect()
+
+    async def _invoke_on_connect(self) -> None:
+        if self._on_connect is None:
+            return
+        try:
+            result = self._on_connect()
+            if isinstance(result, Awaitable):
+                await result
+        except Exception as e:
+            self.log.warning('[%s] on_connect callback failed: %s', self._name, e)
 
     def _start_capture_task(self) -> None:
         if self._shutting_down:

--- a/rosys/vision/capture_device.py
+++ b/rosys/vision/capture_device.py
@@ -73,9 +73,6 @@ class CaptureDevice(abc.ABC):
     async def _enter_streaming(self) -> None:
         """Enter STREAMING and notify the owner."""
         self._set_state(CaptureState.STREAMING)
-        await self._invoke_on_connect()
-
-    async def _invoke_on_connect(self) -> None:
         if self._on_connect is None:
             return
         try:

--- a/rosys/vision/mjpeg_camera/arkvision_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/arkvision_mjpeg_device.py
@@ -1,25 +1,33 @@
 from collections.abc import Awaitable, Callable
 
 from .arkvision_settings_interface import ArkVisionSettingsInterface
-from .mjpeg_device import MjpegDevice
+from .mjpeg_device import CameraAddressUnknown, MjpegDevice
 from .vendors import VendorType, mac_to_vendor
 
 
 class ArkVisionMjpegDevice(MjpegDevice):
     """MJPEG device for Ark Vision ArkCam Basic+ cameras. Includes auto-enable and configuration through the REST API."""
 
-    def __init__(self, mac: str, ip: str, *,
+    def __init__(self, mac: str, ip: str | None = None, *,
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
+                 on_new_image_data: Callable[[bytes, float], Awaitable | None],
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.ARKVISION:
             raise ValueError(
                 f'ArkVisionMjpegDevice can only be used with ARKVISION devices. Got {vendor} for mac="{mac}"')
-        self.settings_interface = ArkVisionSettingsInterface(ip)
         super().__init__(mac, ip, index=index, username=username, password=password,
-                         on_new_image_data=on_new_image_data)
+                         on_new_image_data=on_new_image_data, on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
+
+    @property
+    def settings_interface(self) -> ArkVisionSettingsInterface:
+        if self.ip is None:
+            raise CameraAddressUnknown(f'cannot reach the settings of {self._mac} without an address')
+        return ArkVisionSettingsInterface(self.ip)
 
     async def _prepare_stream(self) -> None:
         await self.settings_interface.enable_http_mjpeg()

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -1,6 +1,7 @@
-import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+
+import httpx
 
 from .mjpeg_device import MjpegDevice
 from .vendors import VendorType, mac_to_vendor
@@ -22,46 +23,54 @@ class AxisSettings:
 
 
 class AxisMjpegDevice(MjpegDevice):
-    def __init__(self, mac: str, ip: str, *,
+    """MJPEG device for AXIS cameras, which take fps, resolution and mirroring as stream URL parameters.
+
+    A changed setting only changes the URL, so it takes effect when the stream is next opened.
+    """
+
+    def __init__(self, mac: str, ip: str | None = None, *,
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
-        super().__init__(mac, ip, index=index, username=username, password=password, on_new_image_data=on_new_image_data)
-
-        self.axis_settings = AxisSettings(fps=6, resolution=(640, 480), mirrored=False)
-
+                 on_new_image_data: Callable[[bytes, float], Awaitable | None],
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.AXIS:
             raise ValueError(f'AxisMjpegDevice can only be used with AXIS devices. Got {vendor} for mac="{mac}"')
+
+        self.axis_settings = AxisSettings(fps=6, resolution=(640, 480), mirrored=False)
+
+        super().__init__(mac, ip, index=index, username=username, password=password,
+                         on_new_image_data=on_new_image_data, on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
+
+    @property
+    def url(self) -> str | None:
+        url = super().url
+        if url is None:
+            return None
+        width, height = self.axis_settings.resolution
+        return str(httpx.URL(url).copy_merge_params({
+            'fps': self.axis_settings.fps,
+            'resolution': f'{width}x{height}',
+            'mirror': 1 if self.axis_settings.mirrored else 0,
+        }))
 
     async def get_fps(self) -> int:
         return self.axis_settings.fps
 
     async def set_fps(self, fps: int) -> None:
         self.axis_settings.fps = fps
-        self._url = re.sub(r'fps=\d+', f'fps={fps}', self._url)
-        if 'fps=' not in self._url:
-            self._url += f'&fps={fps}'
-        self.restart_capture()
 
     async def get_resolution(self) -> tuple[int, int]:
         return self.axis_settings.resolution
 
     async def set_resolution(self, width: int, height: int) -> None:
         self.axis_settings.resolution = (width, height)
-        self._url = re.sub(r'resolution=\d+x\d+', f'resolution={width}x{height}', self._url)
-        if 'resolution=' not in self._url:
-            self._url += f'&resolution={width}x{height}'
-        self.restart_capture()
 
     async def get_mirrored(self) -> bool:
         return self.axis_settings.mirrored
 
     async def set_mirrored(self, mirrored: bool) -> None:
         self.axis_settings.mirrored = mirrored
-        value = 1 if mirrored else 0
-        self._url = re.sub(r'mirror=\d', f'mirror={value}', self._url)
-        if 'mirror=' not in self._url:
-            self._url += f'&mirror={value}'
-        self.restart_capture()

--- a/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/axis_mjpeg_device.py
@@ -23,10 +23,7 @@ class AxisSettings:
 
 
 class AxisMjpegDevice(MjpegDevice):
-    """MJPEG device for AXIS cameras, which take fps, resolution and mirroring as stream URL parameters.
-
-    A changed setting only changes the URL, so it takes effect when the stream is next opened.
-    """
+    """MJPEG device for AXIS cameras, which take fps, resolution and mirroring as stream URL parameters."""
 
     def __init__(self, mac: str, ip: str | None = None, *,
                  index: int | None = None,

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -32,15 +32,11 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         self.username = username
         self.password = password
 
-        self.ip = ip
-
-        self.index: int | None = None
         parts = self.id.split('-')
-        if len(parts) == 2 and parts[1].isdigit():
-            self.index = int(parts[1])
-
+        self.index: int | None = int(parts[1]) if len(parts) == 2 and parts[1].isdigit() else None
         self.mac = parts[0]
         self.device: MjpegDevice | None = None
+        self._ip: str | None = ip
 
         self._register_parameter('fps', self._get_fps, self._set_fps, default_value=fps)
         self._register_parameter('resolution', self._get_resolution, self._set_resolution, default_value=resolution)
@@ -59,28 +55,42 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
     def is_connected(self) -> bool:
         return (self.device is not None) and self.device.is_connected
 
+    @property
+    def is_active(self) -> bool:
+        return (self.device is not None) and self.device.is_active
+
+    @property
+    def ip(self) -> str | None:
+        """The address of the camera; a running device rebinds to a new one without being torn down."""
+        return self._ip
+
+    @ip.setter
+    def ip(self, ip: str | None) -> None:
+        self._ip = ip
+        if self.device is not None:
+            self.device.ip = ip
+
     async def connect(self) -> None:
-        if self.is_connected:
-            return
-
-        if not self.ip:
-            self.log.error('No IP address provided')
-            return
-
-        try:
+        async with self._device_connection():
+            if self.device is not None:
+                if self.device.is_active:
+                    return
+                await self._tear_down_device()
             self.device = MjpegDeviceFactory.create(self.mac, self.ip, index=self.index, username=self.username,
-                                                    password=self.password, on_new_image_data=self._handle_new_image_data)
-        except ValueError as error:
-            self.log.error('Could not connect to device: %s', error)
-            return
-
-        await self._apply_all_parameters()
+                                                    password=self.password,
+                                                    on_new_image_data=self._handle_new_image_data,
+                                                    on_connect=self._apply_all_parameters,
+                                                    reconnect_interval=self.reconnect_interval)
 
     async def disconnect(self) -> None:
+        async with self._device_connection():
+            await self._tear_down_device()
+
+    async def _tear_down_device(self) -> None:
+        """Tear down the device. The caller must hold `device_connection_lock`."""
         if self.device is None:
             return
-
-        self.device.shutdown()
+        await self.device.shutdown()
         self.device = None
 
     async def _handle_new_image_data(self, image_bytes: bytes, timestamp: float) -> None:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -26,6 +26,7 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
                  mirrored: bool = False,
                  **kwargs: Any,
                  ) -> None:
+        self.device: MjpegDevice | None = None
         super().__init__(id=id, name=name, connect_after_init=connect_after_init,
                          base_path_overwrite=base_path_overwrite, **kwargs)
         self.log = logging.getLogger(f'rosys.vision.mjpeg_camera.{self.id}')
@@ -35,7 +36,6 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         parts = self.id.split('-')
         self.index: int | None = int(parts[1]) if len(parts) == 2 and parts[1].isdigit() else None
         self.mac = parts[0]
-        self.device: MjpegDevice | None = None
         self._ip: str | None = ip
 
         self._register_parameter('fps', self._get_fps, self._set_fps, default_value=fps)
@@ -69,6 +69,10 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         self._ip = ip
         if self.device is not None:
             self.device.ip = ip
+
+    def _apply_reconnect_interval(self) -> None:
+        if self.device is not None:
+            self.device.reconnect_interval = self.reconnect_interval
 
     async def connect(self) -> None:
         async with self._device_connection():

--- a/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
@@ -38,8 +38,7 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera]):
     def restore_from_dict(self, data: dict[str, dict]) -> None:
         for camera_data in data.get('cameras', {}).values():
             self.log.debug('restoring camera: %s', camera_data)
-            camera = MjpegCamera.from_dict(camera_data)
-            self.add_camera(camera)
+            self.add_camera(MjpegCamera.from_dict(camera_data))
 
     async def scan_for_cameras(self) -> list[tuple[str, str]]:
         self.log.debug('scanning for cameras...')
@@ -79,15 +78,13 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera]):
 
     async def update_device_list(self) -> None:
         for camera_id, ip in await self.scan_for_cameras():
-            if camera_id not in self._cameras:
+            camera = self._cameras.get(camera_id)
+            if camera is None:
                 self.log.info('found new camera "%s" at ip "%s"', camera_id, ip)
                 self.add_camera(MjpegCamera(id=camera_id, username=self.username,
-                                password=self.password, ip=ip))
-            camera = self._cameras[camera_id]
-            if not camera.is_connected:
-                self.log.info('activating camera "%s" at ip "%s" ...', camera.id, ip)
+                                            password=self.password, ip=ip))
+            else:
                 camera.ip = ip
-                await camera.connect()
 
     async def shutdown(self) -> None:
         for camera in self._cameras.values():

--- a/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera_provider.py
@@ -31,7 +31,6 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera]):
         self.network_interface = network_interface
 
         self.log = logging.getLogger('rosys.mjpeg_camera_provider')
-        rosys.on_shutdown(self.shutdown)
         if auto_scan:
             rosys.on_repeat(self.update_device_list, self.SCAN_INTERVAL)
 
@@ -85,7 +84,3 @@ class MjpegCameraProvider(CameraProvider[MjpegCamera]):
                                             password=self.password, ip=ip))
             else:
                 camera.ip = ip
-
-    async def shutdown(self) -> None:
-        for camera in self._cameras.values():
-            await camera.disconnect()

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -1,17 +1,20 @@
-import asyncio
 import logging
-from asyncio import Task
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 
 import httpx
 
 from ... import rosys
-from ...rosys import on_startup
+from ..capture_device import CaptureDevice, CaptureState
+from ..http import new_async_client
 from ..image_processing import remove_exif
 from .vendors import mac_to_url
 
 log = logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device')
+
+
+class CameraAddressUnknown(Exception):
+    """Raised when the camera settings are used before discovery has found an address."""
 
 
 def parse_capture_timestamp(part_header: bytes) -> float | None:
@@ -34,42 +37,71 @@ def parse_capture_timestamp(part_header: bytes) -> float | None:
         return None
 
 
-class MjpegDevice:
+class MjpegDevice(CaptureDevice):
 
-    def __init__(self, mac: str, ip: str, *,
+    def __init__(self, mac: str, ip: str | None = None, *,
                  index: int | None = None,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
+                 on_new_image_data: Callable[[bytes, float], Awaitable | None],
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
+        super().__init__(name=mac,
+                         log=logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device.' + mac),
+                         reconnect_interval=reconnect_interval)
         self._mac = mac
         self._ip = ip
-        self.log = logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device.' + self._mac)
-
+        self._index = index
         self._on_new_image_data = on_new_image_data
-        self._capture_task: Task | None = None
+        self._on_connect = on_connect
         self._username = username
         self._password = password
-        url = mac_to_url(mac, ip, index=index)
-        if url is None:
-            raise ValueError(f'could not determine URL for {mac}')
-        self._url = url
 
-        self.start_capture_task()
+        self._start_capture_task()
 
     @property
-    def is_connected(self) -> bool:
-        return (self._capture_task is not None) and (not self._capture_task.done())
+    def ip(self) -> str | None:
+        """The address of the camera; assigning a new one makes the capture loop reopen the stream there."""
+        return self._ip
 
-    def start_capture_task(self) -> None:
-        def create_capture_task() -> None:
-            loop = asyncio.get_event_loop()
-            self._capture_task = loop.create_task(self.run_capture_task())
-        on_startup(create_capture_task)
+    @ip.setter
+    def ip(self, ip: str | None) -> None:
+        if ip == self._ip:
+            return
+        self.log.info('address changed to %s', ip)
+        self._ip = ip
+        self.restart_capture()
 
-    def restart_capture(self) -> None:
-        self.log.debug('Restarting capture task')
-        self.shutdown()
-        self.start_capture_task()
+    @property
+    def url(self) -> str | None:
+        """The stream URL, or ``None`` when the address is unknown or no URL scheme is known for the mac."""
+        if self._ip is None:
+            return None
+        return mac_to_url(self._mac, self._ip, index=self._index)
+
+    def _retry_reason(self) -> str | None:
+        if self._ip is None:
+            return 'no address known'
+        if self.url is None:
+            return f'no stream URL for mac "{self._mac}"'
+        if self.is_refused:
+            return 'camera refused the stream'
+        return None
+
+    def _describe_session_error(self, error: Exception) -> str:
+        if isinstance(error, CameraAddressUnknown):
+            return 'no address known yet'
+        if isinstance(error, httpx.HTTPError):
+            return f'cannot reach the camera: {error}'
+        return super()._describe_session_error(error)
+
+    async def _invoke_on_connect(self) -> None:
+        """Notify the owner that a capture session has been (re-)established, e.g. to reapply camera parameters."""
+        if self._on_connect is None:
+            return
+        result = self._on_connect()
+        if isinstance(result, Awaitable):
+            await result
 
     async def _prepare_stream(self) -> None:
         """Hook executed right before the MJPEG stream is opened (and on every restart).
@@ -113,38 +145,39 @@ class MjpegDevice:
 
             self.log.debug('Stream ended')
         except httpx.ReadTimeout:
-            self.log.warning('Connection to %s timed out', self._url)
+            self.log.warning('Connection to %s timed out', self.url)
 
-    async def run_capture_task(self) -> None:
-        self.log.debug('Starting capture task for %s', self._url)
+    async def _run_session(self) -> None:
+        """Open a stream and read it until it ends."""
+        url = self.url
+        if url is None:
+            return
+        self.log.debug('Starting capture task for %s', url)
 
-        async with httpx.AsyncClient() as client:
-            try:
-                await self._prepare_stream()
-                async with open_stream(client, self._url, self._username, self._password) as response:
-                    if response is not None:
-                        async for image, capture_time in self._frame_reader(response):
-                            if not image:
-                                continue
-                            try:
-                                timestamp = capture_time if capture_time is not None else rosys.time()
-                                result = self._on_new_image_data(remove_exif(image), timestamp)
-                                if isinstance(result, Awaitable):
-                                    await result
-                            except Exception as e:
-                                self.log.error('Error processing image: %s', e)
-            except Exception as e:
-                self.log.warning('Connection to %s failed. Was something disconnected?\n%s', self._url, e)
-                raise
-
-        self.log.warning('Capture task stopped')
-        self._capture_task = None
-
-    def shutdown(self) -> None:
-        self.log.debug('Shutting down capture task')
-        if self._capture_task is not None:
-            self._capture_task.cancel()
-            self._capture_task = None
+        async with new_async_client() as client:
+            await self._prepare_stream()
+            async with open_stream(client, url, self._username, self._password) as response:
+                if response is None:
+                    self._set_state(CaptureState.REFUSED)
+                    return
+                self._set_state(CaptureState.STREAMING)
+                await self._invoke_on_connect()
+                async for image, capture_time in self._frame_reader(response):
+                    if self.url != url:
+                        self.log.info('stream settings changed; reopening the stream')
+                        return
+                    if not image:
+                        continue
+                    try:
+                        timestamp = capture_time if capture_time is not None else rosys.time()
+                        callback_result = self._on_new_image_data(remove_exif(image), timestamp)
+                        if isinstance(callback_result, Awaitable):
+                            await callback_result
+                    except Exception as e:
+                        self.log.error('Error processing image: %s', e)
+                    if not self._keeps_running():
+                        return
+        self.log.debug('capture session ended')
 
     async def get_fps(self) -> int | None:
         return None
@@ -181,7 +214,7 @@ async def open_stream(client: httpx.AsyncClient, url: str,
     """Negotiate the auth scheme and open the http connection.
 
     Credentials are only sent after the camera has challenged the unauthenticated request with a 401.
-    Yields the live 200 response, or ``None`` if the camera refused the connection.
+    Yields the live 200 response, or ``None`` when the camera answered something else.
     """
     auth: httpx.Auth | None = None
     while True:
@@ -192,7 +225,7 @@ async def open_stream(client: httpx.AsyncClient, url: str,
                 continue
             if response.status_code != 200:
                 auth_scheme = response.request.headers.get('authorization', '<none>').split(' ', 1)[0]
-                log.error('could not connect to %s (auth: %s): %s %s',
+                log.error('camera at %s refused the stream (auth: %s): %s %s',
                           url, auth_scheme, response.status_code, response.reason_phrase)
                 yield None
                 return

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -79,13 +79,13 @@ class MjpegDevice(CaptureDevice):
             return None
         return mac_to_url(self._mac, self._ip, index=self._index)
 
-    def _retry_reason(self) -> str | None:
+    def _retry_reason(self) -> tuple[int, str] | None:
         if self._ip is None:
-            return 'no address known'
+            return logging.DEBUG, 'no address known'
         if self.url is None:
-            return f'no stream URL for mac "{self._mac}"'
+            return logging.DEBUG, f'no stream URL for mac "{self._mac}"'
         if self.is_refused:
-            return 'camera refused the stream'
+            return logging.INFO, 'camera refused the stream'
         return None
 
     def _describe_session_error(self, error: Exception) -> str:

--- a/rosys/vision/mjpeg_camera/mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device.py
@@ -48,12 +48,12 @@ class MjpegDevice(CaptureDevice):
                  reconnect_interval: float = 3.0) -> None:
         super().__init__(name=mac,
                          log=logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device.' + mac),
+                         on_connect=on_connect,
                          reconnect_interval=reconnect_interval)
         self._mac = mac
         self._ip = ip
         self._index = index
         self._on_new_image_data = on_new_image_data
-        self._on_connect = on_connect
         self._username = username
         self._password = password
 
@@ -94,14 +94,6 @@ class MjpegDevice(CaptureDevice):
         if isinstance(error, httpx.HTTPError):
             return f'cannot reach the camera: {error}'
         return super()._describe_session_error(error)
-
-    async def _invoke_on_connect(self) -> None:
-        """Notify the owner that a capture session has been (re-)established, e.g. to reapply camera parameters."""
-        if self._on_connect is None:
-            return
-        result = self._on_connect()
-        if isinstance(result, Awaitable):
-            await result
 
     async def _prepare_stream(self) -> None:
         """Hook executed right before the MJPEG stream is opened (and on every restart).
@@ -160,8 +152,7 @@ class MjpegDevice(CaptureDevice):
                 if response is None:
                     self._set_state(CaptureState.REFUSED)
                     return
-                self._set_state(CaptureState.STREAMING)
-                await self._invoke_on_connect()
+                await self._enter_streaming()
                 async for image, capture_time in self._frame_reader(response):
                     if self.url != url:
                         self.log.info('stream settings changed; reopening the stream')

--- a/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_device_factory.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Awaitable, Callable
 
 from .arkvision_mjpeg_device import ArkVisionMjpegDevice
@@ -7,41 +8,50 @@ from .motec_mjpeg_device import MotecMjpegDevice
 from .openipc_zauberzeug_mjpeg_device import OpenIpcZauberzeugMjpegDevice
 from .vendors import VendorType, mac_to_vendor
 
+log = logging.getLogger('rosys.vision.mjpeg_camera.mjpeg_device_factory')
+
 
 class MjpegDeviceFactory:
     @staticmethod
-    def create(mac: str, ip: str, *,
+    def create(mac: str, ip: str | None = None, *,
                index: int | None = None,
                username: str | None = None,
                password: str | None = None,
                control_port: int | None = None,
-               on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> MjpegDevice:
+               on_new_image_data: Callable[[bytes, float], Awaitable | None],
+               on_connect: Callable[[], Awaitable | None] | None = None,
+               reconnect_interval: float = 3.0) -> MjpegDevice:
 
         vendor = mac_to_vendor(mac)
 
         if vendor == VendorType.AXIS:
             return AxisMjpegDevice(mac, ip,
-                                   index=index, username=username,
-                                   password=password, on_new_image_data=on_new_image_data)
+                                   index=index, username=username, password=password,
+                                   on_new_image_data=on_new_image_data, on_connect=on_connect,
+                                   reconnect_interval=reconnect_interval)
 
         if vendor == VendorType.MOTEC:
             return MotecMjpegDevice(mac, ip,
-                                    username=username, password=password,
-                                    control_port=control_port, on_new_image_data=on_new_image_data)
+                                    username=username, password=password, control_port=control_port,
+                                    on_new_image_data=on_new_image_data, on_connect=on_connect,
+                                    reconnect_interval=reconnect_interval)
 
         if vendor == VendorType.ARKVISION:
             return ArkVisionMjpegDevice(mac, ip,
-                                        index=index, username=username,
-                                        password=password, on_new_image_data=on_new_image_data)
+                                        index=index, username=username, password=password,
+                                        on_new_image_data=on_new_image_data, on_connect=on_connect,
+                                        reconnect_interval=reconnect_interval)
 
         if vendor == VendorType.OPENIPC_ZAUBERZEUG:
             return OpenIpcZauberzeugMjpegDevice(mac, ip,
                                                 username=username, password=password,
-                                                on_new_image_data=on_new_image_data)
+                                                on_new_image_data=on_new_image_data, on_connect=on_connect,
+                                                reconnect_interval=reconnect_interval)
 
-        if vendor == VendorType.GOODCAM:
-            return MjpegDevice(mac, ip,
-                               username=username, password=password,
-                               on_new_image_data=on_new_image_data)
+        if vendor is VendorType.OTHER:
+            log.warning('unknown vendor for mac="%s", no stream URL known for this camera', mac)
 
-        raise ValueError(f'Unknown vendor for mac="{mac}"')
+        return MjpegDevice(mac, ip,
+                           username=username, password=password,
+                           on_new_image_data=on_new_image_data, on_connect=on_connect,
+                           reconnect_interval=reconnect_interval)

--- a/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/motec_mjpeg_device.py
@@ -1,24 +1,33 @@
 from collections.abc import Awaitable, Callable
 
-from .mjpeg_device import MjpegDevice
+from .mjpeg_device import CameraAddressUnknown, MjpegDevice
 from .motec_settings_interface import MotecSettingsInterface
 from .vendors import VendorType, mac_to_vendor
 
 
 class MotecMjpegDevice(MjpegDevice):
-    def __init__(self, mac: str, ip: str, *,
+    def __init__(self, mac: str, ip: str | None = None, *,
                  username: str | None = '',
                  password: str | None = '',
                  control_port: int | None = 8885,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
-
-        super().__init__(mac, ip, username=username, password=password, on_new_image_data=on_new_image_data)
-
+                 on_new_image_data: Callable[[bytes, float], Awaitable | None],
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.MOTEC:
             raise ValueError(f'MotecMjpegDevice can only be used with MOTEC devices. Got {vendor} for mac="{mac}"')
 
-        self.settings_interface = MotecSettingsInterface(ip, port=control_port or 8885)
+        self._control_port = control_port or 8885
+
+        super().__init__(mac, ip, username=username, password=password,
+                         on_new_image_data=on_new_image_data, on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
+
+    @property
+    def settings_interface(self) -> MotecSettingsInterface:
+        if self.ip is None:
+            raise CameraAddressUnknown(f'cannot reach the settings of {self._mac} without an address')
+        return MotecSettingsInterface(self.ip, port=self._control_port)
 
     async def set_fps(self, fps: int) -> None:
         await self.settings_interface.set_fps(fps)

--- a/rosys/vision/mjpeg_camera/openipc_zauberzeug_mjpeg_device.py
+++ b/rosys/vision/mjpeg_camera/openipc_zauberzeug_mjpeg_device.py
@@ -1,7 +1,7 @@
 from collections.abc import Awaitable, Callable
 
 from ..openipc_zauberzeug_settings_interface import OpenIpcZauberzeugSettingsInterface
-from .mjpeg_device import MjpegDevice
+from .mjpeg_device import CameraAddressUnknown, MjpegDevice
 from .vendors import VendorType, mac_to_vendor
 
 
@@ -13,18 +13,26 @@ class OpenIpcZauberzeugMjpegDevice(MjpegDevice):
     instead of the no-op defaults of the base class.
     """
 
-    def __init__(self, mac: str, ip: str, *,
+    def __init__(self, mac: str, ip: str | None = None, *,
                  username: str | None = None,
                  password: str | None = None,
-                 on_new_image_data: Callable[[bytes, float], Awaitable | None]) -> None:
-        super().__init__(mac, ip, username=username, password=password, on_new_image_data=on_new_image_data)
-
+                 on_new_image_data: Callable[[bytes, float], Awaitable | None],
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
         vendor = mac_to_vendor(mac)
         if vendor != VendorType.OPENIPC_ZAUBERZEUG:
             raise ValueError(f'OpenIpcZauberzeugMjpegDevice can only be used with '
                              f'OPENIPC_ZAUBERZEUG devices. Got {vendor} for mac="{mac}"')
 
-        self.settings_interface = OpenIpcZauberzeugSettingsInterface(ip, username=username, password=password)
+        super().__init__(mac, ip, username=username, password=password,
+                         on_new_image_data=on_new_image_data, on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
+
+    @property
+    def settings_interface(self) -> OpenIpcZauberzeugSettingsInterface:
+        if self.ip is None:
+            raise CameraAddressUnknown(f'cannot reach the settings of {self._mac} without an address')
+        return OpenIpcZauberzeugSettingsInterface(self.ip, username=self._username, password=self._password)
 
     async def set_fps(self, fps: int) -> None:
         await self.settings_interface.set_mjpeg_fps(fps)

--- a/rosys/vision/reconnect.py
+++ b/rosys/vision/reconnect.py
@@ -1,0 +1,20 @@
+import logging
+
+MIN_RECONNECT_INTERVAL = 0.1
+"""Shortest wait between two connection attempts.
+
+An interval of zero reads as "retry at once", which on a single event loop means a capture loop
+that never lets anything else run.
+"""
+
+MAX_RECONNECT_INTERVAL = 30.0
+"""Wait between attempts after a camera answered without a stream, so a camera that starts
+answering again is picked up within this long at the latest."""
+
+
+def clamp_reconnect_interval(interval: float, log: logging.Logger) -> float:
+    """Hold `interval` to `MIN_RECONNECT_INTERVAL`, saying so when the requested value cannot be honored."""
+    if interval >= MIN_RECONNECT_INTERVAL:
+        return interval
+    log.warning('a reconnect interval of %.2f s is too short; using %.2f s', interval, MIN_RECONNECT_INTERVAL)
+    return MIN_RECONNECT_INTERVAL

--- a/rosys/vision/reconnect.py
+++ b/rosys/vision/reconnect.py
@@ -1,15 +1,10 @@
 import logging
 
 MIN_RECONNECT_INTERVAL = 0.1
-"""Shortest wait between two connection attempts.
-
-An interval of zero reads as "retry at once", which on a single event loop means a capture loop
-that never lets anything else run.
-"""
+"""Shortest wait between two connection attempts; zero would starve the event loop."""
 
 MAX_RECONNECT_INTERVAL = 30.0
-"""Wait between attempts after a camera answered without a stream, so a camera that starts
-answering again is picked up within this long at the latest."""
+"""Longest wait between two connection attempts, so a camera that answers again is picked up in time."""
 
 
 def clamp_reconnect_interval(interval: float, log: logging.Logger) -> float:

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -31,7 +31,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         self.log = logging.getLogger(f'rosys.vision.rtsp_camera.{self.id}')
 
         self.device: RtspDevice | None = None
-        self.ip: str | None = ip
+        self._ip: str | None = ip
 
         self._register_parameter('substream', self.get_substream, self.set_substream,
                                  min_value=0, max_value=1, step=1, default_value=substream)
@@ -66,35 +66,49 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         return self.device is not None and self.device.is_connected
 
     @property
-    def url(self) -> str | None:
-        if not self.is_connected:
-            return None
-        assert self.device is not None
+    def is_active(self) -> bool:
+        return self.device is not None and self.device.is_active
 
+    @property
+    def ip(self) -> str | None:
+        """The address of the camera; a running device rebinds to a new one without being torn down."""
+        return self._ip
+
+    @ip.setter
+    def ip(self, ip: str | None) -> None:
+        self._ip = ip
+        if self.device is not None:
+            self.device.ip = ip
+
+    @property
+    def url(self) -> str | None:
+        if self.device is None:
+            return None
         return self.device.url
 
     async def connect(self) -> None:
-        if self.is_connected:
-            return
-
-        if not self.ip:
-            self.log.error('no IP address provided for camera %s', self.id)
-            return
-
-        self.device = RtspDevice(mac=self.mac, ip=self.ip,
-                                 substream=self.parameters['substream'],
-                                 fps=self.parameters['fps'],
-                                 on_new_image_data=self._handle_new_image_data,
-                                 avdec=self.parameters['avdec'])
-
-        await self._apply_all_parameters()
+        async with self._device_connection():
+            if self.device is not None:
+                if self.device.is_active:
+                    return
+                await self._tear_down_device()
+            self.device = RtspDevice(mac=self.mac, ip=self.ip,
+                                     substream=self.parameters['substream'],
+                                     fps=self.parameters['fps'],
+                                     on_new_image_data=self._handle_new_image_data,
+                                     on_connect=self._apply_all_parameters,
+                                     avdec=self.parameters['avdec'],
+                                     reconnect_interval=self.reconnect_interval)
 
     async def disconnect(self) -> None:
-        if not self.is_connected:
-            return
-        logging.info('camera %s: disconnect initialized...', self.id)
+        async with self._device_connection():
+            await self._tear_down_device()
 
-        assert self.device is not None
+    async def _tear_down_device(self) -> None:
+        """Tear down the device. The caller must hold `device_connection_lock`."""
+        if self.device is None:
+            return
+        self.log.info('disconnect initialized...')
         await self.device.shutdown()
         self.device = None
 
@@ -143,8 +157,11 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
         self.device.set_avdec(avdec)
 
-    async def _apply_parameters(self, new_values: dict[str, Any], force_set: bool = False) -> None:
-        await super()._apply_parameters(new_values, force_set)
-        if self.is_connected:
-            assert self.device is not None
-            await self.device.restart_gstreamer()
+    async def set_parameters(self, new_values: dict[str, Any]) -> None:
+        # NOTE the restart lives here rather than in _apply_parameters: the device invokes _apply_all_parameters
+        # from within its own capture task whenever a stream comes up, and a restart would cancel that very task.
+        async with self._device_connection():  # a device that is being torn down must not be restarted
+            await super().set_parameters(new_values)
+            if self.is_active:
+                assert self.device is not None
+                await self.device.restart_gstreamer()

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -158,8 +158,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         self.device.set_avdec(avdec)
 
     async def set_parameters(self, new_values: dict[str, Any]) -> None:
-        # NOTE the restart lives here rather than in _apply_parameters: the device invokes _apply_all_parameters
-        # from within its own capture task whenever a stream comes up, and a restart would cancel that very task.
+        # not in _apply_parameters: the device calls _apply_all_parameters from the capture task a restart would cancel
         async with self._device_connection():  # a device that is being torn down must not be restarted
             await super().set_parameters(new_values)
             if self.is_active:

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -112,7 +112,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         """Tear down the device. The caller must hold `device_connection_lock`."""
         if self.device is None:
             return
-        self.log.info('disconnect initialized...')
+        self.log.debug('tearing down the device')
         await self.device.shutdown()
         self.device = None
 

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -23,6 +23,7 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
                  ip: str | None = None,
                  **kwargs) -> None:
         self.mac = mac
+        self.device: RtspDevice | None = None
         super().__init__(id=id or f'{mac}-{substream}',
                          name=name,
                          connect_after_init=connect_after_init,
@@ -30,7 +31,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
 
         self.log = logging.getLogger(f'rosys.vision.rtsp_camera.{self.id}')
 
-        self.device: RtspDevice | None = None
         self._ip: str | None = ip
 
         self._register_parameter('substream', self.get_substream, self.set_substream,
@@ -79,6 +79,10 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         self._ip = ip
         if self.device is not None:
             self.device.ip = ip
+
+    def _apply_reconnect_interval(self) -> None:
+        if self.device is not None:
+            self.device.reconnect_interval = self.reconnect_interval
 
     @property
     def url(self) -> str | None:

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -22,7 +22,7 @@ class RtspCameraProvider(CameraProvider[RtspCamera]):
         self.frame_rate = frame_rate
         self.substream = substream
         self.network_interface = network_interface
-        self.avdec = avdec
+        self.avdec: Literal['h264', 'h265'] = avdec
 
         self.log = logging.getLogger('rosys.rtsp_camera_provider')
 
@@ -32,8 +32,7 @@ class RtspCameraProvider(CameraProvider[RtspCamera]):
 
     def restore_from_dict(self, data: dict[str, dict]) -> None:
         for camera_data in data.get('cameras', {}).values():
-            camera = RtspCamera.from_dict(camera_data)
-            self.add_camera(camera)
+            self.add_camera(RtspCamera.from_dict(camera_data))
 
     @staticmethod
     async def scan_for_cameras(network_interface: str | None = None) -> list[tuple[str, str]]:
@@ -45,12 +44,10 @@ class RtspCameraProvider(CameraProvider[RtspCamera]):
             camera = next((c for c in self._cameras.values() if c.mac == mac), None)
             if camera is None:
                 self.log.debug('found new camera %s', mac)
-                camera = RtspCamera(mac=mac, fps=self.frame_rate, substream=self.substream, avdec=self.avdec, ip=ip)
-                self.add_camera(camera)
-            if not camera.is_connected:
-                self.log.info('activating authorized camera %s...', camera.id)
+                self.add_camera(RtspCamera(mac=mac, fps=self.frame_rate,
+                                           substream=self.substream, avdec=self.avdec, ip=ip))
+            else:
                 camera.ip = ip
-                await camera.connect()
 
         self.log.debug('scanning completed, found %d cameras', len(self._cameras))
 

--- a/rosys/vision/rtsp_camera/rtsp_camera_provider.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera_provider.py
@@ -26,7 +26,6 @@ class RtspCameraProvider(CameraProvider[RtspCamera]):
 
         self.log = logging.getLogger('rosys.rtsp_camera_provider')
 
-        rosys.on_shutdown(self.shutdown)
         if auto_scan:
             rosys.on_repeat(self.update_device_list, self.SCAN_INTERVAL)
 
@@ -50,7 +49,3 @@ class RtspCameraProvider(CameraProvider[RtspCamera]):
                 camera.ip = ip
 
         self.log.debug('scanning completed, found %d cameras', len(self._cameras))
-
-    async def shutdown(self) -> None:
-        for camera in self._cameras.values():
-            await camera.disconnect()

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -11,113 +11,186 @@ from asyncio.subprocess import Process
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Literal
+from typing import ClassVar, Literal
 
 import numpy as np
-from nicegui import background_tasks
 
 from ... import rosys
 from ...vision.image import ImageArray
+from ..capture_device import CaptureDevice
 from ..openipc_zauberzeug_settings_interface import OpenIpcZauberzeugSettingsInterface
+from ..reconnect import MAX_RECONNECT_INTERVAL
 from .arkvision_rtsp_interface import ArkVisionRtspInterface
 from .jovision_rtsp_interface import JovisionInterface
 from .vendors import VendorType, mac_to_url, mac_to_vendor
 
 
-class RtspDevice:
+class RtspDevice(CaptureDevice):
+    UNAUTHORIZED_RECONNECT_INTERVAL: ClassVar[float] = MAX_RECONNECT_INTERVAL
+    '''How long to wait between attempts while the camera rejects our credentials.
 
-    def __init__(self, mac: str, ip: str, *,
+    The rejection is only inferred from gstreamer's stderr, so a false positive must slow the retries
+    down rather than stop them.
+    '''
+
+    def __init__(self, mac: str, ip: str | None = None, *,
                  substream: int, fps: int, on_new_image_data: Callable[[ImageArray, float], Awaitable | None],
-                 avdec: Literal['h264', 'h265'] = 'h264') -> None:
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 avdec: Literal['h264', 'h265'] = 'h264',
+                 reconnect_interval: float = 3.0) -> None:
+        super().__init__(name=mac,
+                         log=logging.getLogger('rosys.vision.rtsp_camera.rtsp_device.' + mac),
+                         reconnect_interval=reconnect_interval)
         self._mac = mac
         self._ip = ip
-        self.log = logging.getLogger('rosys.vision.rtsp_camera.rtsp_device.' + self._mac)
 
         self._fps = fps
         self._substream = substream
         self._on_new_image_data = on_new_image_data
+        self._on_connect = on_connect
         self._avdec: Literal['h264', 'h265'] = self._clamp_avdec(avdec)
 
-        self._capture_task: asyncio.Task | None = None
         self._capture_process: Process | None = None
         self._authorized: bool = True
-
-        vendor_type = mac_to_vendor(mac)
+        self._warned_about_missing_url: bool = False
+        self._warned_about_missing_settings: bool = False
 
         self._settings_interface: JovisionInterface | ArkVisionRtspInterface | OpenIpcZauberzeugSettingsInterface | None = None
-        if vendor_type == VendorType.JOVISION:
-            self._settings_interface = JovisionInterface(ip)
-        elif vendor_type == VendorType.ARKVISION:
-            self._settings_interface = ArkVisionRtspInterface(ip)
-        elif vendor_type == VendorType.OPENIPC_ZAUBERZEUG:
-            self._settings_interface = OpenIpcZauberzeugSettingsInterface(ip)
-        else:
-            self.log.warning('[%s] No settings interface for vendor type %s', self._mac, vendor_type)
-            self.log.warning('[%s] Using default fps of 10', self._mac)
+        self._bind_settings_interface()
 
-        self.log.info('[%s] Starting VideoStream for %s', self._mac, self.url)
-        self._start_gstreamer_task()
+        self._start_capture_task()
+
+    def _bind_settings_interface(self) -> None:
+        """(Re-)create the vendor settings interface for the current address."""
+        if self._ip is None:
+            self._settings_interface = None
+            return
+        vendor_type = mac_to_vendor(self._mac)
+        if vendor_type == VendorType.JOVISION:
+            self._settings_interface = JovisionInterface(self._ip)
+        elif vendor_type == VendorType.ARKVISION:
+            self._settings_interface = ArkVisionRtspInterface(self._ip)
+        elif vendor_type == VendorType.OPENIPC_ZAUBERZEUG:
+            self._settings_interface = OpenIpcZauberzeugSettingsInterface(self._ip)
+        else:
+            self._settings_interface = None
+            if not self._warned_about_missing_settings:  # rebinding on every address change must not spam the log
+                self._warned_about_missing_settings = True
+                self.log.warning('[%s] no settings interface for vendor type %s; keeping the configured fps',
+                                 self._mac, vendor_type)
 
     @property
     def is_connected(self) -> bool:
-        return self._capture_task is not None
+        """Whether the gstreamer stream is currently running."""
+        return self._capture_process is not None and self._capture_process.returncode is None
 
     @property
     def authorized(self) -> bool:
+        """Whether the last attempt was not rejected; ``False`` while backing off after a rejected login."""
         return self._authorized
 
     @property
-    def url(self) -> str:
-        url = mac_to_url(self._mac, self._ip, self._substream)
-        if url is None:
-            raise ValueError(f'could not determine RTSP URL for {self._mac}')
-        return url
+    def ip(self) -> str | None:
+        """The address of the camera; assigning a new one makes the capture loop use it for its next session."""
+        return self._ip
 
-    async def shutdown(self) -> None:
-        process = self._capture_process
-        if process is not None:
-            self.log.debug('[%s] Terminating gstreamer process', self._mac)
-            process.terminate()
-            try:
-                await asyncio.wait_for(process.wait(), timeout=5)
-            except TimeoutError:
-                self.log.warning('[%s] Timeout while waiting for gstreamer process to terminate', self._mac)
-            else:
-                self.log.debug('[%s] Successfully shut down process (code %s)',
-                               self._mac, process.returncode if process.returncode is not None else 'None')
-                self._capture_process = None
-        if self._capture_task is not None and not self._capture_task.done():
-            self.log.debug('[%s] Cancelling gstreamer task', self._mac)
-            self._capture_task.cancel()
-            try:
-                await asyncio.wait_for(self._capture_task, timeout=5)
-            except TimeoutError:
-                self.log.warning('[%s] Timeout while waiting for capture task to cancel', self._mac)
-                return
-            except asyncio.CancelledError:
-                self.log.debug('[%s] Task was successfully cancelled', self._mac)
-            else:
-                self.log.debug('[%s] Task finished', self._mac)
-            self._capture_task = None
-
-    def _start_gstreamer_task(self) -> None:
-        self.log.debug('[%s] Starting gstreamer task', self._mac)
-        if self._capture_task is not None and not self._capture_task.done():
-            self.log.warning('[%s] capture task already running', self._mac)
+    @ip.setter
+    def ip(self, ip: str | None) -> None:
+        if ip == self._ip:
             return
-        self._capture_task = background_tasks.create(self._run_gstreamer(), name=f'capture {self._mac}')
+        self.log.info('[%s] address changed to %s', self._mac, ip)
+        self._ip = ip
+        self._bind_settings_interface()
+        self._authorized = True  # a rejection was about the previous address
+        if self.is_connected:
+            assert self._capture_process is not None
+            self._capture_process.terminate()
+
+    @property
+    def url(self) -> str | None:
+        """The stream URL, or ``None`` when the address is unknown or no URL scheme is known for the mac."""
+        if self._ip is None:
+            return None
+        return mac_to_url(self._mac, self._ip, self._substream)
+
+    async def _tear_down_session(self) -> None:
+        process = self._capture_process
+        if process is None:
+            return
+        self.log.debug('[%s] Terminating gstreamer process', self._mac)
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=5)
+        except TimeoutError:
+            self.log.warning('[%s] Timeout while waiting for gstreamer process to terminate', self._mac)
+        else:
+            if self._capture_process is process:
+                self._capture_process = None
+
+    def _start_capture_task(self) -> None:
+        # every attempt starts fresh: an earlier rejection says nothing about this one
+        self._authorized = True
+        super()._start_capture_task()
+
+    def _warn_about_missing_url(self) -> None:
+        """Warn once that no URL can be built for this camera.
+
+        The URL scheme follows from the mac, so retrying cannot help; warning on every attempt would
+        only fill the log.
+        """
+        if self._warned_about_missing_url:
+            return
+        self._warned_about_missing_url = True
+        self.log.warning('[%s] no RTSP URL known for vendor %s; this camera cannot be reached',
+                         self._mac, mac_to_vendor(self._mac))
+
+    def _retry_reason(self) -> str | None:
+        if not self._authorized:
+            return 'credentials rejected'
+        if self._ip is None:
+            return 'no address known'
+        if self.url is None:
+            self._warn_about_missing_url()
+            return 'no stream URL known'
+        return None
+
+    async def _wait_before_retry(self, delay: float) -> None:
+        """Extend the wait while our login stays rejected.
+
+        Waiting in chunks re-reads the verdict, so a new address ends a long wait early instead of
+        holding on to a verdict that was about the previous address. The deadline bounds the whole
+        wait, whatever the chunk size is.
+        """
+        deadline = rosys.time() + self.UNAUTHORIZED_RECONNECT_INTERVAL
+        await rosys.sleep(delay)
+        while self._keeps_running() and not self._authorized and rosys.time() < deadline:
+            await rosys.sleep(self._retry_interval)
 
     async def restart_gstreamer(self) -> None:
         await self.shutdown()
-        self._start_gstreamer_task()
+        self._start_capture_task()
 
-    async def _run_gstreamer(self) -> None:
-        if self._capture_process is not None and self._capture_process.returncode is None:
+    async def _invoke_on_connect(self) -> None:
+        """Notify the owner that a capture session has been (re-)established, e.g. to reapply camera parameters."""
+        if self._on_connect is None:
+            return
+        result = self._on_connect()
+        if isinstance(result, Awaitable):
+            await result
+
+    async def _run_session(self) -> None:
+        """Run a gstreamer session until it ends."""
+        if self.is_connected:
             self.log.warning('[%s] capture process already running', self._mac)
             return
+        url = self.url
+        if url is None:
+            return
+
+        capture_process: Process | None = None
 
         async def stream() -> AsyncGenerator[ImageArray, None]:
-            url = self.url
+            nonlocal capture_process
             self.log.debug('[%s] Starting gstreamer pipeline for %s', self._mac, url)
             # to try: replace avdec_h264 with nvh264dec ! nvvidconv (!videoconvert)
             command = f'gst-launch-1.0 --quiet rtspsrc location="{url}" latency=0 protocols=tcp ! rtp{self._avdec}depay ! avdec_{self._avdec} ! videoconvert ! video/x-raw,format=RGB ! queue max-size-buffers=1 leaky=downstream ! gdppay ! fdsink sync=false'
@@ -130,6 +203,8 @@ class RtspDevice:
             assert process.stdout is not None
             assert process.stderr is not None
             self._capture_process = process
+            capture_process = process
+            await self._invoke_on_connect()
 
             width = None
             height = None
@@ -181,15 +256,19 @@ class RtspDevice:
                 if 'Unauthorized' in error_message:
                     self._authorized = False
 
-        async for image in stream():
-            timestamp = rosys.time()
-            result = self._on_new_image_data(image, timestamp)
-            if isinstance(result, Awaitable):
-                await result
-
-        self.log.info('[%s] stream ended', self._mac)
-
-        self._capture_task = None
+        try:
+            async for image in stream():
+                timestamp = rosys.time()
+                result = self._on_new_image_data(image, timestamp)
+                if isinstance(result, Awaitable):
+                    await result
+            self.log.info('[%s] stream ended', self._mac)
+        finally:
+            if capture_process is not None and capture_process.returncode is None:
+                self.log.debug('[%s] terminating leftover gstreamer process', self._mac)
+                capture_process.terminate()
+            if self._capture_process is capture_process:  # a concurrent session owns its own process
+                self._capture_process = None
 
     async def set_fps(self, fps: int) -> None:
         self._fps = fps

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -72,10 +72,6 @@ class RtspDevice(CaptureDevice):
                                  self._mac, vendor_type)
 
     @property
-    def is_connected(self) -> bool:
-        return self._capture_process is not None and self._capture_process.returncode is None
-
-    @property
     def authorized(self) -> bool:
         return not self.is_refused
 
@@ -138,7 +134,7 @@ class RtspDevice(CaptureDevice):
 
     async def _run_session(self) -> None:
         """Run a gstreamer session until it ends."""
-        if self.is_connected:
+        if self._capture_process is not None and self._capture_process.returncode is None:
             self.log.warning('[%s] capture process already running', self._mac)
             return
         url = self.url
@@ -162,7 +158,6 @@ class RtspDevice(CaptureDevice):
             assert process.stderr is not None
             self._capture_process = process
             capture_process = process
-            await self._invoke_on_connect()
 
             width = None
             height = None
@@ -220,6 +215,8 @@ class RtspDevice(CaptureDevice):
                 result = self._on_new_image_data(image, timestamp)
                 if isinstance(result, Awaitable):
                     await result
+                if not self.is_connected:
+                    await self._enter_streaming()
             self.log.info('[%s] stream ended', self._mac)
         finally:
             if capture_process is not None and capture_process.returncode is None:

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -33,6 +33,7 @@ class RtspDevice(CaptureDevice):
                  reconnect_interval: float = 3.0) -> None:
         super().__init__(name=mac,
                          log=logging.getLogger('rosys.vision.rtsp_camera.rtsp_device.' + mac),
+                         on_connect=on_connect,
                          reconnect_interval=reconnect_interval)
         self._mac = mac
         self._ip = ip
@@ -40,7 +41,6 @@ class RtspDevice(CaptureDevice):
         self._fps = fps
         self._substream = substream
         self._on_new_image_data = on_new_image_data
-        self._on_connect = on_connect
         self._avdec: Literal['h264', 'h265'] = self._clamp_avdec(avdec)
 
         self._capture_process: Process | None = None
@@ -135,14 +135,6 @@ class RtspDevice(CaptureDevice):
     async def restart_gstreamer(self) -> None:
         await self.shutdown()
         self._start_capture_task()
-
-    async def _invoke_on_connect(self) -> None:
-        """Notify the owner that a capture session has been (re-)established, e.g. to reapply camera parameters."""
-        if self._on_connect is None:
-            return
-        result = self._on_connect()
-        if isinstance(result, Awaitable):
-            await result
 
     async def _run_session(self) -> None:
         """Run a gstreamer session until it ends."""

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -11,27 +11,20 @@ from asyncio.subprocess import Process
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar, Literal
+from typing import Literal
 
 import numpy as np
 
 from ... import rosys
 from ...vision.image import ImageArray
-from ..capture_device import CaptureDevice
+from ..capture_device import CaptureDevice, CaptureState
 from ..openipc_zauberzeug_settings_interface import OpenIpcZauberzeugSettingsInterface
-from ..reconnect import MAX_RECONNECT_INTERVAL
 from .arkvision_rtsp_interface import ArkVisionRtspInterface
 from .jovision_rtsp_interface import JovisionInterface
 from .vendors import VendorType, mac_to_url, mac_to_vendor
 
 
 class RtspDevice(CaptureDevice):
-    UNAUTHORIZED_RECONNECT_INTERVAL: ClassVar[float] = MAX_RECONNECT_INTERVAL
-    '''How long to wait between attempts while the camera rejects our credentials.
-
-    The rejection is only inferred from gstreamer's stderr, so a false positive must slow the retries
-    down rather than stop them.
-    '''
 
     def __init__(self, mac: str, ip: str | None = None, *,
                  substream: int, fps: int, on_new_image_data: Callable[[ImageArray, float], Awaitable | None],
@@ -51,7 +44,6 @@ class RtspDevice(CaptureDevice):
         self._avdec: Literal['h264', 'h265'] = self._clamp_avdec(avdec)
 
         self._capture_process: Process | None = None
-        self._authorized: bool = True
         self._warned_about_missing_url: bool = False
         self._warned_about_missing_settings: bool = False
 
@@ -86,8 +78,7 @@ class RtspDevice(CaptureDevice):
 
     @property
     def authorized(self) -> bool:
-        """Whether the last attempt was not rejected; ``False`` while backing off after a rejected login."""
-        return self._authorized
+        return not self.is_refused
 
     @property
     def ip(self) -> str | None:
@@ -101,10 +92,7 @@ class RtspDevice(CaptureDevice):
         self.log.info('[%s] address changed to %s', self._mac, ip)
         self._ip = ip
         self._bind_settings_interface()
-        self._authorized = True  # a rejection was about the previous address
-        if self.is_connected:
-            assert self._capture_process is not None
-            self._capture_process.terminate()
+        self.restart_capture()
 
     @property
     def url(self) -> str | None:
@@ -127,11 +115,6 @@ class RtspDevice(CaptureDevice):
             if self._capture_process is process:
                 self._capture_process = None
 
-    def _start_capture_task(self) -> None:
-        # every attempt starts fresh: an earlier rejection says nothing about this one
-        self._authorized = True
-        super()._start_capture_task()
-
     def _warn_about_missing_url(self) -> None:
         """Warn once that no URL can be built for this camera.
 
@@ -145,7 +128,7 @@ class RtspDevice(CaptureDevice):
                          self._mac, mac_to_vendor(self._mac))
 
     def _retry_reason(self) -> str | None:
-        if not self._authorized:
+        if self.is_refused:
             return 'credentials rejected'
         if self._ip is None:
             return 'no address known'
@@ -153,18 +136,6 @@ class RtspDevice(CaptureDevice):
             self._warn_about_missing_url()
             return 'no stream URL known'
         return None
-
-    async def _wait_before_retry(self, delay: float) -> None:
-        """Extend the wait while our login stays rejected.
-
-        Waiting in chunks re-reads the verdict, so a new address ends a long wait early instead of
-        holding on to a verdict that was about the previous address. The deadline bounds the whole
-        wait, whatever the chunk size is.
-        """
-        deadline = rosys.time() + self.UNAUTHORIZED_RECONNECT_INTERVAL
-        await rosys.sleep(delay)
-        while self._keeps_running() and not self._authorized and rosys.time() < deadline:
-            await rosys.sleep(self._retry_interval)
 
     async def restart_gstreamer(self) -> None:
         await self.shutdown()
@@ -253,8 +224,8 @@ class RtspDevice(CaptureDevice):
                 self.log.error('gstreamer process %s exited with code %s.\nstderr: %s',
                                process.pid, return_code, error_message)
 
-                if 'Unauthorized' in error_message:
-                    self._authorized = False
+                if 'Unauthorized' in error_message:  # inferred from stderr only, so back off rather than give up
+                    self._set_state(CaptureState.REFUSED)
 
         try:
             async for image in stream():

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -72,10 +72,6 @@ class RtspDevice(CaptureDevice):
                                  self._mac, vendor_type)
 
     @property
-    def authorized(self) -> bool:
-        return not self.is_refused
-
-    @property
     def ip(self) -> str | None:
         """The address of the camera; assigning a new one makes the capture loop use it for its next session."""
         return self._ip

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -73,7 +73,6 @@ class RtspDevice(CaptureDevice):
 
     @property
     def is_connected(self) -> bool:
-        """Whether the gstreamer stream is currently running."""
         return self._capture_process is not None and self._capture_process.returncode is None
 
     @property
@@ -116,11 +115,7 @@ class RtspDevice(CaptureDevice):
                 self._capture_process = None
 
     def _warn_about_missing_url(self) -> None:
-        """Warn once that no URL can be built for this camera.
-
-        The URL scheme follows from the mac, so retrying cannot help; warning on every attempt would
-        only fill the log.
-        """
+        """Warn once that no URL can be built for this camera."""
         if self._warned_about_missing_url:
             return
         self._warned_about_missing_url = True

--- a/rosys/vision/rtsp_camera/rtsp_device.py
+++ b/rosys/vision/rtsp_camera/rtsp_device.py
@@ -127,14 +127,14 @@ class RtspDevice(CaptureDevice):
         self.log.warning('[%s] no RTSP URL known for vendor %s; this camera cannot be reached',
                          self._mac, mac_to_vendor(self._mac))
 
-    def _retry_reason(self) -> str | None:
+    def _retry_reason(self) -> tuple[int, str] | None:
         if self.is_refused:
-            return 'credentials rejected'
+            return logging.INFO, 'credentials rejected'
         if self._ip is None:
-            return 'no address known'
+            return logging.DEBUG, 'no address known'
         if self.url is None:
             self._warn_about_missing_url()
-            return 'no stream URL known'
+            return logging.DEBUG, 'no stream URL known'
         return None
 
     async def restart_gstreamer(self) -> None:

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -1,0 +1,879 @@
+import asyncio
+import logging
+from contextlib import asynccontextmanager, suppress
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from nicegui import background_tasks
+from rosys.vision.reconnect import MAX_RECONNECT_INTERVAL, MIN_RECONNECT_INTERVAL
+
+import rosys
+from rosys.testing import forward
+from rosys.vision import MjpegCamera, MjpegCameraProvider, RtspCamera, RtspCameraProvider
+from rosys.vision.mjpeg_camera.arkvision_mjpeg_device import ArkVisionMjpegDevice
+from rosys.vision.mjpeg_camera.axis_mjpeg_device import AxisMjpegDevice
+from rosys.vision.mjpeg_camera.mjpeg_device import CameraAddressUnknown, CaptureState, MjpegDevice
+from rosys.vision.mjpeg_camera.mjpeg_device_factory import MjpegDeviceFactory
+from rosys.vision.mjpeg_camera.motec_mjpeg_device import MotecMjpegDevice
+from rosys.vision.mjpeg_camera.openipc_zauberzeug_mjpeg_device import OpenIpcZauberzeugMjpegDevice
+from rosys.vision.rtsp_camera.rtsp_device import RtspDevice
+
+# A MAC that maps to a "GOODCAM" URL in both the RTSP and MJPEG vendor tables.
+# GOODCAM needs no settings interface, so the device is constructed without any network access.
+GOODCAM_MAC = '2c:6f:51:00:00:01'
+
+# A MAC that maps to AXIS, whose stream settings are part of the URL rather than a settings interface.
+AXIS_MAC = '00:40:8c:00:00:01'
+
+MOTEC_MAC = '2c:26:5f:00:00:01'
+ARKVISION_MAC = '18:fd:cb:00:00:01'
+OPENIPC_ZAUBERZEUG_MAC = '7a:7a:21:00:00:01'
+
+# A MAC no vendor table knows, so no stream URL can be built for it.
+UNKNOWN_VENDOR_MAC = '02:00:00:00:00:01'
+
+
+async def _no_stream(self) -> None:
+    """Stand-in for a capture session that never delivers a frame and never ends on its own."""
+    await rosys.sleep(60.0)
+
+
+def stalled_mjpeg_stream():
+    """Keep an `MjpegDevice` in a single capture session without touching the network."""
+    return patch.object(MjpegDevice, '_run_session', _no_stream)
+
+
+def stalled_rtsp_stream():
+    """Keep an `RtspDevice` in a single capture session without spawning gstreamer."""
+    return patch.object(RtspDevice, '_run_session', _no_stream)
+
+
+class FakeGstreamerProcess:
+    """Stand-in for the gstreamer process, so a device reports `is_connected` without spawning one."""
+
+    def __init__(self) -> None:
+        self.returncode: int | None = None
+
+    def terminate(self) -> None:
+        self.returncode = -15
+
+    async def wait(self) -> int | None:
+        return self.returncode
+
+
+async def _connected_rtsp_stream(self) -> None:
+    """Stand-in for a gstreamer session that comes up and reapplies parameters, but spawns nothing."""
+    self._capture_process = FakeGstreamerProcess()  # pylint: disable=protected-access
+    try:
+        await self._invoke_on_connect()  # pylint: disable=protected-access
+        await rosys.sleep(60.0)
+    finally:
+        self._capture_process = None  # pylint: disable=protected-access
+
+
+def connected_rtsp_stream():
+    """Keep an `RtspDevice` in a single *connected* capture session without spawning gstreamer."""
+    return patch.object(RtspDevice, '_run_session', _connected_rtsp_stream)
+
+
+async def forward_until(condition, *, step: float = 0.3, real_step: float = 0.05,
+                        attempts: int = 20, message: str = 'condition was not met') -> None:
+    """Advance simulated time in steps, yielding real time between them, until `condition` holds.
+
+    `rosys.testing.forward(until=...)` only yields via `asyncio.sleep(0)`, so it can exhaust its
+    timeout before real loopback sockets or `io_bound` threads have made any progress.
+    """
+    for _ in range(attempts):
+        if condition():
+            return
+        await forward(step)
+        await asyncio.sleep(real_step)
+    assert condition(), message
+
+
+async def _survives_one_cancellation() -> None:
+    """Stand-in for a capture task that resumes after its first cancellation instead of ending."""
+    with suppress(asyncio.CancelledError):
+        await asyncio.sleep(60.0)
+    await asyncio.sleep(60.0)
+
+
+JPEG_FRAME = b'\xff\xd8' + bytes(32) + b'\xff\xd9'  # minimal SOI..EOI JPEG marker pair
+
+
+@pytest.fixture
+def vision_log(rosys_integration: None, caplog: pytest.LogCaptureFixture):
+    logger = logging.getLogger('rosys.vision')  # NOTE: the test log configuration disables propagation to the root
+    logger.addHandler(caplog.handler)
+    yield caplog
+    logger.removeHandler(caplog.handler)
+
+
+async def wait_in_real_time(condition, *, step: float = 0.02, attempts: int = 200,
+                            message: str = 'condition was not met') -> None:
+    """Wait for `condition` without advancing simulated time.
+
+    `forward()` does not advance while a `rosys.run.cpu_bound` call is in flight, so a test that
+    holds one open has to wait in real time.
+    """
+    for _ in range(attempts):
+        if condition():
+            return
+        await asyncio.sleep(step)
+    assert condition(), message
+
+
+def live_capture_tasks(name: str) -> list[asyncio.Task]:
+    """The capture loops still running under this task name; a device names its task, so a leftover shows up."""
+    return [task for task in asyncio.all_tasks() if task.get_name() == name and not task.done()]
+
+
+async def cancel_leftover_loops(name: str) -> None:
+    """Cancel the capture loops under this name and wait for them to end, as a crashing loop leaves them.
+
+    Also keeps a failing test from leaving a loop behind that would hold up the next one.
+    """
+    tasks = live_capture_tasks(name)
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+class SlowFirstDecode:
+    """Stand-in for `nicegui.run.cpu_bound` that stalls its first call.
+
+    `rosys.run.cpu_bound` turns a cancellation during the call into a `None` result instead of
+    raising, so this is where a shutdown or an address change lands while a frame is being decoded.
+    """
+
+    def __init__(self, seconds: float = 0.3) -> None:
+        self.seconds = seconds
+        self.started = asyncio.Event()
+        self.finished = asyncio.Event()
+
+    async def __call__(self, callback, *args, **kwargs):
+        if not self.started.is_set():
+            self.started.set()
+            try:
+                await asyncio.sleep(self.seconds)
+            finally:  # the cancellation arrives here, so the stall ends either way
+                self.finished.set()
+        return callback(*args, **kwargs)
+
+
+async def decode_frame(data: bytes, timestamp: float) -> None:  # pylint: disable=unused-argument
+    """Image callback shaped like `MjpegCamera._handle_new_image_data`, which decodes via `cpu_bound`."""
+    await rosys.run.cpu_bound(len, data)
+
+
+class FlakyMjpegServer:
+    """Local HTTP server that serves `frames_per_connection` fake JPEG frames and then drops the connection.
+
+    One frame per connection mimics a camera whose stream keeps ending; `None` keeps the stream open.
+    Any `status` other than 200 is answered instead of a stream.
+    """
+
+    def __init__(self, frames_per_connection: int | None = 1, status: int = 200) -> None:
+        self.connections = 0
+        self.frames_per_connection = frames_per_connection
+        self.status = status
+        self._server: asyncio.Server | None = None
+
+    @property
+    def port(self) -> int:
+        assert self._server is not None
+        return self._server.sockets[0].getsockname()[1]
+
+    async def start(self) -> None:
+        self._server = await asyncio.start_server(self._handle, '127.0.0.1', 0)
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        self.connections += 1
+        try:
+            try:
+                await asyncio.wait_for(reader.readuntil(b'\r\n\r\n'), timeout=2)
+            except Exception:  # reading the request is best-effort
+                pass
+            if self.status != 200:
+                refusal = f'HTTP/1.1 {self.status} refused\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'
+                writer.write(refusal.encode())
+                await writer.drain()
+                return
+            writer.write(b'HTTP/1.1 200 OK\r\n'
+                         b'Content-Type: multipart/x-mixed-replace; boundary=frame\r\n\r\n')
+            sent = 0
+            while self.frames_per_connection is None or sent < self.frames_per_connection:
+                writer.write(JPEG_FRAME)
+                await writer.drain()
+                sent += 1
+                if self.frames_per_connection is None:
+                    await asyncio.sleep(0.02)
+        except (ConnectionResetError, BrokenPipeError):
+            pass  # the device closed the stream
+        finally:
+            writer.close()
+
+    async def stop(self) -> None:
+        assert self._server is not None
+        self._server.close()
+        with suppress(TimeoutError):  # a client still reading must not hold up the test
+            await asyncio.wait_for(self._server.wait_closed(), timeout=1)
+
+
+async def test_mjpeg_device_reconnects_after_stream_drops(rosys_integration):
+    server = FlakyMjpegServer()
+    await server.start()
+    frames: list[bytes] = []
+    device = MjpegDevice(GOODCAM_MAC, f'127.0.0.1:{server.port}',
+                         on_new_image_data=lambda data, timestamp: frames.append(data))
+    device.reconnect_interval = 0.2
+    try:
+        await forward_until(lambda: server.connections >= 3, attempts=60,
+                            message='device did not reconnect')
+        await forward_until(lambda: len(frames) >= 3, attempts=60,
+                            message='no frames received across reconnects')
+
+        await device.shutdown()
+        await asyncio.sleep(0.1)
+        assert not device.is_connected
+        connections_at_shutdown = server.connections
+        for _ in range(5):
+            await forward(0.3)
+            await asyncio.sleep(0.05)
+        assert server.connections == connections_at_shutdown, 'device kept reconnecting after shutdown'
+    finally:
+        await device.shutdown()
+        await server.stop()
+
+
+async def test_rtsp_device_reconnects_until_shutdown(rosys_integration):
+    sessions = 0
+
+    async def fake_gstreamer(self) -> None:
+        nonlocal sessions
+        sessions += 1
+        await rosys.sleep(0.05)  # simulate a short-lived stream that ends on its own
+
+    with patch.object(RtspDevice, '_run_session', fake_gstreamer):
+        device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
+                            on_new_image_data=lambda array, timestamp: None,
+                            reconnect_interval=0.2)
+        await forward(2.0)
+        assert sessions >= 3, f'device did not reconnect (only {sessions} sessions)'
+        assert device.is_active  # loop alive; is_connected is False here because the stubbed gstreamer opens no process
+
+        await device.shutdown()
+        assert not device.is_active
+        sessions_at_shutdown = sessions
+        await forward(2.0)
+        assert sessions == sessions_at_shutdown, 'device kept reconnecting after shutdown'
+
+
+@pytest.mark.parametrize('make_camera', [
+    lambda: RtspCamera(mac='aa:bb:cc:dd:ee:ff', reconnect_interval=12.5, connect_after_init=False),
+    lambda: MjpegCamera(id='test_cam', ip='192.168.1.1', reconnect_interval=12.5, connect_after_init=False),
+])
+def test_camera_persists_reconnect_interval(rosys_integration, make_camera):
+    camera = make_camera()
+    data = camera.to_dict()
+    assert data['reconnect_interval'] == 12.5
+    assert type(camera).from_dict(data).reconnect_interval == 12.5
+
+
+async def test_mjpeg_device_backs_off_after_401(rosys_integration):
+    server = FlakyMjpegServer(status=401)
+    await server.start()
+    device = MjpegDevice(GOODCAM_MAC, f'127.0.0.1:{server.port}',
+                         on_new_image_data=lambda data, timestamp: None,
+                         reconnect_interval=0.2)
+    device.REFUSED_RECONNECT_INTERVAL = 4.0  # type: ignore[misc]
+    try:
+        await forward_until(lambda: device.is_refused, step=0.2,
+                            message='expected the device to mark itself refused after a 401 response')
+        assert device.is_active is True, 'expected the capture loop to stay alive while backing off'
+        assert device.is_connected is False, 'expected a refused device to remain disconnected'
+
+        connections_after_401 = server.connections
+        for _ in range(5):  # well beyond reconnect_interval, still inside the back-off
+            await forward(0.2)
+            await asyncio.sleep(0.05)
+        assert server.connections == connections_after_401, (
+            'expected the device to throttle its retries after a 401 response'
+        )
+
+        await forward_until(lambda: server.connections > connections_after_401, step=0.5, attempts=40,
+                            message='expected the device to retry once the back-off elapsed')
+    finally:
+        await device.shutdown()
+        await server.stop()
+
+
+async def test_mjpeg_device_reports_an_unreachable_camera_without_a_traceback(vision_log):
+    device = MjpegDevice(GOODCAM_MAC, '127.0.0.1:1',
+                         on_new_image_data=lambda data, timestamp: None, reconnect_interval=0.2)
+    try:
+        await forward_until(lambda: any('cannot reach' in record.getMessage() for record in vision_log.records),
+                            message='expected the device to report that it cannot reach the camera')
+        assert not [record for record in vision_log.records if record.exc_info], (
+            'expected no traceback for a camera that is simply not there'
+        )
+    finally:
+        await device.shutdown()
+
+
+async def test_mjpeg_device_retries_at_a_new_address_despite_back_off(rosys_integration):
+    rejecting_server = FlakyMjpegServer(status=401)
+    new_server = FlakyMjpegServer()
+    await rejecting_server.start()
+    await new_server.start()
+    device = MjpegDevice(GOODCAM_MAC, f'127.0.0.1:{rejecting_server.port}',
+                         on_new_image_data=lambda data, timestamp: None,
+                         reconnect_interval=0.2)
+    device.REFUSED_RECONNECT_INTERVAL = 600.0  # type: ignore[misc]
+    try:
+        await forward_until(lambda: device.is_refused, step=0.2,
+                            message='expected the device to mark itself refused after a 401 response')
+
+        device.ip = f'127.0.0.1:{new_server.port}'  # a rejection was about the previous address
+        await forward_until(lambda: new_server.connections >= 1, step=0.2,
+                            message='expected an address change to end the back-off')
+    finally:
+        await device.shutdown()
+        await rejecting_server.stop()
+        await new_server.stop()
+
+
+async def test_a_reconnect_interval_that_can_be_honored_is_kept(vision_log):
+    device = MjpegDevice(GOODCAM_MAC, on_new_image_data=lambda data, timestamp: None, reconnect_interval=2.5)
+    try:
+        assert device.reconnect_interval == 2.5
+        assert not [record for record in vision_log.records if 'too short' in record.getMessage()]
+
+        device.reconnect_interval = 0.0
+        assert device.reconnect_interval == MIN_RECONNECT_INTERVAL, 'expected a later assignment to be held too'
+        assert [record for record in vision_log.records if 'too short' in record.getMessage()]
+    finally:
+        await device.shutdown()
+
+
+async def test_rtsp_device_backs_off_after_rejected_login(rosys_integration):
+    sessions = 0
+
+    async def unauthorized_gstreamer(self) -> None:
+        nonlocal sessions
+        sessions += 1
+        self._authorized = False  # pylint: disable=protected-access
+
+    with patch.object(RtspDevice, '_run_session', unauthorized_gstreamer):
+        device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
+                            on_new_image_data=lambda array, timestamp: None,
+                            reconnect_interval=0.2)
+        device.UNAUTHORIZED_RECONNECT_INTERVAL = 4.0  # type: ignore[misc]
+        try:
+            await forward(0.5)
+            assert sessions == 1, f'expected the device to throttle its retries, got {sessions} sessions'
+            assert device.authorized is False, 'expected the device to mark itself unauthorized'
+            assert device.is_active is True, 'expected the capture loop to stay alive while backing off'
+
+            await forward(4.0)
+            assert sessions >= 2, 'expected the device to retry once the unauthorized back-off elapsed'
+
+            device.ip = '192.168.0.6'  # a rejection was about the previous address
+            sessions_at_address_change = sessions
+            await forward(0.5)
+            assert sessions > sessions_at_address_change, (
+                'expected an address change to end the unauthorized back-off'
+            )
+        finally:
+            await device.shutdown()
+
+
+async def test_mjpeg_device_invokes_on_connect_per_session(rosys_integration):
+    server = FlakyMjpegServer()
+    await server.start()
+    connect_calls = 0
+
+    def count_connect() -> None:
+        nonlocal connect_calls
+        connect_calls += 1
+
+    device = MjpegDevice(GOODCAM_MAC, f'127.0.0.1:{server.port}',
+                         on_new_image_data=lambda data, timestamp: None,
+                         on_connect=count_connect,
+                         reconnect_interval=0.2)
+    try:
+        await forward_until(lambda: connect_calls >= 3,
+                            message='on_connect was not invoked for each new stream')
+    finally:
+        await device.shutdown()
+        await server.stop()
+
+
+async def test_rtsp_camera_restarts_stream_on_set_parameters_but_not_on_reapply(rosys_integration):
+    camera = RtspCamera(mac=GOODCAM_MAC, ip='192.168.0.5', connect_after_init=False)
+    with connected_rtsp_stream(), \
+            patch.object(RtspDevice, 'restart_gstreamer') as restart:
+        await camera.connect()
+        # the session reapplies the parameters itself, which only runs the setters while connected
+        await forward_until(lambda: camera.is_connected, message='expected the capture session to come up')
+
+        restart.assert_not_called()  # a reapply from the device's own capture task must not restart the stream
+
+        await camera.set_parameters({'fps': 7})
+        restart.assert_called_once()
+        await camera.disconnect()
+
+
+async def test_axis_camera_applies_parameters_without_restarting_its_own_session(rosys_integration):
+    sessions = 0
+
+    async def stream(self) -> None:
+        nonlocal sessions
+        sessions += 1
+        self._state = CaptureState.STREAMING  # pylint: disable=protected-access
+        await self._invoke_on_connect()  # pylint: disable=protected-access
+        await rosys.sleep(60.0)
+
+    camera = MjpegCamera(id=AXIS_MAC, ip='192.168.0.5', fps=12, connect_after_init=False)
+    with patch.object(MjpegDevice, '_run_session', stream):
+        await camera.connect()
+        try:
+            await forward_until(lambda: sessions >= 1, message='expected a capture session to start')
+            await forward(2.0)
+            assert sessions == 1, 'expected the reapplied parameters not to restart the capture task'
+            assert camera.device is not None
+            assert 'fps=12' in (camera.device.url or ''), 'expected the requested fps to reach the stream URL'
+        finally:
+            await camera.disconnect()
+
+
+async def test_mjpeg_device_reopens_the_stream_when_its_url_changes(rosys_integration):
+    opened_urls: list[str] = []
+
+    @asynccontextmanager
+    async def open_stream(client, url, username, password):  # pylint: disable=unused-argument
+        opened_urls.append(url)
+        yield object()  # the response only reaches the patched frame reader
+
+    async def endless_frames(self, response):  # pylint: disable=unused-argument
+        while True:
+            await rosys.sleep(0.05)
+            yield b'\xff\xd8' + bytes(32) + b'\xff\xd9', None
+
+    with patch('rosys.vision.mjpeg_camera.mjpeg_device.open_stream', open_stream), \
+            patch.object(MjpegDevice, '_frame_reader', endless_frames):
+        device = AxisMjpegDevice(AXIS_MAC, '192.168.0.5', on_new_image_data=lambda data, timestamp: None)
+        device.reconnect_interval = 0.2
+        try:
+            await forward_until(lambda: len(opened_urls) == 1, message='expected the stream to be opened')
+            await device.set_fps(12)
+            await forward_until(lambda: len(opened_urls) == 2,
+                                message='expected the stream to reopen after the settings changed')
+            assert 'fps=6' in opened_urls[0] and 'fps=12' in opened_urls[1]
+        finally:
+            await device.shutdown()
+
+
+async def test_mjpeg_device_stops_streaming_when_shut_down_during_a_callback(rosys_integration):
+    server = FlakyMjpegServer(frames_per_connection=None)
+    await server.start()
+    frames: list[bytes] = []
+    decode = SlowFirstDecode()
+
+    async def handle_image(data: bytes, timestamp: float) -> None:
+        await decode_frame(data, timestamp)
+        frames.append(data)
+
+    with patch('nicegui.run.cpu_bound', decode):
+        device = MjpegDevice(GOODCAM_MAC, f'127.0.0.1:{server.port}', on_new_image_data=handle_image)
+        try:
+            await wait_in_real_time(decode.started.is_set, message='no frame reached the callback')
+            await device.shutdown()
+            await wait_in_real_time(decode.finished.is_set, message='the stalled callback never returned')
+            await asyncio.sleep(0.05)  # let the frame that was in flight finish
+            frames_after_shutdown = len(frames)
+            await asyncio.sleep(0.15)  # a surviving session would deliver several more frames
+            assert len(frames) == frames_after_shutdown, 'the capture task kept streaming after shutdown'
+            assert not live_capture_tasks(f'capture {GOODCAM_MAC}'), 'the capture task survived shutdown'
+        finally:
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')
+            await server.stop()
+
+
+async def test_mjpeg_device_keeps_one_capture_loop_across_an_address_change(rosys_integration):
+    server = FlakyMjpegServer(frames_per_connection=None)
+    await server.start()
+    decode = SlowFirstDecode()
+
+    with patch('nicegui.run.cpu_bound', decode):
+        device = MjpegDevice(GOODCAM_MAC, f'127.0.0.1:{server.port}', on_new_image_data=decode_frame)
+        try:
+            await wait_in_real_time(decode.started.is_set, message='no frame reached the callback')
+            device.ip = '127.0.0.1:1'  # a provider rebinds the camera to another address
+            await wait_in_real_time(decode.finished.is_set, message='the stalled callback never returned')
+            await asyncio.sleep(0.1)
+            assert len(live_capture_tasks(f'capture {GOODCAM_MAC}')) == 1, \
+                'the replaced capture loop is still running'
+        finally:
+            await device.shutdown()
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')
+            await server.stop()
+
+
+async def test_rtsp_device_keeps_one_capture_loop_across_concurrent_restarts(rosys_integration):
+    task_name = f'capture {GOODCAM_MAC}'
+    with connected_rtsp_stream():
+        device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
+                            on_new_image_data=lambda array, timestamp: None)
+        try:
+            await forward_until(lambda: device.is_connected, message='expected the capture session to come up')
+            await asyncio.gather(device.restart_gstreamer(), device.restart_gstreamer())
+            await asyncio.sleep(0.05)
+            assert len(live_capture_tasks(task_name)) == 1, \
+                f'expected one capture loop, got {len(live_capture_tasks(task_name))}'
+        finally:
+            await device.shutdown()
+            await cancel_leftover_loops(task_name)
+
+
+async def test_rtsp_camera_does_not_restart_a_device_it_is_disconnecting(rosys_integration):
+    task_name = f'capture {GOODCAM_MAC}'
+    camera = RtspCamera(mac=GOODCAM_MAC, ip='192.168.0.5', connect_after_init=False)
+    with connected_rtsp_stream():
+        try:
+            await camera.connect()
+            await forward_until(lambda: camera.is_connected, message='expected the capture session to come up')
+            await asyncio.gather(camera.disconnect(), camera.set_parameters({'fps': 7}))
+            await asyncio.sleep(0.05)
+            assert camera.device is None, 'expected the camera to end up disconnected'
+            assert not live_capture_tasks(task_name), 'a capture loop outlived the disconnect'
+        finally:
+            await camera.disconnect()
+            await cancel_leftover_loops(task_name)
+
+
+async def test_axis_device_derives_url_from_its_settings(rosys_integration):
+    with stalled_mjpeg_stream():
+        device = AxisMjpegDevice(AXIS_MAC, '192.168.0.5', index=1,
+                                 on_new_image_data=lambda data, timestamp: None)
+        try:
+            assert device.url is not None
+            assert 'camera=1' in device.url
+            assert 'fps=6' in device.url and 'resolution=640x480' in device.url and 'mirror=0' in device.url
+
+            await device.set_fps(12)
+            await device.set_resolution(1280, 720)
+            await device.set_mirrored(True)
+            assert device.url is not None
+            assert 'fps=12' in device.url and 'resolution=1280x720' in device.url and 'mirror=1' in device.url
+            assert device.url.count('fps=') == 1, 'expected the URL to be rebuilt rather than appended to'
+        finally:
+            await device.shutdown()
+
+
+async def test_axis_device_url_follows_address_and_keeps_settings(rosys_integration):
+    with stalled_mjpeg_stream():
+        device = AxisMjpegDevice(AXIS_MAC, on_new_image_data=lambda data, timestamp: None)
+        try:
+            assert device.url is None, 'expected no URL while the address is unknown'
+            assert device.is_active, 'expected the capture loop to run even without an address'
+
+            await device.set_fps(12)
+            device.ip = '192.168.0.5'
+            assert device.url is not None and '192.168.0.5' in device.url
+            assert 'fps=12' in device.url, 'expected the stream settings to survive the address change'
+            assert device.is_active
+        finally:
+            await device.shutdown()
+
+
+async def test_mjpeg_camera_is_active_without_known_address(rosys_integration):
+    """A camera that cannot reach its device yet still reports that a connection is wanted."""
+    camera = MjpegCamera(id=GOODCAM_MAC, connect_after_init=False)
+    await camera.connect()
+    try:
+        assert camera.device is not None, 'expected connect() to create a device even without an address'
+        assert camera.device.url is None, 'expected no stream URL while the address is unknown'
+        assert camera.is_active, 'expected the camera to report that it wants to be connected'
+        assert not camera.is_connected
+        assert camera.is_reconnecting
+    finally:
+        await camera.disconnect()
+
+
+async def test_mjpeg_camera_stays_active_while_its_login_is_rejected(rosys_integration):
+    """A rejected login does not revoke the wish to be connected, so `connect()` stays a no-op."""
+    server = FlakyMjpegServer(status=401)
+    await server.start()
+    camera = MjpegCamera(id=GOODCAM_MAC, ip=f'127.0.0.1:{server.port}',
+                         connect_after_init=False, reconnect_interval=0.2)
+    await camera.connect()
+    device = camera.device
+    assert device is not None
+    try:
+        await forward_until(lambda: device.is_refused, step=0.2,
+                            message='expected the camera to be rejected by the 401 server')
+        assert camera.is_active, 'expected a rejected camera to still report that it wants to be connected'
+        assert not camera.is_connected
+        assert camera.is_reconnecting
+    finally:
+        await camera.disconnect()
+    assert not camera.is_active, 'expected only disconnect() to end the wish to be connected'
+
+
+async def test_rtsp_camera_is_active_without_known_address(rosys_integration):
+    camera = RtspCamera(mac=GOODCAM_MAC, connect_after_init=False)
+    await camera.connect()
+    try:
+        assert camera.device is not None, 'expected connect() to create a device even without an address'
+        assert camera.url is None, 'expected no stream URL while the address is unknown'
+        assert camera.is_active, 'expected the camera to report that it wants to be connected'
+        assert not camera.is_connected
+    finally:
+        await camera.disconnect()
+
+
+async def test_mjpeg_provider_adds_and_connects_new_camera(rosys_integration):
+    with stalled_mjpeg_stream():
+        provider = MjpegCameraProvider(auto_scan=False)
+        with patch.object(provider, 'scan_for_cameras', AsyncMock(return_value=[(GOODCAM_MAC, '127.0.0.1:1')])):
+            await provider.update_device_list()
+        camera = provider.cameras[GOODCAM_MAC]
+        await asyncio.sleep(0.05)  # let the camera's own connect task run
+        assert camera.is_active, 'expected a discovered camera to connect on its own'
+        assert camera.ip == '127.0.0.1:1'
+        await provider.shutdown()
+
+
+async def test_mjpeg_provider_rebinds_moved_camera(rosys_integration):
+    with stalled_mjpeg_stream():
+        provider = MjpegCameraProvider(auto_scan=False)
+        camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1:1', connect_after_init=False)
+        provider.add_camera(camera)
+        await camera.connect()
+        assert camera.is_active
+        old_device = camera.device
+
+        with patch.object(provider, 'scan_for_cameras', AsyncMock(return_value=[(GOODCAM_MAC, '127.0.0.1:2')])):
+            await provider.update_device_list()
+
+        assert camera.ip == '127.0.0.1:2'
+        assert camera.device is old_device, 'expected the device to be rebound rather than torn down'
+        assert camera.device is not None and '127.0.0.1:2' in (camera.device.url or '')
+        assert camera.is_active
+        await provider.shutdown()
+
+
+async def test_mjpeg_provider_supplies_ip_to_pending_camera(rosys_integration):
+    with stalled_mjpeg_stream():
+        provider = MjpegCameraProvider(auto_scan=False)
+        camera = MjpegCamera(id=GOODCAM_MAC, connect_after_init=False)
+        provider.add_camera(camera)
+        await camera.connect()  # no IP known yet, so the device has nothing to open
+        assert camera.is_active
+        assert camera.device is not None and camera.device.url is None
+
+        with patch.object(provider, 'scan_for_cameras', AsyncMock(return_value=[(GOODCAM_MAC, '127.0.0.1:1')])):
+            await provider.update_device_list()
+
+        assert camera.ip == '127.0.0.1:1'
+        assert camera.device is not None and '127.0.0.1:1' in (camera.device.url or ''), \
+            'expected the device to pick up the discovered address'
+        assert camera.is_active
+        await provider.shutdown()
+
+
+async def test_mjpeg_provider_leaves_disconnected_camera_alone(rosys_integration):
+    with stalled_mjpeg_stream():
+        provider = MjpegCameraProvider(auto_scan=False)
+        camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1:1', connect_after_init=False)
+        provider.add_camera(camera)
+        await camera.connect()
+        await camera.disconnect()
+
+        with patch.object(provider, 'scan_for_cameras', AsyncMock(return_value=[(GOODCAM_MAC, '127.0.0.1:2')])):
+            await provider.update_device_list()
+
+        assert camera.ip == '127.0.0.1:2', 'expected the provider to record the new address'
+        assert not camera.is_active, 'expected the provider to leave a deliberately disconnected camera alone'
+
+
+async def test_rtsp_provider_rebinds_moved_camera(rosys_integration):
+    with stalled_rtsp_stream():
+        provider = RtspCameraProvider(auto_scan=False)
+        camera = RtspCamera(mac=GOODCAM_MAC, ip='192.168.0.5', connect_after_init=False)
+        provider.add_camera(camera)
+        await camera.connect()
+        assert camera.is_active
+        old_device = camera.device
+
+        with patch('rosys.vision.rtsp_camera.rtsp_camera_provider.find_known_cameras',
+                   AsyncMock(return_value=[(GOODCAM_MAC, '192.168.0.6')])):
+            await provider.update_device_list()
+
+        assert camera.ip == '192.168.0.6'
+        assert camera.device is old_device, 'expected the device to be rebound rather than torn down'
+        assert camera.device is not None and '192.168.0.6' in (camera.device.url or '')
+        assert camera.is_active
+        await provider.shutdown()
+
+
+async def test_camera_clamps_a_reconnect_interval_that_would_not_wait(rosys_integration):
+    for interval in (0.0, -1.0):
+        camera = MjpegCamera(id='test_cam', reconnect_interval=interval, connect_after_init=False)
+        assert camera.reconnect_interval == MIN_RECONNECT_INTERVAL, 'expected the camera to clamp the interval'
+
+
+async def test_camera_passes_its_reconnect_interval_to_a_replaced_device(rosys_integration):
+    """The interval belongs to the camera, not to whichever device happens to exist."""
+    camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1:1', connect_after_init=False)
+    camera.reconnect_interval = 7.0
+    with stalled_mjpeg_stream():
+        await camera.connect()
+        try:
+            assert camera.device is not None
+            assert camera.device.reconnect_interval == 7.0
+        finally:
+            await camera.disconnect()
+
+
+def test_no_wait_between_attempts_exceeds_the_cap():
+    """A refused camera must be picked up as soon as it answers again, like any other retry."""
+    assert MjpegDevice.REFUSED_RECONNECT_INTERVAL <= MAX_RECONNECT_INTERVAL
+    assert RtspDevice.UNAUTHORIZED_RECONNECT_INTERVAL <= MAX_RECONNECT_INTERVAL
+
+
+async def test_camera_is_not_active_once_its_capture_loop_died(rosys_integration):
+    """Without this, the camera reports `is_reconnecting` forever with nothing running."""
+    camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1:1', connect_after_init=False)
+    with stalled_mjpeg_stream():
+        await camera.connect()
+        try:
+            assert camera.is_active
+            assert camera.device is not None
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')  # as a crashing loop would
+            assert not camera.is_active, 'expected a camera with a dead capture loop to report is_active False'
+            assert not camera.is_reconnecting, 'expected no reconnect state without a loop that could reconnect'
+        finally:
+            await camera.disconnect()
+
+
+async def test_camera_connect_replaces_a_device_whose_loop_died(rosys_integration):
+    camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1:1', connect_after_init=False)
+    with stalled_mjpeg_stream():
+        await camera.connect()
+        try:
+            dead_device = camera.device
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')
+
+            await camera.connect()
+            assert camera.device is not dead_device, 'expected connect() to replace the dead device'
+            assert camera.is_active
+        finally:
+            await camera.disconnect()
+
+
+async def test_mjpeg_device_state_survives_a_dying_zombie_session(rosys_integration):
+    """A replaced capture task must not report its own end as the state of the loop that replaced it."""
+    device = MjpegDevice(GOODCAM_MAC, '127.0.0.1:1', on_new_image_data=lambda data, timestamp: None)
+    try:
+        device._state = CaptureState.STREAMING  # pylint: disable=protected-access
+        device._set_state(CaptureState.CONNECTING)  # pylint: disable=protected-access
+        assert device.is_connected, 'expected a foreign task not to change the state of the live loop'
+    finally:
+        await device.shutdown()
+
+
+async def test_rtsp_shutdown_reraises_a_cancellation_of_its_caller(rosys_integration):
+    with stalled_rtsp_stream():
+        device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
+                            on_new_image_data=lambda array, timestamp: None)
+        try:
+            device._capture_task = background_tasks.create(  # pylint: disable=protected-access
+                _survives_one_cancellation(), name=f'capture {GOODCAM_MAC}')
+            await asyncio.sleep(0)
+
+            caller = background_tasks.create(device.shutdown(), name='shutdown caller')
+            await asyncio.sleep(0)
+            caller.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await caller
+        finally:
+            for task in asyncio.all_tasks():
+                if task.get_name() == f'capture {GOODCAM_MAC}':
+                    task.cancel()
+
+
+@pytest.mark.parametrize('mac, expected_type', [
+    (AXIS_MAC, AxisMjpegDevice),
+    (MOTEC_MAC, MotecMjpegDevice),
+    (ARKVISION_MAC, ArkVisionMjpegDevice),
+    (OPENIPC_ZAUBERZEUG_MAC, OpenIpcZauberzeugMjpegDevice),
+    (GOODCAM_MAC, MjpegDevice),
+    (UNKNOWN_VENDOR_MAC, MjpegDevice),
+])
+async def test_mjpeg_device_factory_builds_the_vendor_device(rosys_integration, mac: str, expected_type: type):
+    with stalled_mjpeg_stream():
+        device = MjpegDeviceFactory.create(mac, '127.0.0.1:1',
+                                           on_new_image_data=lambda data, timestamp: None,
+                                           reconnect_interval=4.0)
+        try:
+            assert type(device) is expected_type
+            assert device.reconnect_interval == 4.0, 'expected the factory to forward the reconnect interval'
+        finally:
+            await device.shutdown()
+
+
+async def test_mjpeg_device_factory_warns_about_an_unknown_vendor(rosys_integration, vision_log):
+    with stalled_mjpeg_stream():
+        device = MjpegDeviceFactory.create(UNKNOWN_VENDOR_MAC, '127.0.0.1:1',
+                                           on_new_image_data=lambda data, timestamp: None)
+        try:
+            assert [record for record in vision_log.records if 'no stream URL known' in record.getMessage()], \
+                'expected the factory to say that this camera cannot be reached'
+        finally:
+            await device.shutdown()
+
+
+def test_settings_of_a_camera_without_an_address_raise_a_domain_error():
+    device = ArkVisionMjpegDevice.__new__(ArkVisionMjpegDevice)
+    device._mac = ARKVISION_MAC  # pylint: disable=protected-access
+    device._ip = None  # pylint: disable=protected-access
+    with pytest.raises(CameraAddressUnknown):
+        _ = device.settings_interface
+
+
+async def test_mjpeg_device_reports_a_missing_address_without_a_traceback(rosys_integration, vision_log):
+    async def unknown_address(self) -> None:
+        raise CameraAddressUnknown('no address')
+
+    with patch.object(MjpegDevice, '_run_session', unknown_address):
+        device = MjpegDevice(GOODCAM_MAC, '127.0.0.1:1', on_new_image_data=lambda data, timestamp: None,
+                             reconnect_interval=0.2)
+        try:
+            await forward_until(lambda: any('no address known yet' in record.getMessage()
+                                            for record in vision_log.records),
+                                step=0.1, real_step=0.02,
+                                message='device did not report the missing address')
+            assert not [record for record in vision_log.records if record.exc_info], \
+                'expected a missing address to be reported without a traceback'
+        finally:
+            await device.shutdown()
+
+
+async def test_a_device_being_torn_down_is_not_restarted(rosys_integration):
+    """`shutdown()` awaits its capture task, so a restart landing in that window must not revive it."""
+    with stalled_rtsp_stream():
+        device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
+                            on_new_image_data=lambda array, timestamp: None)
+        await asyncio.sleep(0)
+        assert device.is_active
+
+        async def restart_while_shutting_down() -> None:
+            await asyncio.sleep(0)
+            device._start_capture_task()  # pylint: disable=protected-access
+
+        await asyncio.gather(device.shutdown(), restart_while_shutting_down())
+        assert not device.is_active, 'expected the device to stay down while it was being torn down'

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from nicegui import background_tasks
-from rosys.vision.reconnect import MAX_RECONNECT_INTERVAL, MIN_RECONNECT_INTERVAL
 
 import rosys
 from rosys.testing import forward
@@ -16,6 +15,7 @@ from rosys.vision.mjpeg_camera.mjpeg_device import CameraAddressUnknown, Capture
 from rosys.vision.mjpeg_camera.mjpeg_device_factory import MjpegDeviceFactory
 from rosys.vision.mjpeg_camera.motec_mjpeg_device import MotecMjpegDevice
 from rosys.vision.mjpeg_camera.openipc_zauberzeug_mjpeg_device import OpenIpcZauberzeugMjpegDevice
+from rosys.vision.reconnect import MAX_RECONNECT_INTERVAL, MIN_RECONNECT_INTERVAL
 from rosys.vision.rtsp_camera.rtsp_device import RtspDevice
 
 # A MAC that maps to a "GOODCAM" URL in both the RTSP and MJPEG vendor tables.

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -823,6 +823,24 @@ async def test_mjpeg_device_state_survives_a_dying_zombie_session(rosys_integrat
         await device.shutdown()
 
 
+async def test_a_capture_task_that_ignores_its_cancellation_keeps_the_device_active(rosys_integration):
+    """Otherwise `connect()` would start a second loop next to the one that is still running."""
+    with stalled_rtsp_stream():
+        device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
+                            on_new_image_data=lambda array, timestamp: None)
+        device.CANCEL_TIMEOUT = 0.05  # type: ignore[misc]
+        try:
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')
+            device._capture_task = background_tasks.create(  # pylint: disable=protected-access
+                _survives_one_cancellation(), name=f'capture {GOODCAM_MAC}')
+            await asyncio.sleep(0)
+
+            await device.shutdown()
+            assert device.is_active, 'expected the device to stay active while its capture task is still running'
+        finally:
+            await cancel_leftover_loops(f'capture {GOODCAM_MAC}')
+
+
 async def test_rtsp_shutdown_reraises_a_cancellation_of_its_caller(rosys_integration):
     with stalled_rtsp_stream():
         device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -18,8 +18,7 @@ from rosys.vision.mjpeg_camera.openipc_zauberzeug_mjpeg_device import OpenIpcZau
 from rosys.vision.reconnect import MAX_RECONNECT_INTERVAL, MIN_RECONNECT_INTERVAL
 from rosys.vision.rtsp_camera.rtsp_device import RtspDevice
 
-# A MAC that maps to a "GOODCAM" URL in both the RTSP and MJPEG vendor tables.
-# GOODCAM needs no settings interface, so the device is constructed without any network access.
+# GOODCAM has a URL in both the RTSP and MJPEG vendor tables and no settings interface, so no network access
 GOODCAM_MAC = '2c:6f:51:00:00:01'
 
 # A MAC that maps to AXIS, whose stream settings are part of the URL rather than a settings interface.
@@ -78,11 +77,8 @@ def connected_rtsp_stream():
 
 async def forward_until(condition, *, step: float = 0.3, real_step: float = 0.05,
                         attempts: int = 20, message: str = 'condition was not met') -> None:
-    """Advance simulated time in steps, yielding real time between them, until `condition` holds.
-
-    `rosys.testing.forward(until=...)` only yields via `asyncio.sleep(0)`, so it can exhaust its
-    timeout before real loopback sockets or `io_bound` threads have made any progress.
-    """
+    """Advance simulated time in steps, yielding real time between them, until `condition` holds."""
+    # forward(until=...) only yields via asyncio.sleep(0), too little for loopback sockets or io_bound threads
     for _ in range(attempts):
         if condition():
             return
@@ -111,11 +107,7 @@ def vision_log(rosys_integration: None, caplog: pytest.LogCaptureFixture):
 
 async def wait_in_real_time(condition, *, step: float = 0.02, attempts: int = 200,
                             message: str = 'condition was not met') -> None:
-    """Wait for `condition` without advancing simulated time.
-
-    `forward()` does not advance while a `rosys.run.cpu_bound` call is in flight, so a test that
-    holds one open has to wait in real time.
-    """
+    """Wait for `condition` without advancing simulated time, e.g. while a `cpu_bound` call blocks `forward()`."""
     for _ in range(attempts):
         if condition():
             return
@@ -129,10 +121,7 @@ def live_capture_tasks(name: str) -> list[asyncio.Task]:
 
 
 async def cancel_leftover_loops(name: str) -> None:
-    """Cancel the capture loops under this name and wait for them to end, as a crashing loop leaves them.
-
-    Also keeps a failing test from leaving a loop behind that would hold up the next one.
-    """
+    """Cancel the capture loops under this name and wait for them to end, as a crashing loop leaves them."""
     tasks = live_capture_tasks(name)
     for task in tasks:
         task.cancel()
@@ -142,11 +131,7 @@ async def cancel_leftover_loops(name: str) -> None:
 
 
 class SlowFirstDecode:
-    """Stand-in for `nicegui.run.cpu_bound` that stalls its first call.
-
-    `rosys.run.cpu_bound` turns a cancellation during the call into a `None` result instead of
-    raising, so this is where a shutdown or an address change lands while a frame is being decoded.
-    """
+    """Stand-in for `nicegui.run.cpu_bound` that stalls its first call."""
 
     def __init__(self, seconds: float = 0.3) -> None:
         self.seconds = seconds
@@ -169,11 +154,7 @@ async def decode_frame(data: bytes, timestamp: float) -> None:  # pylint: disabl
 
 
 class FlakyMjpegServer:
-    """Local HTTP server that serves `frames_per_connection` fake JPEG frames and then drops the connection.
-
-    One frame per connection mimics a camera whose stream keeps ending; `None` keeps the stream open.
-    Any `status` other than 200 is answered instead of a stream.
-    """
+    """Local HTTP server that drops the connection after `frames_per_connection` fake JPEG frames (``None``: never)."""
 
     def __init__(self, frames_per_connection: int | None = 1, status: int = 200) -> None:
         self.connections = 0

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -679,7 +679,7 @@ async def test_mjpeg_provider_adds_and_connects_new_camera(rosys_integration):
         await asyncio.sleep(0.05)  # let the camera's own connect task run
         assert camera.is_active, 'expected a discovered camera to connect on its own'
         assert camera.ip == '127.0.0.1:1'
-        await provider.shutdown()
+        await camera.disconnect()
 
 
 async def test_mjpeg_provider_rebinds_moved_camera(rosys_integration):
@@ -698,7 +698,7 @@ async def test_mjpeg_provider_rebinds_moved_camera(rosys_integration):
         assert camera.device is old_device, 'expected the device to be rebound rather than torn down'
         assert camera.device is not None and '127.0.0.1:2' in (camera.device.url or '')
         assert camera.is_active
-        await provider.shutdown()
+        await camera.disconnect()
 
 
 async def test_mjpeg_provider_supplies_ip_to_pending_camera(rosys_integration):
@@ -717,7 +717,7 @@ async def test_mjpeg_provider_supplies_ip_to_pending_camera(rosys_integration):
         assert camera.device is not None and '127.0.0.1:1' in (camera.device.url or ''), \
             'expected the device to pick up the discovered address'
         assert camera.is_active
-        await provider.shutdown()
+        await camera.disconnect()
 
 
 async def test_mjpeg_provider_leaves_disconnected_camera_alone(rosys_integration):
@@ -752,7 +752,7 @@ async def test_rtsp_provider_rebinds_moved_camera(rosys_integration):
         assert camera.device is old_device, 'expected the device to be rebound rather than torn down'
         assert camera.device is not None and '192.168.0.6' in (camera.device.url or '')
         assert camera.is_active
-        await provider.shutdown()
+        await camera.disconnect()
 
 
 async def test_camera_clamps_a_reconnect_interval_that_would_not_wait(rosys_integration):

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -761,7 +761,7 @@ async def test_camera_clamps_a_reconnect_interval_that_would_not_wait(rosys_inte
         assert camera.reconnect_interval == MIN_RECONNECT_INTERVAL, 'expected the camera to clamp the interval'
 
 
-async def test_camera_passes_its_reconnect_interval_to_a_replaced_device(rosys_integration):
+async def test_camera_passes_its_reconnect_interval_to_its_device(rosys_integration):
     """The interval belongs to the camera, not to whichever device happens to exist."""
     camera = MjpegCamera(id=GOODCAM_MAC, ip='127.0.0.1:1', connect_after_init=False)
     camera.reconnect_interval = 7.0
@@ -770,6 +770,8 @@ async def test_camera_passes_its_reconnect_interval_to_a_replaced_device(rosys_i
         try:
             assert camera.device is not None
             assert camera.device.reconnect_interval == 7.0
+            camera.reconnect_interval = 9.0
+            assert camera.device.reconnect_interval == 9.0, 'expected a live device to follow the camera'
         finally:
             await camera.disconnect()
 

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -364,17 +364,17 @@ async def test_rtsp_device_backs_off_after_rejected_login(rosys_integration):
     async def unauthorized_gstreamer(self) -> None:
         nonlocal sessions
         sessions += 1
-        self._authorized = False  # pylint: disable=protected-access
+        self._set_state(CaptureState.REFUSED)  # pylint: disable=protected-access
 
     with patch.object(RtspDevice, '_run_session', unauthorized_gstreamer):
         device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
                             on_new_image_data=lambda array, timestamp: None,
                             reconnect_interval=0.2)
-        device.UNAUTHORIZED_RECONNECT_INTERVAL = 4.0  # type: ignore[misc]
+        device.REFUSED_RECONNECT_INTERVAL = 4.0  # type: ignore[misc]
         try:
             await forward(0.5)
             assert sessions == 1, f'expected the device to throttle its retries, got {sessions} sessions'
-            assert device.authorized is False, 'expected the device to mark itself unauthorized'
+            assert device.is_refused, 'expected the device to mark itself refused'
             assert device.is_active is True, 'expected the capture loop to stay alive while backing off'
 
             await forward(4.0)
@@ -742,7 +742,7 @@ async def test_camera_passes_its_reconnect_interval_to_a_replaced_device(rosys_i
 def test_no_wait_between_attempts_exceeds_the_cap():
     """A refused camera must be picked up as soon as it answers again, like any other retry."""
     assert MjpegDevice.REFUSED_RECONNECT_INTERVAL <= MAX_RECONNECT_INTERVAL
-    assert RtspDevice.UNAUTHORIZED_RECONNECT_INTERVAL <= MAX_RECONNECT_INTERVAL
+    assert RtspDevice.REFUSED_RECONNECT_INTERVAL <= MAX_RECONNECT_INTERVAL
 
 
 async def test_camera_is_not_active_once_its_capture_loop_died(rosys_integration):

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -16,7 +16,7 @@ from rosys.vision.mjpeg_camera.mjpeg_device_factory import MjpegDeviceFactory
 from rosys.vision.mjpeg_camera.motec_mjpeg_device import MotecMjpegDevice
 from rosys.vision.mjpeg_camera.openipc_zauberzeug_mjpeg_device import OpenIpcZauberzeugMjpegDevice
 from rosys.vision.reconnect import MAX_RECONNECT_INTERVAL, MIN_RECONNECT_INTERVAL
-from rosys.vision.rtsp_camera.rtsp_device import RtspDevice
+from rosys.vision.rtsp_camera.rtsp_device import GDPPACKET_FORMAT, GDPPayloadType, RtspDevice
 
 # GOODCAM has a URL in both the RTSP and MJPEG vendor tables and no settings interface, so no network access
 GOODCAM_MAC = '2c:6f:51:00:00:01'
@@ -48,26 +48,31 @@ def stalled_rtsp_stream():
 
 
 class FakeGstreamerProcess:
-    """Stand-in for the gstreamer process, so a device reports `is_connected` without spawning one."""
+    """Stand-in for the gstreamer process; the test feeds its stdout with GDP packets."""
 
     def __init__(self) -> None:
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
         self.returncode: int | None = None
+        self.pid = 4711
 
     def terminate(self) -> None:
         self.returncode = -15
+        self.stdout.feed_eof()
+        self.stderr.feed_eof()
 
     async def wait(self) -> int | None:
         return self.returncode
 
 
+def gdp_packet(payload_type: GDPPayloadType, payload: bytes) -> bytes:
+    return GDPPACKET_FORMAT.pack(1, b'\x00', payload_type.value, len(payload), 0, 0, 0, 0, 0, bytes(14), 0, 0) + payload
+
+
 async def _connected_rtsp_stream(self) -> None:
-    """Stand-in for a gstreamer session that comes up and reapplies parameters, but spawns nothing."""
-    self._capture_process = FakeGstreamerProcess()  # pylint: disable=protected-access
-    try:
-        await self._invoke_on_connect()  # pylint: disable=protected-access
-        await rosys.sleep(60.0)
-    finally:
-        self._capture_process = None  # pylint: disable=protected-access
+    """Stand-in for a gstreamer session that delivers frames and reapplies parameters, but spawns nothing."""
+    await self._enter_streaming()  # pylint: disable=protected-access
+    await rosys.sleep(60.0)
 
 
 def connected_rtsp_stream():
@@ -243,7 +248,7 @@ async def test_rtsp_device_reconnects_until_shutdown(rosys_integration):
                             reconnect_interval=0.2)
         await forward(2.0)
         assert sessions >= 3, f'device did not reconnect (only {sessions} sessions)'
-        assert device.is_active  # loop alive; is_connected is False here because the stubbed gstreamer opens no process
+        assert device.is_active  # loop alive; is_connected is False here because the stubbed session delivers no frame
 
         await device.shutdown()
         assert not device.is_active
@@ -413,6 +418,35 @@ async def test_mjpeg_device_keeps_streaming_when_on_connect_fails(rosys_integrat
         await server.stop()
 
 
+async def test_rtsp_device_is_connected_once_the_first_frame_arrives(rosys_integration):
+    process = FakeGstreamerProcess()
+    frames: list = []
+    connect_calls = 0
+
+    def count_connect() -> None:
+        nonlocal connect_calls
+        connect_calls += 1
+
+    with patch('asyncio.create_subprocess_exec', AsyncMock(return_value=process)):
+        device = RtspDevice(GOODCAM_MAC, '192.168.0.5', substream=0, fps=5,
+                            on_new_image_data=lambda array, timestamp: frames.append(array),
+                            on_connect=count_connect)
+        try:
+            await asyncio.sleep(0.05)
+            assert device.is_active
+            assert not device.is_connected, 'expected no connection while gstreamer has not delivered a frame'
+            assert connect_calls == 0, 'expected on_connect to wait for the first frame'
+
+            process.stdout.feed_data(gdp_packet(GDPPayloadType.CAPS, b'video/x-raw, width=(int)2, height=(int)2'))
+            process.stdout.feed_data(gdp_packet(GDPPayloadType.BUFFER, bytes(2 * 2 * 3)))
+            await wait_in_real_time(lambda: len(frames) == 1, message='expected the frame to reach the callback')
+            assert device.is_connected
+            assert connect_calls == 1
+        finally:
+            await device.shutdown()
+        assert not device.is_connected
+
+
 async def test_rtsp_camera_restarts_stream_on_set_parameters_but_not_on_reapply(rosys_integration):
     camera = RtspCamera(mac=GOODCAM_MAC, ip='192.168.0.5', connect_after_init=False)
     with connected_rtsp_stream(), \
@@ -434,8 +468,7 @@ async def test_axis_camera_applies_parameters_without_restarting_its_own_session
     async def stream(self) -> None:
         nonlocal sessions
         sessions += 1
-        self._state = CaptureState.STREAMING  # pylint: disable=protected-access
-        await self._invoke_on_connect()  # pylint: disable=protected-access
+        await self._enter_streaming()  # pylint: disable=protected-access
         await rosys.sleep(60.0)
 
     camera = MjpegCamera(id=AXIS_MAC, ip='192.168.0.5', fps=12, connect_after_init=False)

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -392,6 +392,27 @@ async def test_mjpeg_device_invokes_on_connect_per_session(rosys_integration):
         await server.stop()
 
 
+async def test_mjpeg_device_keeps_streaming_when_on_connect_fails(rosys_integration, vision_log):
+    server = FlakyMjpegServer(frames_per_connection=None)
+    await server.start()
+    frames: list[bytes] = []
+
+    def failing_on_connect() -> None:
+        raise RuntimeError('settings endpoint down')
+
+    device = MjpegDevice(GOODCAM_MAC, f'127.0.0.1:{server.port}',
+                         on_new_image_data=lambda data, timestamp: frames.append(data),
+                         on_connect=failing_on_connect,
+                         reconnect_interval=0.2)
+    try:
+        await forward_until(lambda: len(frames) >= 3, message='expected frames despite the failing on_connect')
+        assert server.connections == 1, 'expected the failing on_connect not to end the session'
+        assert [record for record in vision_log.records if 'on_connect callback failed' in record.getMessage()]
+    finally:
+        await device.shutdown()
+        await server.stop()
+
+
 async def test_rtsp_camera_restarts_stream_on_set_parameters_but_not_on_reapply(rosys_integration):
     camera = RtspCamera(mac=GOODCAM_MAC, ip='192.168.0.5', connect_after_init=False)
     with connected_rtsp_stream(), \


### PR DESCRIPTION
> **Stack** (supersedes #423; review bottom-up, each PR is based on the one above it):
> 1. #470 — vision I/O helpers
> 2. #471 — RTSP and MJPEG reconnection **(this PR)**
> 3. #472 — USB and simulated reconnection

### Motivation

Cameras lose their connection due to network glitches, a bad cable or a power hiccup.
Today a dropped connection ends the device's capture task for good, so the only way back is a full `CameraProvider` scan, which is heavy and, with `auto_scan=False`, may also surface cameras we deliberately don't want connected (common in test and development setups).

This supersedes #423: reconnection lives **inside each device**, where the connection already lives, and providers are no longer involved in reconnection at all.
The review feedback on #423 is folded in; the branch was split so the RTSP/MJPEG core can be reviewed on its own, with USB and simulated cameras following in the next PR of the stack.

We also introduce a base class for devices (see implementation section) to share the new funcitonality more directly.

### Implementation

**One self-healing loop for all devices.**
The new `CaptureDevice` base (`rosys/vision/capture_device.py`) runs one capture session at a time and reopens the stream `reconnect_interval` seconds (default 3.0) after a session ends or fails, until `shutdown()` tears it down.
Subclasses only supply `_run_session()` and say how the camera is reached.
The loop is a small state machine (`CaptureState`: `CONNECTING` / `STREAMING` / `REFUSED` / `STOPPED`).

**Backoff on explicit refusals by the camera**
When the camera answers without a stream (MJPEG: any non-200 response after the auth handshake; RTSP: `Unauthorized` on gstreamer's stderr), the device enters `REFUSED` and backs off to one attempt every 30 s (`MAX_RECONNECT_INTERVAL`) instead of giving up.
It stays `is_active` and recovers on its own once the answer changes. The most likely cause is that someone edits credentials on the camera or that its ip is corrected.

**Uniform connection-state contract** across devices and cameras:

- `is_connected`: the camera is actually delivering frames right now.
- `is_active`: a connection is wanted, i.e. the self-healing loop is alive (streaming or waiting to reconnect).
- `is_reconnecting`: `is_active and not is_connected`.

`connect()` and `disconnect()` keep their semantics: `connect()` creates the self-healing device (replacing one whose loop died), `disconnect()` stops the retries and tears it down.
`connect()` now always creates a device, even when no address is known yet; such a camera reports `is_active` but not `is_connected` and starts streaming as soon as the address appears.

**Providers only discover and rebind.**
`MjpegCameraProvider` and `RtspCameraProvider` no longer call `connect()`/`disconnect()`.
Their scan adds newly found cameras (which connect themselves via `connect_after_init`) and pushes a changed address into a running device through new `ip` setters; a deliberately disconnected camera is left alone even with `auto_scan` enabled.

**Supporting changes:**

- Back-off policy (`MIN_RECONNECT_INTERVAL`, `MAX_RECONNECT_INTERVAL`, `clamp_reconnect_interval`) lives in `rosys/vision/reconnect.py`, so devices do not depend on the camera base module.
  Every camera takes a `reconnect_interval`, clamps it to at least 0.1 s (zero would starve the event loop) and persists it in `to_dict()`.
- `url` becomes a derived, nullable property; `AxisMjpegDevice` derives its query string from `axis_settings` instead of patching a stored URL, and its setters no longer restart the session from inside the capture task (the frame loop notices the changed URL).
- `MjpegDeviceFactory` warns about an unknown vendor instead of raising; a camera whose settings have no address raises a domain error.
- `on_connect` fires once a session is actually connected, so parameters are really reapplied after every reconnect.
- Permanent misconfigurations (unknown vendor, missing address, refused stream) are logged once at `WARNING`/`ERROR` without a traceback, while the expected "waiting for an address" stays at `DEBUG`.

### Tests

`tests/test_camera_reconnect.py` covers the behavior without hardware:

- `MjpegDevice` against a local flaky HTTP server: reconnects after the stream drops, backs off after a `401` but retries at a new address, keeps one capture loop across an address change, stops streaming when shut down during a callback.
- `RtspDevice` with the gstreamer session stubbed: reconnects until `shutdown()`, backs off after a rejected login, keeps one loop across concurrent restarts, re-raises a cancellation of its caller.
- Camera/provider contract: `is_active` without a known address and while a login is rejected, `connect()` replaces a device whose loop died, providers add and connect new cameras, rebind moved cameras and leave disconnected ones alone.
- Policy: `reconnect_interval` is persisted, clamped and passed to a replaced device; no wait between attempts exceeds the cap.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5-1
