### PR TITLE
Send the upload creation date under the key the detector node reads

### DIFF
--- a/rosys/vision/detector_hardware.py
+++ b/rosys/vision/detector_hardware.py
@@ -103,8 +103,10 @@ class DetectorHardware(Detector):
             metadata: dict[str, Any] = {
                 'source': source,
                 'tags': tags or [],
-                'created': _creation_date_to_isoformat(creation_date),
             }
+            # NOTE: unlike detect, the node parses this dict as ImageMetadata; absent `created` falls back to its time
+            if (created := _creation_date_to_isoformat(creation_date)) is not None:
+                metadata['created'] = created
 
             if detections := image.get_detections(self.name):
                 detections_dict = detections.to_dict()

--- a/rosys/vision/detector_hardware.py
+++ b/rosys/vision/detector_hardware.py
@@ -103,7 +103,7 @@ class DetectorHardware(Detector):
             metadata: dict[str, Any] = {
                 'source': source,
                 'tags': tags or [],
-                'creation_date': _creation_date_to_isoformat(creation_date),
+                'created': _creation_date_to_isoformat(creation_date),
             }
 
             if detections := image.get_detections(self.name):

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -2,24 +2,44 @@ from datetime import datetime
 from typing import Any
 
 import numpy as np
+import pytest
 
 from rosys.vision import DetectorHardware, Image
 
+Payloads = dict[str, dict[str, Any]]
 
-async def test_upload_keys_the_creation_date_as_created():
-    """The upload metadata is parsed against ``ImageMetadata``, which declares ``created``.
 
-    The ``detect`` payloads keep ``creation_date``: the detector node reads that one itself.
-    """
+@pytest.fixture
+def payloads() -> Payloads:
+    return {}
+
+
+@pytest.fixture
+def detector(monkeypatch: pytest.MonkeyPatch, payloads: Payloads) -> DetectorHardware:
+    async def capture(event: str, data: dict[str, Any], **_: Any) -> dict[str, Any]:
+        payloads[event] = data
+        return {'items': [{} for _ in data.get('images', [])]}
+
     detector = DetectorHardware(port=1234)
-    detector.sio.connected = True
-    emitted: list[dict[str, Any]] = []
+    monkeypatch.setattr(detector.sio, 'connected', True)
+    monkeypatch.setattr(detector.sio, 'emit', capture)
+    monkeypatch.setattr(detector.sio, 'call', capture)
+    return detector
 
-    async def capture(event: str, data: dict[str, Any]) -> None:
-        emitted.append(data)
-    detector.sio.emit = capture  # type: ignore[method-assign]
 
-    await detector.upload(Image.from_array(np.zeros((2, 2, 3), dtype=np.uint8)),
-                          creation_date=datetime(2020, 1, 1, 12, 0, 0))
+@pytest.mark.parametrize('creation_date, expected', [
+    (datetime(2020, 1, 1, 12, 0, 0), {'created': '2020-01-01T12:00:00'}),
+    ('2020-01-01T12:00:00', {'created': '2020-01-01T12:00:00'}),
+    (None, {}),  # an absent key lets the node fall back to its own time
+])
+async def test_upload_sends_the_creation_date_as_created(detector: DetectorHardware, payloads: Payloads,
+                                                         creation_date: datetime | str | None, expected: dict):
+    await detector.upload(Image.from_array(np.zeros((2, 2, 3), dtype=np.uint8)), creation_date=creation_date)
+    assert payloads['upload']['metadata'] == {'source': None, 'tags': [], **expected}
 
-    assert emitted[0]['metadata']['created'] == '2020-01-01T12:00:00'
+
+async def test_detect_keeps_the_creation_date_key(detector: DetectorHardware, payloads: Payloads):
+    image = Image.from_array(np.zeros((2, 2, 3), dtype=np.uint8))
+    await detector.detect(image, lazy=False, creation_date='2020-01-01T12:00:00')
+    await detector.batch_detect([image], creation_date='2020-01-01T12:00:00')
+    assert payloads['detect']['creation_date'] == payloads['batch_detect']['creation_date'] == '2020-01-01T12:00:00'

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from typing import Any
+
+import numpy as np
+
+from rosys.vision import DetectorHardware, Image
+
+
+async def test_upload_keys_the_creation_date_as_created():
+    """The upload metadata is parsed against ``ImageMetadata``, which declares ``created``.
+
+    The ``detect`` payloads keep ``creation_date``: the detector node reads that one itself.
+    """
+    detector = DetectorHardware(port=1234)
+    detector.sio.connected = True
+    emitted: list[dict[str, Any]] = []
+
+    async def capture(event: str, data: dict[str, Any]) -> None:
+        emitted.append(data)
+    detector.sio.emit = capture  # type: ignore[method-assign]
+
+    await detector.upload(Image.from_array(np.zeros((2, 2, 3), dtype=np.uint8)),
+                          creation_date=datetime(2020, 1, 1, 12, 0, 0))
+
+    assert emitted[0]['metadata']['created'] == '2020-01-01T12:00:00'


