### PR TITLE
Reconnect USB and simulated cameras at the device level too

### DIFF
--- a/docs/examples/cameras/README.md
+++ b/docs/examples/cameras/README.md
@@ -47,6 +47,30 @@ It automatically updates every 0.1 seconds to detect and display new cameras, an
 {! examples/cameras/control.py !}
 ```
 
+## Automatic Reconnection
+
+Cameras can lose their connection due to network glitches, a bad cable or a power hiccup.
+Every camera reconnects on its own: once connected, the underlying device keeps trying to restore its stream every `reconnect_interval` seconds (default 3.0) for as long as the camera stays connected.
+The wait is owned by the camera, so it also applies to a device created later, and it is clamped to at least 0.1 s so a misconfigured `0` cannot starve the event loop.
+`RtspCamera` and `MjpegCamera` re-open their stream, `UsbCamera` re-opens the video device (even if its `/dev/video*` node changed), and `SimulatedCamera` resumes after a simulated drop.
+Reconnection runs until the camera is disconnected, so `disconnect()` both stops the retries and tears down the device.
+`is_connected` tells whether a camera is streaming right now, while `is_active` tells whether a connection is wanted at all, i.e. whether the camera keeps trying.
+`is_active` follows the device's capture loop rather than the mere existence of a device, so a camera whose loop died reports `is_active == False` and `connect()` replaces the device instead of returning early.
+
+`connect()` always creates that device, even when the camera cannot be reached at all — because its address is not known yet, or no `/dev/video*` node exists.
+Such a camera reports `is_active` but not `is_connected`, and starts streaming as soon as the address or the video device appears.
+
+A camera that answers without a stream is the one case where retrying is throttled instead of continuing at `reconnect_interval`:
+`RtspCamera` and `MjpegCamera` fall back to one attempt every 30 seconds, because the camera is reachable and has said no.
+Asking again a second later cannot change that answer, and some cameras answer repeated failed logins by locking the account.
+Such a camera stays active and recovers on its own once the answer changes.
+A camera's own `username` and `password` are read when its device is created, so use `reconnect()` to retry with changed credentials.
+
+Camera providers therefore do not connect or reconnect cameras themselves.
+Their periodic scan only discovers new cameras and hands a changed address (e.g. after a new DHCP lease) to the cameras it already knows, which the running device picks up for its next attempt.
+A newly discovered camera still connects on its own, because `connect_after_init` defaults to `True`.
+A deliberately disconnected camera stays disconnected, even with `auto_scan` enabled.
+
 ## Streaming RTSP Cameras
 
 The following example shows how to stream images from an RTSP camera.

--- a/docs/examples/cameras/README.md
+++ b/docs/examples/cameras/README.md
@@ -51,23 +51,13 @@ It automatically updates every 0.1 seconds to detect and display new cameras, an
 
 Cameras can lose their connection due to network glitches, a bad cable or a power hiccup.
 Every camera reconnects on its own: once connected, the underlying device keeps trying to restore its stream every `reconnect_interval` seconds (default 3.0) for as long as the camera stays connected.
-The wait is owned by the camera, so it also applies to a device created later, and it is clamped to at least 0.1 s so a misconfigured `0` cannot starve the event loop.
-`RtspCamera` and `MjpegCamera` re-open their stream, `UsbCamera` re-opens the video device (even if its `/dev/video*` node changed), and `SimulatedCamera` resumes after a simulated drop.
-Reconnection runs until the camera is disconnected, so `disconnect()` both stops the retries and tears down the device.
-`is_connected` tells whether a camera is streaming right now, while `is_active` tells whether a connection is wanted at all, i.e. whether the camera keeps trying.
-`is_active` follows the device's capture loop rather than the mere existence of a device, so a camera whose loop died reports `is_active == False` and `connect()` replaces the device instead of returning early.
+Reconnection runs until the camera is disconnected, so `disconnect()` both stops the retries and tears down the device connection.
+`is_connected` tells whether a camera is streaming right now, while `is_active` tells whether a connection is wanted at all, i.e. whether the camera keeps trying to reconnect.
 
-`connect()` always creates that device, even when the camera cannot be reached at all — because its address is not known yet, or no `/dev/video*` node exists.
+`connect()` always creates a Device, even when the camera cannot be reached at all — because its address is not known yet, or no `/dev/video*` node exists.
 Such a camera reports `is_active` but not `is_connected`, and starts streaming as soon as the address or the video device appears.
 
-A camera that answers without a stream is the one case where retrying is throttled instead of continuing at `reconnect_interval`:
-`RtspCamera` and `MjpegCamera` fall back to one attempt every 30 seconds, because the camera is reachable and has said no.
-Asking again a second later cannot change that answer, and some cameras answer repeated failed logins by locking the account.
-Such a camera stays active and recovers on its own once the answer changes.
-A camera's own `username` and `password` are read when its device is created, so use `reconnect()` to retry with changed credentials.
-
-Camera providers therefore do not connect or reconnect cameras themselves.
-Their periodic scan only discovers new cameras and hands a changed address (e.g. after a new DHCP lease) to the cameras it already knows, which the running device picks up for its next attempt.
+Camera providers therefore do not reconnect cameras themselves.
 A newly discovered camera still connects on its own, because `connect_after_init` defaults to `True`.
 A deliberately disconnected camera stays disconnected, even with `auto_scan` enabled.
 

--- a/docs/examples/cameras/README.md
+++ b/docs/examples/cameras/README.md
@@ -50,7 +50,7 @@ It automatically updates every 0.1 seconds to detect and display new cameras, an
 ## Automatic Reconnection
 
 Cameras can lose their connection due to network glitches, a bad cable or a power hiccup.
-Every camera reconnects on its own: once connected, the underlying device keeps trying to restore its stream every `reconnect_interval` seconds (default 3.0) for as long as the camera stays connected.
+Every camera reconnects on its own: after `connect()`, the underlying device keeps trying to restore its stream every `reconnect_interval` seconds (default 3.0) for as long as the camera stays active.
 Reconnection runs until the camera is disconnected, so `disconnect()` both stops the retries and tears down the device connection.
 `is_connected` tells whether a camera is streaming right now, while `is_active` tells whether a connection is wanted at all, i.e. whether the camera keeps trying to reconnect.
 

--- a/docs/examples/cameras/control.py
+++ b/docs/examples/cameras/control.py
@@ -18,8 +18,10 @@ def add_card(camera: rosys.vision.Camera, container: ui.element) -> None:
                     streams[uid] = ui.interactive_image()
                     ui.label(uid).classes('m-2')
                     with ui.row():
+                        ui.button('connect', on_click=camera.connect) \
+                            .bind_enabled_from(camera, 'is_active', backward=lambda active: not active)
                         ui.button('disconnect', on_click=camera.disconnect) \
-                            .bind_enabled_from(camera, 'is_connected')
+                            .bind_enabled_from(camera, 'is_active')
                     if isinstance(camera, rosys.vision.ConfigurableCamera):
                         create_camera_settings_panel(camera)
 
@@ -39,7 +41,7 @@ def create_camera_settings_panel(camera: rosys.vision.ConfigurableCamera) -> Non
     camera_parameters = camera.get_capabilities()
     parameter_names = [parameter.name for parameter in camera_parameters]
     with ui.expansion('Settings').classes('w-full') \
-            .bind_enabled_from(camera, 'is_connected'):
+            .bind_enabled_from(camera, 'is_active'):
         if isinstance(camera, rosys.vision.RtspCamera):
             ui.label('URL') \
                 .bind_text_from(camera, 'url',

--- a/rosys/vision/camera/camera.py
+++ b/rosys/vision/camera/camera.py
@@ -11,6 +11,7 @@ from typing import Any, ClassVar, Self
 from nicegui import Event
 
 from ... import rosys
+from ..capture_device import CaptureDevice
 from ..image import Image
 from ..image_route import create_image_route
 from ..reconnect import MIN_RECONNECT_INTERVAL, clamp_reconnect_interval
@@ -39,6 +40,7 @@ class Camera(abc.ABC):
         self.id: str = id
         self.name = name or self.id
         self.connect_after_init = connect_after_init
+        self.device: CaptureDevice | None = None
         self._reconnect_interval = MIN_RECONNECT_INTERVAL
         self.reconnect_interval = reconnect_interval
         self.images: deque[Image] = deque(maxlen=Camera.IMAGE_HISTORY_LENGTH)
@@ -69,8 +71,10 @@ class Camera(abc.ABC):
         self._reconnect_interval = clamp_reconnect_interval(interval, logger)
         self._apply_reconnect_interval()
 
-    def _apply_reconnect_interval(self) -> None:  # noqa: B027
+    def _apply_reconnect_interval(self) -> None:
         """Forward `reconnect_interval` to a live device."""
+        if self.device is not None:
+            self.device.reconnect_interval = self.reconnect_interval
 
     @property
     def streaming(self) -> bool:

--- a/rosys/vision/mjpeg_camera/mjpeg_camera.py
+++ b/rosys/vision/mjpeg_camera/mjpeg_camera.py
@@ -70,10 +70,6 @@ class MjpegCamera(TransformableCamera, ConfigurableCamera):
         if self.device is not None:
             self.device.ip = ip
 
-    def _apply_reconnect_interval(self) -> None:
-        if self.device is not None:
-            self.device.reconnect_interval = self.reconnect_interval
-
     async def connect(self) -> None:
         async with self._device_connection():
             if self.device is not None:

--- a/rosys/vision/rtsp_camera/rtsp_camera.py
+++ b/rosys/vision/rtsp_camera/rtsp_camera.py
@@ -80,10 +80,6 @@ class RtspCamera(ConfigurableCamera, TransformableCamera):
         if self.device is not None:
             self.device.ip = ip
 
-    def _apply_reconnect_interval(self) -> None:
-        if self.device is not None:
-            self.device.reconnect_interval = self.reconnect_interval
-
     @property
     def url(self) -> str | None:
         if self.device is None:

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -21,6 +21,7 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
                  height: int | None = None,
                  color: str | None = None,
                  fps: int = 5,
+                 simulate_failing: bool = False,
                  **kwargs,
                  ) -> None:
         super().__init__(id=id,
@@ -30,6 +31,7 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
         self.device: SimulatedDevice | None = None
         if width is not None or height is not None:
             resolution = (width or resolution[0], height or resolution[1])
+        self.simulate_failing = simulate_failing
         self._register_parameter('resolution', self._get_resolution, self._set_resolution, resolution)
         self._register_parameter('color', self._get_color, self._set_color,
                                  color or f'#{random.randint(0, 0xffffff):06x}')
@@ -50,16 +52,36 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
 
     @property
     def is_connected(self) -> bool:
-        return self.device is not None
+        return self.device is not None and self.device.is_connected
+
+    @property
+    def is_active(self) -> bool:
+        return self.device is not None and self.device.is_active
 
     async def connect(self) -> None:
-        if not self.is_connected:
+        async with self._device_connection():
+            if self.device is not None:
+                if self.device.is_active:
+                    return
+                await self._tear_down_device()
             width, height = self.parameters['resolution']
             self.device = SimulatedDevice(id=self.id, size=ImageSize(width=width, height=height),
-                                          fps=self.parameters['fps'], on_new_image=self._add_image)
+                                          fps=self.parameters['fps'],
+                                          on_new_image=self._add_image,
+                                          on_connect=self._apply_all_parameters,
+                                          reconnect_interval=self.reconnect_interval,
+                                          simulate_failing=self.simulate_failing)
             await self._apply_all_parameters()
 
     async def disconnect(self) -> None:
+        async with self._device_connection():
+            await self._tear_down_device()
+
+    async def _tear_down_device(self) -> None:
+        """Tear down the device. The caller must hold `device_connection_lock`."""
+        if self.device is None:
+            return
+        await self.device.shutdown()
         self.device = None
 
     def _set_resolution(self, value: tuple[int, int]) -> None:

--- a/rosys/vision/simulated_camera/simulated_camera.py
+++ b/rosys/vision/simulated_camera/simulated_camera.py
@@ -71,7 +71,6 @@ class SimulatedCamera(ConfigurableCamera, TransformableCamera):
                                           on_connect=self._apply_all_parameters,
                                           reconnect_interval=self.reconnect_interval,
                                           simulate_failing=self.simulate_failing)
-            await self._apply_all_parameters()
 
     async def disconnect(self) -> None:
         async with self._device_connection():

--- a/rosys/vision/simulated_camera/simulated_camera_provider.py
+++ b/rosys/vision/simulated_camera/simulated_camera_provider.py
@@ -1,5 +1,6 @@
 import warnings
 
+from ...helpers.deprecation import deprecated_param
 from ..camera_provider import CameraProvider
 from .simulated_camera import SimulatedCamera
 
@@ -10,7 +11,10 @@ class SimulatedCameraProvider(CameraProvider[SimulatedCamera]):
     In the current implementation the images only contain the camera ID and the current time.
     """
 
-    def __init__(self, *, simulate_failing: bool = False) -> None:
+    @deprecated_param('auto_scan')
+    def __init__(self, *,
+                 simulate_failing: bool = False,
+                 auto_scan: bool = True) -> None:  # pylint: disable=unused-argument
         super().__init__()
 
         self.simulate_failing = simulate_failing

--- a/rosys/vision/simulated_camera/simulated_camera_provider.py
+++ b/rosys/vision/simulated_camera/simulated_camera_provider.py
@@ -1,8 +1,5 @@
-import random
-from collections.abc import AsyncGenerator
-from typing import Any
+import warnings
 
-from ... import rosys
 from ..camera_provider import CameraProvider
 from .simulated_camera import SimulatedCamera
 
@@ -12,61 +9,34 @@ class SimulatedCameraProvider(CameraProvider[SimulatedCamera]):
 
     In the current implementation the images only contain the camera ID and the current time.
     """
-    SCAN_INTERVAL = 10
 
-    def __init__(self, *,
-                 simulate_failing: bool = False,
-                 auto_scan: bool = True) -> None:
+    def __init__(self, *, simulate_failing: bool = False) -> None:
         super().__init__()
 
-        self.simulate_device_failure = simulate_failing
+        self.simulate_failing = simulate_failing
 
-        if auto_scan:
-            rosys.on_repeat(self.update_device_list, self.SCAN_INTERVAL)
+    @property
+    def simulate_device_failure(self) -> bool:
+        warnings.warn('`simulate_device_failure` is deprecated, use `simulate_failing` instead.',
+                      DeprecationWarning, stacklevel=2)
+        return self.simulate_failing
 
-    def backup_to_dict(self) -> dict:
-        cameras = {}
-        for camera in self._cameras.values():
-            cameras[camera.id] = camera.to_dict()
-        return {}
+    @simulate_device_failure.setter
+    def simulate_device_failure(self, value: bool) -> None:
+        warnings.warn('`simulate_device_failure` is deprecated, use `simulate_failing` instead.',
+                      DeprecationWarning, stacklevel=2)
+        self.simulate_failing = value
 
     def restore_from_dict(self, data: dict[str, dict]) -> None:
         for camera_data in data.get('cameras', {}).values():
             camera = SimulatedCamera.from_dict(camera_data)
             self.add_camera(camera)
 
-    async def scan_for_cameras(self) -> AsyncGenerator[str, Any]:
-        """Simulated device discovery by returning all camera's IDs.
-
-        If simulate_device_failure is set, disconnected cameras are returned with a fixed probability.
-        """
-        for camera in self._cameras.values():
-            if not camera.is_connected and self.simulate_device_failure:
-                # return camera with fixed probability
-                if random.random() < 0.5:
-                    yield camera.id
-            else:
-                yield camera.id
-
     async def update_device_list(self) -> None:
-        async for camera_id in self.scan_for_cameras():
-            camera = self._cameras.get(camera_id)
-            if not camera:
-                camera = SimulatedCamera(id=camera_id, resolution=(640, 480))
-                self.add_camera(camera)
-
-            if not camera.is_connected:
-                await camera.connect()
-                continue
-            assert camera.device is not None
-
-            if self.simulate_device_failure:
-                # disconnect cameras randomly with probability rising with time
-                time_since_last_activation = rosys.time() - camera.device.creation_time
-                if random.random() < time_since_last_activation / 30.0:
-                    await camera.disconnect()
+        """Simulated cameras are created explicitly with `add_cameras`, so there is nothing to discover."""
 
     def add_cameras(self, num_cameras: int) -> None:
         for _ in range(num_cameras):
             new_id = f'cam{len(self._cameras)}'
-            self.add_camera(SimulatedCamera(id=new_id, resolution=(640, 480)))
+            self.add_camera(SimulatedCamera(id=new_id, resolution=(640, 480),
+                                            simulate_failing=self.simulate_failing))

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -1,3 +1,5 @@
+import logging
+import random
 from collections.abc import Awaitable, Callable
 
 import numpy as np
@@ -6,29 +8,55 @@ import PIL.ImageDraw
 
 from ... import rosys
 from ...geometry import Point
+from ..capture_device import CaptureDevice, CaptureState
 from ..image import Image, ImageSize
 
+MEAN_TIME_TO_FAILURE = 30.0
+"""Average seconds a simulated stream survives while `simulate_failing` is set."""
 
-class SimulatedDevice:
+
+class SimulatedDevice(CaptureDevice):
 
     def __init__(self,
                  id: str,  # pylint: disable=redefined-builtin
                  *,
                  size: ImageSize,
                  on_new_image: Callable[[Image], Awaitable | None],
+                 on_connect: Callable[[], Awaitable | None] | None = None,
                  color: str = '#ffffff',
-                 fps: float = 30.0) -> None:
+                 fps: float = 30.0,
+                 reconnect_interval: float = 3.0,
+                 simulate_failing: bool = False) -> None:
+        super().__init__(name=id,
+                         log=logging.getLogger('rosys.vision.simulated_camera.simulated_device.' + id),
+                         on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
         self._id = id
         self.size = size
         self.color = color
         self._on_new_image = on_new_image
-        self._creation_time: float = rosys.time()
+        self.simulate_failing = simulate_failing
+        self._frame_interval = 1.0 / fps
 
-        self._repeater = rosys.on_repeat(self._create_image, interval=1.0 / fps)
+        self._start_capture_task()
+        self._state = CaptureState.STREAMING  # a simulated camera is reachable the moment it exists
 
-    @property
-    def creation_time(self) -> float:
-        return self._creation_time
+    def disconnect(self) -> None:
+        """Simulate a connection loss (e.g. a bad cable); the device reconnects itself after `reconnect_interval`."""
+        if self._state is CaptureState.STREAMING:
+            self._state = CaptureState.CONNECTING
+
+    async def _run_session(self) -> None:
+        await self._enter_streaming()
+        session_start = rosys.time()
+        while self._keeps_running() and self.is_connected:
+            await rosys.sleep(self._frame_interval)
+            if not self.is_connected:
+                break
+            if self.simulate_failing and \
+                    random.random() < (rosys.time() - session_start) / MEAN_TIME_TO_FAILURE * self._frame_interval:
+                return
+            await self._create_image()
 
     async def _create_image(self) -> None:
         timestamp = rosys.time()
@@ -42,10 +70,10 @@ class SimulatedDevice:
             await result
 
     def set_fps(self, fps: float) -> None:
-        self._repeater.interval = 1.0 / fps
+        self._frame_interval = 1.0 / fps
 
     def get_fps(self) -> float:
-        return 1.0 / self._repeater.interval
+        return 1.0 / self._frame_interval
 
 
 def _create_image_data(id: str, size: ImageSize, color: str, timestamp: float) -> Image:  # pylint: disable=redefined-builtin

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -48,13 +48,11 @@ class SimulatedDevice(CaptureDevice):
 
     async def _run_session(self) -> None:
         await self._enter_streaming()
-        session_start = rosys.time()
         while self._keeps_running() and self.is_connected:
             await rosys.sleep(self._frame_interval)
             if not self.is_connected:
                 break
-            if self.simulate_failing and \
-                    random.random() < (rosys.time() - session_start) / MEAN_TIME_TO_FAILURE * self._frame_interval:
+            if self.simulate_failing and random.random() < self._frame_interval / MEAN_TIME_TO_FAILURE:
                 return
             await self._create_image()
 

--- a/rosys/vision/simulated_camera/simulated_device.py
+++ b/rosys/vision/simulated_camera/simulated_device.py
@@ -41,8 +41,8 @@ class SimulatedDevice(CaptureDevice):
         self._start_capture_task()
         self._state = CaptureState.STREAMING  # a simulated camera is reachable the moment it exists
 
-    def disconnect(self) -> None:
-        """Simulate a connection loss (e.g. a bad cable); the device reconnects itself after `reconnect_interval`."""
+    def simulate_connection_loss(self) -> None:
+        """Drop the stream as a bad cable would; the device reconnects itself after `reconnect_interval`."""
         if self._state is CaptureState.STREAMING:
             self._state = CaptureState.CONNECTING
 

--- a/rosys/vision/usb_camera/usb_camera.py
+++ b/rosys/vision/usb_camera/usb_camera.py
@@ -33,6 +33,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
                          name=name,
                          connect_after_init=connect_after_init,
                          **kwargs)
+        self.log = logging.getLogger(f'rosys.vision.usb_camera.{self.id}')
         self._pending_operations = 0
         self.device: UsbDevice | None = None
         self.detect: bool = False
@@ -40,7 +41,7 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
 
         if width is not None or height is not None:
             resolution = (width or resolution[0], height or resolution[1])
-        self._register_parameter('auto_exposure', self.get_exposure, self.set_exposure, auto_exposure)
+        self._register_parameter('auto_exposure', self.get_auto_exposure, self.set_auto_exposure, auto_exposure)
         self._register_parameter('exposure', self.get_exposure, self.set_exposure, exposure)
         self._register_parameter('resolution', self.get_resolution, self.set_resolution, resolution)
         self._register_parameter('fps', self.get_fps, self.set_fps, fps)
@@ -59,36 +60,38 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
 
     @property
     def is_connected(self) -> bool:
-        return self.device is not None
+        return self.device is not None and self.device.is_connected
+
+    @property
+    def is_active(self) -> bool:
+        return self.device is not None and self.device.is_active
 
     async def connect(self) -> None:
-        if self.is_connected:
-            return
-
-        device = UsbDevice.from_uid(self.id, self._handle_new_image_data)
-        if device is None:
-            logging.warning('Connecting camera %s: failed', self.id)
-            return
-
-        self.device = device
-        logging.info('Connecting camera %s: succeeded', self.id)
-
-        await self._apply_all_parameters()
+        async with self._device_connection():
+            if self.device is not None:
+                if self.device.is_active:
+                    return
+                await self._tear_down_device()
+            self.device = UsbDevice(self.id,
+                                    on_new_image_data=self._handle_new_image_data,
+                                    on_connect=self._apply_all_parameters,
+                                    reconnect_interval=self.reconnect_interval)
 
     async def disconnect(self) -> None:
-        if not self.is_connected:
-            return
+        async with self._device_connection():
+            await self._tear_down_device()
 
-        assert self.device is not None
-        await self.device.release_capture()
+    async def _tear_down_device(self) -> None:
+        """Tear down the device. The caller must hold `device_connection_lock`."""
+        if self.device is None:
+            return
+        await self.device.shutdown()
         self.device = None
-        logging.info('camera %s: disconnected', self.id)
+        self.log.info('disconnected')
 
     async def _handle_new_image_data(self, image_data: np.ndarray | bytes, timestamp: float) -> None:
-        if not self.is_connected:
+        if self.device is None:
             return None
-
-        assert self.device is not None
 
         image_array: np.ndarray | None
         if isinstance(image_data, np.ndarray):
@@ -130,14 +133,17 @@ class UsbCamera(ConfigurableCamera, TransformableCamera):
         self.device.set_width(resolution[0])
         self.device.set_height(resolution[1])
 
-    def get_resolution(self) -> tuple[int, int]:
+    def get_resolution(self) -> tuple[int, int] | None:
         assert self.device is not None
-        return (self.device.get_width(), self.device.get_height())
+        width, height = self.device.get_width(), self.device.get_height()
+        if width is None or height is None:
+            return None
+        return (width, height)
 
     def set_fps(self, fps: int) -> None:
         assert self.device is not None
         self.device.set_fps(fps)
 
-    def get_fps(self) -> int:
+    def get_fps(self) -> int | None:
         assert self.device is not None
         return self.device.get_fps()

--- a/rosys/vision/usb_camera/usb_camera_provider.py
+++ b/rosys/vision/usb_camera/usb_camera_provider.py
@@ -20,7 +20,6 @@ class UsbCameraProvider(CameraProvider[UsbCamera]):
 
         self.log = logging.getLogger('rosys.usb_camera_provider')
 
-        rosys.on_shutdown(self.shutdown)
         if auto_scan:
             rosys.on_repeat(self.update_device_list, self.SCAN_INTERVAL)
 
@@ -38,15 +37,10 @@ class UsbCameraProvider(CameraProvider[UsbCamera]):
         return (await rosys.run.io_bound(scan_for_connected_devices)) or set()
 
     async def update_device_list(self) -> None:
-        camera_uids = await self.scan_for_cameras()
-        for uid in camera_uids:
+        for uid in await self.scan_for_cameras():
             if uid not in self._cameras:
+                self.log.info('found new camera "%s"', uid)
                 self.add_camera(UsbCamera(id=uid))
-            await self._cameras[uid].connect()
-
-    async def shutdown(self) -> None:
-        for camera in self._cameras.values():
-            await camera.disconnect()
 
     @staticmethod
     def is_operable() -> bool:

--- a/rosys/vision/usb_camera/usb_device.py
+++ b/rosys/vision/usb_camera/usb_device.py
@@ -91,8 +91,6 @@ class UsbDevice(CaptureDevice):
             if not capture_success:
                 self._read_failures += 1
                 if self._read_failures >= self.MAX_READ_FAILURES:
-                    self.log.warning('[%s] releasing capture after %d failed reads',
-                                     self.uid, self._read_failures)
                     await self._release()
                     return
                 await rosys.sleep(0.01)
@@ -115,12 +113,15 @@ class UsbDevice(CaptureDevice):
     async def _open_capture(self) -> None:
         """Find and open the capture for this camera; leaves ``_capture`` as ``None`` when it is unavailable."""
         await self._release()
+        self._read_failures = 0
         device_node = await rosys.run.io_bound(find_device_node, self.uid)
         if device_node is None:
-            self.log.debug('[%s] no video device found', self.uid)
+            self._unavailable_node = None
             return
         capture = await rosys.run.io_bound(UsbDevice.create_capture, device_node)
         if capture is None:
+            if not self._keeps_running():
+                return
             if self._unavailable_node != device_node:
                 self._unavailable_node = device_node
                 self.log.warning('[%s] cannot open %s; another process may be using it', self.uid, device_node)
@@ -129,7 +130,6 @@ class UsbDevice(CaptureDevice):
         self.log.info('[%s] connected on %s', self.uid, device_node)
         self._device_node = device_node
         self._capture = capture
-        self._read_failures = 0
         self.set_video_format()
         await self._enter_streaming()
 
@@ -141,6 +141,13 @@ class UsbDevice(CaptureDevice):
 
     async def _tear_down_session(self) -> None:
         await self._release()
+
+    def _retry_reason(self) -> tuple[int, str]:
+        if self._read_failures >= self.MAX_READ_FAILURES:
+            return logging.WARNING, f'released the capture after {self._read_failures} failed reads'
+        if self._unavailable_node is not None:
+            return logging.INFO, f'cannot open {self._unavailable_node}'
+        return logging.DEBUG, 'no video device found'
 
     async def load_value_ranges(self) -> None:
         output = await self.run_v4l('--all')

--- a/rosys/vision/usb_camera/usb_device.py
+++ b/rosys/vision/usb_camera/usb_device.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 import re
 from collections.abc import Awaitable, Callable
@@ -8,31 +6,39 @@ import cv2
 import numpy as np
 
 from ... import rosys
+from ..capture_device import CaptureDevice
 from .usb_camera_scanner import device_nodes_from_uid
 
 MJPG = cv2.VideoWriter.fourcc(*'MJPG')
 
 
-def find_video_id(camera_uid: str) -> int | None:
-    device_nodes = device_nodes_from_uid(camera_uid)
-    video_ids = [
-        int(node.strip().removeprefix('/dev/video'))
-        for node in device_nodes
-        if node.startswith('/dev/video')
-    ]
-    return min(video_ids) if video_ids else None
+def find_device_node(camera_uid: str) -> str | None:
+    """Find the lowest-numbered ``/dev/video*`` node of the camera with the given uid."""
+    video_nodes = [node.strip() for node in device_nodes_from_uid(camera_uid) if node.startswith('/dev/video')]
+    if not video_nodes:
+        return None
+    return min(video_nodes, key=lambda node: int(node.removeprefix('/dev/video')))
 
 
 def to_bytes(image: np.ndarray) -> bytes:
     return image.tobytes()
 
 
-class UsbDevice:
+class UsbDevice(CaptureDevice):
+    MAX_READ_FAILURES = 10
+    """Number of consecutive failed reads before the capture is considered lost (e.g. unplugged cable)."""
 
-    def __init__(self, video_id: int, capture: cv2.VideoCapture, *,
-                 on_new_image_data: Callable[[np.ndarray | bytes, float], Awaitable | None]) -> None:
-        self._video_id: int = video_id
-        self._capture: cv2.VideoCapture = capture
+    def __init__(self, uid: str, *,
+                 on_new_image_data: Callable[[np.ndarray | bytes, float], Awaitable | None],
+                 on_connect: Callable[[], Awaitable | None] | None = None,
+                 reconnect_interval: float = 3.0) -> None:
+        super().__init__(name=uid,
+                         log=logging.getLogger('rosys.vision.usb_camera.usb_device.' + uid),
+                         on_connect=on_connect,
+                         reconnect_interval=reconnect_interval)
+        self.uid = uid
+        self._device_node: str | None = None
+        self._capture: cv2.VideoCapture | None = None
         self._on_new_image_data = on_new_image_data
         self._exposure_min: int = 0
         self._exposure_max: int = 0
@@ -40,14 +46,15 @@ class UsbDevice:
         self._has_manual_exposure: bool = False
         self._video_formats: set[str] = set()
         self._image_is_jpg: bool = False
+        self._read_failures: int = 0
+        self._unavailable_node: str | None = None
 
-        self.set_video_format()
+        self._start_capture_task()
 
-        self._capture_task = rosys.on_repeat(self._capture_image, interval=0.01)
-
-    def __del__(self) -> None:
-        self._capture.release()
-        self._capture_task.stop()
+    @property
+    def is_connected(self) -> bool:
+        """Whether a working capture is currently open (False while a lost capture is being reconnected)."""
+        return self._capture is not None
 
     @property
     def video_formats(self) -> set[str]:
@@ -58,22 +65,8 @@ class UsbDevice:
         return self._image_is_jpg
 
     @staticmethod
-    def from_uid(camera_id: str, on_new_image_data: Callable[[np.ndarray | bytes, float], Awaitable | None]) -> UsbDevice | None:
-        video_id = find_video_id(camera_id)
-        if video_id is None:
-            logging.error('Could not find video device for camera %s', camera_id)
-            return None
-
-        capture = UsbDevice.create_capture(video_id)
-        if capture is None:
-            logging.error('Could not open video device %s', video_id)
-            return None
-
-        return UsbDevice(video_id=video_id, capture=capture, on_new_image_data=on_new_image_data)
-
-    @staticmethod
-    def create_capture(index: int) -> cv2.VideoCapture | None:
-        capture = cv2.VideoCapture(index)
+    def create_capture(device_node: str) -> cv2.VideoCapture | None:
+        capture = cv2.VideoCapture(device_node, cv2.CAP_V4L2)
         if capture is None:
             return None
         capture.set(cv2.CAP_PROP_BUFFERSIZE, 1)
@@ -82,20 +75,35 @@ class UsbDevice:
             return None
         return capture
 
-    async def _capture_image(self) -> None:
-        if not self._capture.isOpened():
-            return
-        read_result = await rosys.run.io_bound(self._capture.read)
-        if read_result is None:
-            return
-        capture_success, frame = read_result
+    async def _run_session(self) -> None:
+        """Read frames until the capture is lost, then release it."""
+        while self._keeps_running():
+            if self._capture is None or not self._capture.isOpened():
+                await self._open_capture()
+                if self._capture is None:
+                    return
 
-        if capture_success:
+            read_result = await rosys.run.io_bound(self._capture.read)
+            if read_result is None:
+                return
+            capture_success, frame = read_result
+
+            if not capture_success:
+                self._read_failures += 1
+                if self._read_failures >= self.MAX_READ_FAILURES:
+                    self.log.warning('[%s] releasing capture after %d failed reads',
+                                     self.uid, self._read_failures)
+                    await self._release()
+                    return
+                await rosys.sleep(0.01)
+                continue
+            self._read_failures = 0
+
             timestamp = rosys.time()
             if self._image_is_jpg:
                 bytes_ = await rosys.run.io_bound(to_bytes, frame[0])
                 if bytes_ is None:
-                    return
+                    continue
                 result = self._on_new_image_data(bytes_, timestamp)
             else:
                 # convert bgr to rgb
@@ -104,8 +112,35 @@ class UsbDevice:
             if isinstance(result, Awaitable):
                 await result
 
-    async def release_capture(self) -> None:
-        await rosys.run.io_bound(self._capture.release)
+    async def _open_capture(self) -> None:
+        """Find and open the capture for this camera; leaves ``_capture`` as ``None`` when it is unavailable."""
+        await self._release()
+        device_node = await rosys.run.io_bound(find_device_node, self.uid)
+        if device_node is None:
+            self.log.debug('[%s] no video device found', self.uid)
+            return
+        capture = await rosys.run.io_bound(UsbDevice.create_capture, device_node)
+        if capture is None:
+            if self._unavailable_node != device_node:
+                self._unavailable_node = device_node
+                self.log.warning('[%s] cannot open %s; another process may be using it', self.uid, device_node)
+            return
+        self._unavailable_node = None
+        self.log.info('[%s] connected on %s', self.uid, device_node)
+        self._device_node = device_node
+        self._capture = capture
+        self._read_failures = 0
+        self.set_video_format()
+        await self._enter_streaming()
+
+    async def _release(self) -> None:
+        if self._capture is not None:
+            await rosys.run.io_bound(self._capture.release)
+            self._capture = None
+        self._device_node = None
+
+    async def _tear_down_session(self) -> None:
+        await self._release()
 
     async def load_value_ranges(self) -> None:
         output = await self.run_v4l('--all')
@@ -125,11 +160,15 @@ class UsbDevice:
             self._video_formats.add(m.group(1))
 
     async def run_v4l(self, *args) -> str:
-        cmd = ['v4l2-ctl', '-d', str(self._video_id)]
+        if self._device_node is None:
+            return ''
+        cmd = ['v4l2-ctl', '-d', self._device_node]
         cmd.extend(args)
         return await rosys.run.sh(cmd)
 
     def set_video_format(self) -> None:
+        if self._capture is None:
+            return
         if 'MJPG' in self._video_formats:
             # NOTE enforcing motion jpeg for now
             if self._capture.get(cv2.CAP_PROP_FOURCC) != MJPG:
@@ -145,6 +184,8 @@ class UsbDevice:
             self._image_is_jpg = False
 
     def set_auto_exposure(self, auto: bool) -> None:
+        if self._capture is None:
+            return
         if self._has_manual_exposure:
             if auto:
                 self._capture.set(cv2.CAP_PROP_AUTO_EXPOSURE, 3)
@@ -152,6 +193,8 @@ class UsbDevice:
                 self._capture.set(cv2.CAP_PROP_AUTO_EXPOSURE, 1)
 
     def set_exposure(self, value: float) -> None:
+        if self._capture is None:
+            return
         if self._has_manual_exposure:
             is_auto_exposure = self.get_auto_exposure()
             if not is_auto_exposure:
@@ -160,27 +203,38 @@ class UsbDevice:
                     self._capture.set(cv2.CAP_PROP_EXPOSURE, int(value * self._exposure_max))
 
     def get_auto_exposure(self) -> bool | None:
+        if self._capture is None:
+            return None
         return self._capture.get(cv2.CAP_PROP_AUTO_EXPOSURE) == 3
 
     def get_exposure(self) -> float | None:
-        if not self._has_manual_exposure:
+        if self._capture is None or not self._has_manual_exposure:
             return None
         return self._capture.get(cv2.CAP_PROP_EXPOSURE) / self._exposure_max
 
     def set_width(self, width: int) -> None:
-        self._capture.set(cv2.CAP_PROP_FRAME_WIDTH, width)
+        if self._capture is not None:
+            self._capture.set(cv2.CAP_PROP_FRAME_WIDTH, width)
 
-    def get_width(self) -> int:
+    def get_width(self) -> int | None:
+        if self._capture is None:
+            return None
         return int(self._capture.get(cv2.CAP_PROP_FRAME_WIDTH))
 
     def set_height(self, height: int) -> None:
-        self._capture.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
+        if self._capture is not None:
+            self._capture.set(cv2.CAP_PROP_FRAME_HEIGHT, height)
 
-    def get_height(self) -> int:
+    def get_height(self) -> int | None:
+        if self._capture is None:
+            return None
         return int(self._capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
     def set_fps(self, fps: int) -> None:
-        self._capture.set(cv2.CAP_PROP_FPS, fps)
+        if self._capture is not None:
+            self._capture.set(cv2.CAP_PROP_FPS, fps)
 
-    def get_fps(self) -> int:
+    def get_fps(self) -> int | None:
+        if self._capture is None:
+            return None
         return int(self._capture.get(cv2.CAP_PROP_FPS))

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -439,7 +439,7 @@ async def test_simulated_camera_reconnects_after_disconnect(rosys_integration):
     await forward(0.5)
     assert camera.images, 'no images while connected'
 
-    camera.device.disconnect()  # simulate a bad cable
+    camera.device.simulate_connection_loss()
     assert not camera.device.is_connected
     count_at_disconnect = len(camera.images)
     await forward(0.3)  # shorter than reconnect_interval -> still disconnected
@@ -458,7 +458,7 @@ async def test_simulated_camera_reapplies_parameters_after_reconnect(rosys_integ
     assert camera.device is not None
     await forward(0.5)
 
-    camera.device.disconnect()  # simulate a bad cable
+    camera.device.simulate_connection_loss()
     await camera.set_parameters({'color': '#654321'})  # while disconnected, the new value only reaches the cache
     assert camera.device.color == '#123456'
 

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -987,6 +987,37 @@ async def test_rtsp_camera_is_active_without_known_address(rosys_integration):
         await camera.disconnect()
 
 
+async def test_usb_device_waits_quietly_for_a_missing_video_device(vision_log):
+    vision_log.set_level(logging.DEBUG, logger='rosys.vision')
+    with patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value=None):
+        device = UsbDevice('fakecam', on_new_image_data=lambda data, timestamp: None, reconnect_interval=0.2)
+        try:
+            await forward_until(lambda: any('retrying' in record.getMessage() for record in vision_log.records),
+                                message='expected the device to say why it is waiting')
+            retry_records = [record for record in vision_log.records if 'retrying' in record.getMessage()]
+            assert all('no video device found' in record.getMessage() for record in retry_records)
+            assert all(record.levelno == logging.DEBUG for record in retry_records), \
+                'expected a missing video device to be logged at DEBUG only'
+        finally:
+            await device.shutdown()
+
+
+async def test_usb_device_warns_once_about_a_busy_video_device(vision_log):
+    with patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value='/dev/video0'), \
+            patch.object(UsbDevice, 'create_capture', lambda _device_node: None):
+        device = UsbDevice('fakecam', on_new_image_data=lambda data, timestamp: None, reconnect_interval=0.2)
+        try:
+            await forward_until(lambda: sum('retrying' in record.getMessage() for record in vision_log.records) >= 2,
+                                message='expected at least two attempts to open the busy device')
+            retry_records = [record for record in vision_log.records if 'retrying' in record.getMessage()]
+            assert all('cannot open /dev/video0' in record.getMessage() for record in retry_records)
+            assert all(record.levelno == logging.INFO for record in retry_records)
+            assert sum('another process' in record.getMessage() for record in vision_log.records) == 1, \
+                'expected the hint about another process exactly once'
+        finally:
+            await device.shutdown()
+
+
 async def test_usb_camera_is_active_without_video_device(rosys_integration):
     with patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value=None):
         camera = UsbCamera(id='fakecam', connect_after_init=False, reconnect_interval=0.3)

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -2,7 +2,7 @@ import asyncio
 import gc
 import logging
 import weakref
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager, nullcontext, suppress
 from unittest.mock import AsyncMock, patch
 
 import cv2
@@ -285,6 +285,25 @@ def test_camera_persists_reconnect_interval(rosys_integration, make_camera):
     data = camera.to_dict()
     assert data['reconnect_interval'] == 12.5
     assert type(camera).from_dict(data).reconnect_interval == 12.5
+
+
+@pytest.mark.parametrize('make_camera, offline', [
+    (lambda: RtspCamera(mac=GOODCAM_MAC, ip='192.168.0.5', connect_after_init=False), stalled_rtsp_stream),
+    (lambda: MjpegCamera(id=GOODCAM_MAC, ip='192.168.0.5', connect_after_init=False), stalled_mjpeg_stream),
+    (lambda: UsbCamera(id='cam', connect_after_init=False),
+     lambda: patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value=None)),
+    (lambda: SimulatedCamera(id='sim', connect_after_init=False), nullcontext),
+])
+async def test_camera_forwards_reconnect_interval_to_a_live_device(rosys_integration, make_camera, offline):
+    with offline():
+        camera = make_camera()
+        await camera.connect()
+        try:
+            assert camera.device is not None
+            camera.reconnect_interval = 7.5
+            assert camera.device.reconnect_interval == 7.5
+        finally:
+            await camera.disconnect()
 
 
 class FakeCapture:

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -1,14 +1,29 @@
 import asyncio
+import gc
 import logging
+import weakref
 from contextlib import asynccontextmanager, suppress
 from unittest.mock import AsyncMock, patch
 
+import cv2
+import numpy as np
 import pytest
 from nicegui import background_tasks
 
 import rosys
+import rosys.rosys as rosys_core
 from rosys.testing import forward
-from rosys.vision import MjpegCamera, MjpegCameraProvider, RtspCamera, RtspCameraProvider
+from rosys.vision import (
+    ImageSize,
+    MjpegCamera,
+    MjpegCameraProvider,
+    RtspCamera,
+    RtspCameraProvider,
+    SimulatedCamera,
+    SimulatedCameraProvider,
+    UsbCamera,
+    UsbCameraProvider,
+)
 from rosys.vision.mjpeg_camera.arkvision_mjpeg_device import ArkVisionMjpegDevice
 from rosys.vision.mjpeg_camera.axis_mjpeg_device import AxisMjpegDevice
 from rosys.vision.mjpeg_camera.mjpeg_device import CameraAddressUnknown, CaptureState, MjpegDevice
@@ -17,6 +32,8 @@ from rosys.vision.mjpeg_camera.motec_mjpeg_device import MotecMjpegDevice
 from rosys.vision.mjpeg_camera.openipc_zauberzeug_mjpeg_device import OpenIpcZauberzeugMjpegDevice
 from rosys.vision.reconnect import MAX_RECONNECT_INTERVAL, MIN_RECONNECT_INTERVAL
 from rosys.vision.rtsp_camera.rtsp_device import GDPPACKET_FORMAT, GDPPayloadType, RtspDevice
+from rosys.vision.simulated_camera.simulated_device import SimulatedDevice
+from rosys.vision.usb_camera.usb_device import UsbDevice, find_device_node
 
 # GOODCAM has a URL in both the RTSP and MJPEG vendor tables and no settings interface, so no network access
 GOODCAM_MAC = '2c:6f:51:00:00:01'
@@ -260,12 +277,184 @@ async def test_rtsp_device_reconnects_until_shutdown(rosys_integration):
 @pytest.mark.parametrize('make_camera', [
     lambda: RtspCamera(mac='aa:bb:cc:dd:ee:ff', reconnect_interval=12.5, connect_after_init=False),
     lambda: MjpegCamera(id='test_cam', ip='192.168.1.1', reconnect_interval=12.5, connect_after_init=False),
+    lambda: UsbCamera(id='cam', reconnect_interval=12.5, connect_after_init=False),
+    lambda: SimulatedCamera(id='sim', reconnect_interval=12.5, connect_after_init=False),
 ])
 def test_camera_persists_reconnect_interval(rosys_integration, make_camera):
     camera = make_camera()
     data = camera.to_dict()
     assert data['reconnect_interval'] == 12.5
     assert type(camera).from_dict(data).reconnect_interval == 12.5
+
+
+class FakeCapture:
+    """Minimal stand-in for cv2.VideoCapture that can simulate a disconnected device."""
+
+    def __init__(self, *, failing_reads: bool = False) -> None:
+        self._opened = True
+        self._frame = np.zeros((48, 64, 3), dtype=np.uint8)
+        self.props: dict = {}
+        self.failing_reads = failing_reads
+        self.reads = 0
+
+    def isOpened(self) -> bool:  # cv2 API name
+        return self._opened
+
+    def read(self):
+        self.reads += 1
+        if not self._opened or self.failing_reads:
+            return False, None
+        return True, self._frame
+
+    def release(self) -> None:
+        self._opened = False
+
+    def get(self, prop) -> float:
+        return self.props.get(prop, 0.0)
+
+    def set(self, prop, value) -> bool:
+        self.props[prop] = value
+        return True
+
+
+async def test_usb_device_reconnects_after_disconnect(rosys_integration):
+    captures: list[FakeCapture] = []
+
+    def make_capture(_device_node: str) -> FakeCapture:
+        capture = FakeCapture()
+        captures.append(capture)
+        return capture
+
+    frames: list = []
+    with patch.object(UsbDevice, 'create_capture', make_capture), \
+            patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value='/dev/video0'):
+        device = UsbDevice('fakecam', on_new_image_data=lambda data, timestamp: frames.append(data),
+                           reconnect_interval=0.3)
+        try:
+            await forward_until(lambda: bool(frames), step=0.1, real_step=0.02, attempts=15,
+                                message='device did not capture any frames')
+            assert device.is_connected
+            captures_before = len(captures)
+
+            captures[-1].release()  # simulate a bad cable: the capture dies
+            await forward_until(lambda: len(captures) > captures_before, real_step=0.02,
+                                message='device did not reopen its capture')
+            assert device.is_connected
+
+            frames_after_reconnect = len(frames)
+            await forward_until(lambda: len(frames) > frames_after_reconnect,
+                                step=0.1, real_step=0.02, attempts=10,
+                                message='frames did not resume after reconnect')
+
+            await device.shutdown()
+            assert not device.is_connected
+            captures_at_shutdown = len(captures)
+            for _ in range(5):
+                await forward(0.3)
+                await asyncio.sleep(0.02)
+            assert len(captures) == captures_at_shutdown, 'device kept reopening after shutdown'
+        finally:
+            await device.shutdown()
+
+
+async def test_usb_device_releases_a_capture_that_only_fails_to_read(rosys_integration):
+    """A cable pulled mid-stream leaves an opened capture whose reads fail; the session must end."""
+    captures: list[FakeCapture] = []
+
+    def make_capture(_device_node: str) -> FakeCapture:
+        capture = FakeCapture(failing_reads=True)
+        captures.append(capture)
+        return capture
+
+    with patch.object(UsbDevice, 'create_capture', make_capture), \
+            patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value='/dev/video0'):
+        device = UsbDevice('fakecam', on_new_image_data=lambda data, timestamp: None, reconnect_interval=0.3)
+        try:
+            await forward_until(lambda: captures and captures[0].reads >= UsbDevice.MAX_READ_FAILURES,
+                                step=0.1, real_step=0.02, attempts=30,
+                                message='device did not keep reading a capture whose reads fail')
+            assert not device.is_connected, 'expected the capture to be released after the failed reads'
+            assert captures[0].reads == UsbDevice.MAX_READ_FAILURES, \
+                'expected the capture to be released as soon as the failures reach the limit'
+
+            await forward_until(lambda: len(captures) > 1, real_step=0.02,
+                                message='device did not try to reopen its capture')
+        finally:
+            await device.shutdown()
+
+
+async def test_usb_camera_reapplies_parameters_after_reconnect(rosys_integration):
+    captures: list[FakeCapture] = []
+
+    def make_capture(_device_node: str) -> FakeCapture:
+        capture = FakeCapture()
+        captures.append(capture)
+        return capture
+
+    with patch.object(UsbDevice, 'create_capture', make_capture), \
+            patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value='/dev/video0'):
+        camera = UsbCamera(id='fakecam', resolution=(640, 480), fps=5,
+                           connect_after_init=False, reconnect_interval=0.3)
+        await camera.connect()
+        try:
+            await forward_until(lambda: bool(captures) and cv2.CAP_PROP_FRAME_WIDTH in captures[0].props,
+                                step=0.1, real_step=0.02,
+                                message='device did not open a capture and apply parameters')
+            assert captures[0].props[cv2.CAP_PROP_FRAME_WIDTH] == 640, 'parameters were not applied on connect'
+
+            captures[-1].release()  # simulate a bad cable: the capture dies
+            await forward_until(lambda: len(captures) > 1 and cv2.CAP_PROP_FPS in captures[-1].props,
+                                real_step=0.02,
+                                message='device did not reopen its capture and reapply parameters')
+            assert captures[-1].props[cv2.CAP_PROP_FRAME_WIDTH] == 640, 'width was not reapplied after reconnect'
+            assert captures[-1].props[cv2.CAP_PROP_FRAME_HEIGHT] == 480, 'height was not reapplied after reconnect'
+            assert captures[-1].props[cv2.CAP_PROP_FPS] == 5, 'fps was not reapplied after reconnect'
+        finally:
+            await camera.disconnect()
+
+
+async def test_simulated_camera_reconnects_after_disconnect(rosys_integration):
+    camera = SimulatedCamera(id='sim', resolution=(64, 48), fps=10, reconnect_interval=0.5)
+    await camera.connect()
+    assert camera.device is not None
+    await forward(0.5)
+    assert camera.images, 'no images while connected'
+
+    camera.device.disconnect()  # simulate a bad cable
+    assert not camera.device.is_connected
+    count_at_disconnect = len(camera.images)
+    await forward(0.3)  # shorter than reconnect_interval -> still disconnected
+    assert not camera.device.is_connected
+    assert len(camera.images) == count_at_disconnect, 'images kept arriving while disconnected'
+
+    await forward(0.5)  # now past reconnect_interval since the disconnect
+    assert camera.device.is_connected
+    await forward(0.3)
+    assert len(camera.images) > count_at_disconnect, 'images did not resume after reconnect'
+
+
+async def test_simulated_camera_reapplies_parameters_after_reconnect(rosys_integration):
+    camera = SimulatedCamera(id='sim', resolution=(64, 48), fps=10, color='#123456', reconnect_interval=0.5)
+    await camera.connect()
+    assert camera.device is not None
+    await forward(0.5)
+
+    camera.device.disconnect()  # simulate a bad cable
+    await camera.set_parameters({'color': '#654321'})  # while disconnected, the new value only reaches the cache
+    assert camera.device.color == '#123456'
+
+    await forward(1.0)  # the device reconnects itself and the camera reapplies its parameters
+    assert camera.device.is_connected
+    assert camera.device.color == '#654321'
+
+
+async def test_simulated_camera_passes_params_to_device(rosys_integration):
+    camera = SimulatedCamera(id='sim', reconnect_interval=9.0, simulate_failing=True)
+    await camera.connect()
+    assert camera.device is not None
+    assert camera.device.reconnect_interval == 9.0
+    assert camera.device.simulate_failing is True
+    await camera.disconnect()
 
 
 async def test_mjpeg_device_backs_off_after_401(rosys_integration):
@@ -557,6 +746,12 @@ async def test_mjpeg_device_keeps_one_capture_loop_across_an_address_change(rosy
             await server.stop()
 
 
+async def _stub_usb_session(self) -> bool:
+    """Stand-in for a capture session that keeps running without touching any hardware."""
+    await rosys.sleep(60.0)
+    return True
+
+
 async def test_rtsp_device_keeps_one_capture_loop_across_concurrent_restarts(rosys_integration):
     task_name = f'capture {GOODCAM_MAC}'
     with connected_rtsp_stream():
@@ -570,6 +765,23 @@ async def test_rtsp_device_keeps_one_capture_loop_across_concurrent_restarts(ros
                 f'expected one capture loop, got {len(live_capture_tasks(task_name))}'
         finally:
             await device.shutdown()
+            await cancel_leftover_loops(task_name)
+
+
+async def test_usb_camera_keeps_one_capture_loop_across_concurrent_reconnects(rosys_integration):
+    camera_id = 'usb_reconnect_race'
+    task_name = f'capture {camera_id}'
+    with patch.object(UsbDevice, '_run_session', _stub_usb_session):
+        camera = UsbCamera(id=camera_id, connect_after_init=False)
+        try:
+            await camera.connect()
+            await asyncio.sleep(0.05)
+            await asyncio.gather(camera.reconnect(), camera.reconnect())
+            await asyncio.sleep(0.05)
+            assert len(live_capture_tasks(task_name)) == 1, \
+                f'expected one capture loop, got {len(live_capture_tasks(task_name))}'
+        finally:
+            await camera.disconnect()
             await cancel_leftover_loops(task_name)
 
 
@@ -587,6 +799,92 @@ async def test_rtsp_camera_does_not_restart_a_device_it_is_disconnecting(rosys_i
         finally:
             await camera.disconnect()
             await cancel_leftover_loops(task_name)
+
+
+async def test_simulated_camera_disconnect_stops_loop(rosys_integration):
+    camera = SimulatedCamera(id='sim_stop', resolution=(64, 48), fps=10, reconnect_interval=0.2)
+    await camera.connect()
+    await forward(0.4)
+    assert camera.images, 'expected simulated camera to produce images while connected'
+
+    device = camera.device
+    assert device is not None, 'expected simulated camera to have a device after connect'
+    await camera.disconnect()
+    assert camera.device is None, 'expected camera.disconnect() to clear camera.device reference'
+    assert device.is_active is False, 'expected old device loop to stop when camera disconnects'
+
+    image_count_after_disconnect = len(camera.images)
+    for _ in range(6):
+        await forward(0.3)
+    assert len(camera.images) == image_count_after_disconnect, 'expected no new images after camera disconnect'
+
+
+def test_simulate_device_failure_deprecated_alias(rosys_integration):
+    provider = SimulatedCameraProvider(simulate_failing=True)
+
+    with pytest.warns(DeprecationWarning):
+        deprecated_value = provider.simulate_device_failure
+    assert deprecated_value is True, 'expected deprecated alias getter to proxy simulate_failing=True'
+
+    with pytest.warns(DeprecationWarning):
+        provider.simulate_device_failure = False
+    assert provider.simulate_failing is False, 'expected deprecated alias setter to update simulate_failing'
+
+
+async def test_devices_do_not_leak_shutdown_handlers(rosys_integration):
+    handlers_before_device = len(rosys_core.shutdown_handlers)
+    device = SimulatedDevice(id='sim_device_no_shutdown_hook',
+                             size=ImageSize(width=64, height=48),
+                             on_new_image=lambda image: None,
+                             fps=10)
+    try:
+        assert len(rosys_core.shutdown_handlers) == handlers_before_device, (
+            'expected direct device construction to avoid registering shutdown handlers'
+        )
+    finally:
+        await device.shutdown()
+
+    handlers_before_camera = len(rosys_core.shutdown_handlers)
+    camera = SimulatedCamera(id='sim_camera_shutdown_hook', connect_after_init=False)
+    assert len(rosys_core.shutdown_handlers) == handlers_before_camera + 1, (
+        'expected exactly one shutdown handler to be added for a camera instance'
+    )
+    assert rosys_core.shutdown_handlers[-1].__qualname__ == 'SimulatedCamera.disconnect', (
+        'expected the camera to register its own disconnect as the shutdown handler'
+    )
+
+    camera_ref = weakref.ref(camera)
+    del camera
+    gc.collect()
+    assert camera_ref() is None, 'expected the shutdown handler not to keep the camera alive'
+    assert len(rosys_core.shutdown_handlers) == handlers_before_camera, (
+        'expected the handler of a discarded camera to be unregistered'
+    )
+
+    cycling_camera = SimulatedCamera(id='sim_camera_cycle', fps=10, reconnect_interval=0.2, connect_after_init=False)
+    await cycling_camera.connect()
+    await forward(0.3)
+    handlers_before_cycles = len(rosys_core.shutdown_handlers)
+
+    for _ in range(3):
+        await cycling_camera.disconnect()
+        await forward(0.1)
+        await cycling_camera.connect()
+        await forward(0.3)
+
+    assert len(rosys_core.shutdown_handlers) == handlers_before_cycles, (
+        'expected repeated connect/disconnect cycles to avoid adding more shutdown handlers'
+    )
+    await cycling_camera.disconnect()
+
+
+async def test_is_active_tracks_connect_and_disconnect(rosys_integration):
+    camera = SimulatedCamera(id='sim', connect_after_init=False)
+    assert camera.is_active is False
+    await camera.connect()
+    assert camera.is_active is True
+    await camera.disconnect()
+    assert camera.is_active is False
 
 
 async def test_axis_device_derives_url_from_its_settings(rosys_integration):
@@ -668,6 +966,18 @@ async def test_rtsp_camera_is_active_without_known_address(rosys_integration):
         assert not camera.is_connected
     finally:
         await camera.disconnect()
+
+
+async def test_usb_camera_is_active_without_video_device(rosys_integration):
+    with patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value=None):
+        camera = UsbCamera(id='fakecam', connect_after_init=False, reconnect_interval=0.3)
+        await camera.connect()
+        try:
+            await forward(0.5)
+            assert camera.is_active, 'expected the camera to keep retrying while no video device exists'
+            assert not camera.is_connected
+        finally:
+            await camera.disconnect()
 
 
 async def test_mjpeg_provider_adds_and_connects_new_camera(rosys_integration):
@@ -755,9 +1065,65 @@ async def test_rtsp_provider_rebinds_moved_camera(rosys_integration):
         await camera.disconnect()
 
 
+async def test_usb_camera_connects_once_video_device_appears(rosys_integration):
+    device_node: str | None = None
+
+    with patch('rosys.vision.usb_camera.usb_device.find_device_node', lambda _uid: device_node), \
+            patch.object(UsbDevice, 'create_capture', lambda _device_node: FakeCapture()):
+        camera = UsbCamera(id='fakecam', connect_after_init=False, reconnect_interval=0.3)
+        await camera.connect()  # no video device node available yet
+        try:
+            await forward(0.5)
+            assert camera.is_active and not camera.is_connected
+
+            device_node = '/dev/video0'  # the node shows up, e.g. after the cable was plugged back in
+            await forward_until(lambda: camera.is_connected, real_step=0.02,
+                                message='expected the device to connect on its own once the node appeared')
+        finally:
+            await camera.disconnect()
+
+
+async def test_usb_provider_adds_camera_for_new_device(rosys_integration):
+    provider = UsbCameraProvider(auto_scan=False)
+    with patch.object(UsbCameraProvider, 'scan_for_cameras', AsyncMock(return_value={'fakecam'})), \
+            patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value='/dev/video0'), \
+            patch.object(UsbDevice, 'create_capture', lambda _device_node: FakeCapture()):
+        await provider.update_device_list()
+        camera = provider.cameras['fakecam']
+        await asyncio.sleep(0.05)  # let the camera's own connect task run
+        assert camera.is_active, 'expected a discovered camera to connect on its own'
+        await camera.disconnect()
+
+
+async def test_usb_provider_leaves_disconnected_camera_alone(rosys_integration):
+    with patch.object(UsbCameraProvider, 'scan_for_cameras', AsyncMock(return_value={'fakecam'})), \
+            patch('rosys.vision.usb_camera.usb_device.find_device_node', return_value='/dev/video0'), \
+            patch.object(UsbDevice, 'create_capture', lambda _device_node: FakeCapture()):
+        provider = UsbCameraProvider(auto_scan=False)
+        camera = UsbCamera(id='fakecam', connect_after_init=False)
+        provider.add_camera(camera)
+        await camera.connect()
+        assert camera.is_active
+        await camera.disconnect()
+
+        await provider.update_device_list()
+        assert not camera.is_active, 'expected the provider to leave a deliberately disconnected camera alone'
+
+
+async def test_simulated_provider_leaves_disconnected_camera_alone(rosys_integration):
+    provider = SimulatedCameraProvider()
+    camera = SimulatedCamera(id='sim', connect_after_init=False)
+    provider.add_camera(camera)
+    await camera.connect()
+    await camera.disconnect()
+
+    await provider.update_device_list()
+    assert not camera.is_active, 'expected the provider to leave a deliberately disconnected camera alone'
+
+
 async def test_camera_clamps_a_reconnect_interval_that_would_not_wait(rosys_integration):
     for interval in (0.0, -1.0):
-        camera = MjpegCamera(id='test_cam', reconnect_interval=interval, connect_after_init=False)
+        camera = SimulatedCamera(id='sim', reconnect_interval=interval, connect_after_init=False)
         assert camera.reconnect_interval == MIN_RECONNECT_INTERVAL, 'expected the camera to clamp the interval'
 
 
@@ -859,6 +1225,18 @@ async def test_rtsp_shutdown_reraises_a_cancellation_of_its_caller(rosys_integra
             for task in asyncio.all_tasks():
                 if task.get_name() == f'capture {GOODCAM_MAC}':
                     task.cancel()
+
+
+@pytest.mark.parametrize('nodes, expected', [
+    ({'/dev/video2', '/dev/video10', '/dev/video1'}, '/dev/video1'),
+    ({'/dev/video7'}, '/dev/video7'),
+    ({'/dev/media0', '/dev/video3'}, '/dev/video3'),
+    ({'/dev/media0'}, None),
+    (set(), None),
+])
+def test_find_device_node_picks_the_lowest_numbered_video_node(nodes: set[str], expected: str | None):
+    with patch('rosys.vision.usb_camera.usb_device.device_nodes_from_uid', return_value=nodes):
+        assert find_device_node('fakecam') == expected
 
 
 @pytest.mark.parametrize('mac, expected_type', [

--- a/tests/test_camera_reconnect.py
+++ b/tests/test_camera_reconnect.py
@@ -850,6 +850,11 @@ def test_simulate_device_failure_deprecated_alias(rosys_integration):
     assert provider.simulate_failing is False, 'expected deprecated alias setter to update simulate_failing'
 
 
+def test_simulated_provider_accepts_deprecated_auto_scan(rosys_integration):
+    with pytest.warns(DeprecationWarning):
+        SimulatedCameraProvider(auto_scan=False)
+
+
 async def test_devices_do_not_leak_shutdown_handlers(rosys_integration):
     handlers_before_device = len(rosys_core.shutdown_handlers)
     device = SimulatedDevice(id='sim_device_no_shutdown_hook',

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -36,10 +36,12 @@ async def test_usb_camera(rosys_integration):
     if len(connected_uids) == 0:
         pytest.skip('No USB camera detected. This test requires a physical USB camera to be connected.')
     camera = UsbCamera(id=connected_uids[0])
-    await camera.connect()
-    for _ in range(5):
+    await camera.connect()  # the device opens the capture in its own loop, so wait for the first image
+    for _ in range(50):
         await forward(0.1)
-        await asyncio.sleep(0.2)
+        await asyncio.sleep(0.1)
+        if camera.images:
+            break
     assert camera.is_connected
     assert len(camera.images) >= 1
 

--- a/tests/test_recorder_replay.py
+++ b/tests/test_recorder_replay.py
@@ -14,7 +14,7 @@ from rosys.vision.record_replay.replay_camera_provider import ReplayCameraProvid
 @pytest.mark.usefixtures('rosys_integration')
 async def test_record_images(recordings_dir: Path):
     # ARRANGE
-    provider = SimulatedCameraProvider(auto_scan=False)
+    provider = SimulatedCameraProvider()
     cam = SimulatedCamera(id='cam:0', resolution=(64, 48), fps=1)
     provider.add_camera(cam)
     await cam.connect()
@@ -40,7 +40,7 @@ async def test_record_images(recordings_dir: Path):
 @pytest.mark.usefixtures('rosys_integration')
 async def test_playback_replays_images(recordings_dir: Path):
     # ARRANGE
-    provider = SimulatedCameraProvider(auto_scan=False)
+    provider = SimulatedCameraProvider()
     cam = SimulatedCamera(id='cam:1', resolution=(32, 24), fps=1)
     provider.add_camera(cam)
     await cam.connect()


### PR DESCRIPTION
> **Stack** (supersedes #423; review bottom-up, each PR is based on the one above it):
> 1. #470 — vision I/O helpers
> 2. #471 — RTSP and MJPEG reconnection
> 3. #472 — USB and simulated reconnection **(this PR)**

### Motivation

Completes device-level reconnection for the remaining two camera families, so every camera in RoSys follows the same contract introduced for RTSP and MJPEG in the PR below this one.

### Implementation

**`UsbDevice` becomes a `CaptureDevice`.**
A capture session reads frames until the capture is lost (failed reads past `MAX_READ_FAILURES` or a closed handle, e.g. an unplugged cable).
The loop then re-resolves the `/dev/video*` node from the camera uid, which can change on re-plug (`find_device_node` picks the lowest-numbered node), reopens it and reapplies the camera's parameters through `on_connect`, including auto-exposure and exposure.
This replaces the `on_repeat` polling and lets reads run at the camera's native rate instead of being capped by the poll interval.
A node that exists but cannot be opened (another process holds it) is logged once at `WARNING`.

**`SimulatedDevice` fails like a real one.**
It gains `disconnect()` to simulate a cable drop and a `simulate_failing` flag that drops the connection randomly over time, so the failure simulation moves from `SimulatedCameraProvider` into the device, matching where recovery lives.
The provider's `simulate_device_failure` attribute stays as a deprecated alias (emits `DeprecationWarning`) for one release.

**Providers only discover.**
`UsbCameraProvider` and `SimulatedCameraProvider` stop connecting and disconnecting cameras; a `UsbCamera` created before its video device appears is `is_active` and connects on its own once the node shows up.

**Lifecycle.**
The `Camera` base registers `rosys.on_shutdown(self.disconnect)` once per camera instead of once per device, so devices recreated on every reconnect cycle no longer leak shutdown handlers.

**Docs.**
`docs/examples/cameras/README.md` gets an "Automatic Reconnection" section explaining `is_connected` vs `is_active`, and the control example gains a connect button and binds its controls to `is_active`.

### Tests

Added to `tests/test_camera_reconnect.py`:

- `UsbDevice` against a fake capture: reopens after a simulated cable drop, releases a capture that only fails to read, reapplies parameters after reconnect, keeps one capture loop across concurrent reconnects, is active without a video device and connects once one appears.
- `SimulatedCamera`: resumes images after `disconnect()` once `reconnect_interval` elapsed, reapplies parameters, passes its parameters to the device, and `camera.disconnect()` stops the loop.
- Providers leave disconnected cameras alone; the USB provider adds a camera for a new device.
- The deprecated alias warns, devices do not leak shutdown handlers, `is_active` tracks `connect()`/`disconnect()`.

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

---
⬛ claude-fable-5-1