### PR DESCRIPTION
### Motivation

`Detector.upload(creation_date=...)` never reached the Learning Loop.

The socket.io `upload` metadata is parsed with `dacite.from_dict(data_class=ImageMetadata, data=metadata)` and no `config=`, so `strict` defaults to `False` and unmatched keys are dropped silently. `ImageMetadata` declares `created`, not `creation_date` — so the key was dropped, `created` fell back to its `default_factory` (the node's own upload time), and `outbox.save` shipped that timestamp to the loop in place of the caller's.

The `detect` and `batch_detect` payloads are deliberately left alone: that handler reads `data.get('creation_date')` itself and assigns `metadata.created`. Only the upload dict reaches dacite directly, so only that key was wrong — a blanket rename would break the two working paths.

### Implementation

One key rename in `DetectorHardware.upload`.

No detector node ever read the key in the position we send it: `ImageMetadata.created` has existed since `learning_loop_node#41` (Nov 2024), and that version's upload handler read `creation_date` from the *top level* of the event payload, not from inside `metadata` — the current handler has no top-level read at all. So `created` is the only spelling that has ever worked here, on old and new nodes alike.

`tests/test_detector.py` pins the emitted payload; it fails with the fix reverted (`KeyError: 'created'`). This repo had no detector test before, so the file is new.

Heads-up on #475: it lands in both of these places — a new `tests/test_detector.py`, and the same metadata-dict hunk in `detector_hardware.py` (it appends `'state'` directly below this line). Whichever merges second is a trivial two-line resolution; happy to rebase onto it if you'd rather take that one first.

<details><summary>Reproduction — both real packages, no reconstruction</summary>

`uv run --with learning-loop-node python mre.py`, against `rosys` at `16a69da3` and `learning-loop-node 0.22.0`. Drives the real `DetectorHardware.upload()` with `sio.emit` captured, then hands the captured dict to the node's real parser exactly as `detector_node.py`'s sio handler calls it. Last line is the works/broken toggle: same payload, one key renamed.

```python
import asyncio
from datetime import datetime
from typing import Any

import numpy as np
from dacite import from_dict
from learning_loop_node.data_classes import ImageMetadata

from rosys.vision import DetectorHardware, Image

CALLER_DATE = datetime(2020, 1, 1, 12, 0, 0)


async def main() -> None:
    detector = DetectorHardware(port=1234)
    detector.sio.connected = True
    captured: list[dict[str, Any]] = []

    async def capture(event: str, data: dict[str, Any]) -> None:
        captured.append(data)
    detector.sio.emit = capture  # type: ignore[method-assign]

    await detector.upload(Image.from_array(np.zeros((2, 2, 3), dtype=np.uint8)),
                          creation_date=CALLER_DATE)
    metadata = captured[0]['metadata']

    parsed = from_dict(data_class=ImageMetadata, data=metadata)
    print(f'emitted key          : {sorted(k for k in metadata if "creat" in k)}')
    print(f'expected created     : {CALLER_DATE.isoformat()}')
    print(f'actual   created     : {parsed.created}')

    fixed = {**metadata, 'created': metadata.get('creation_date', metadata.get('created'))}
    fixed.pop('creation_date', None)
    print(f"keyed 'created'      : {from_dict(data_class=ImageMetadata, data=fixed).created}")


asyncio.run(main())
```

Before this PR:

```
emitted key          : ['creation_date']
expected created     : 2020-01-01T12:00:00
actual   created     : 2026-09-08_09:42:53.871
keyed 'created'      : 2020-01-01T12:00:00
```

The substituted value is not even ISO-`T` formatted — it is the node's `current_datetime()`, which uses `sep='_'`.

</details>

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).
