### PR TITLE
Choose the plane orientation IPPE can solve

### DIFF
--- a/rosys/vision/spatial_resection.py
+++ b/rosys/vision/spatial_resection.py
@@ -47,7 +47,6 @@ class SpatialResection:
         if np.isnan(world_points).any() or np.isnan(image_points).any():
             raise ValueError('Points contain NaNs')
 
-        # Prepare calibration and undistort image observations for a unified pinhole model
         calibration = Calibration(intrinsics=self.intrinsics)
         K_undist = calibration.get_undistorted_camera_matrix()
 
@@ -57,9 +56,7 @@ class SpatialResection:
 
         plane_frame = _fit_plane_frame(object_points)
 
-        # Decide on algorithm
         if algorithm is None:
-            # Automatic selection
             num_points = object_points.shape[0]
             if num_points >= 4 and plane_frame is not None:
                 method_flag = cv2.SOLVEPNP_IPPE
@@ -90,7 +87,6 @@ class SpatialResection:
         else:
             raise TypeError('Algorithm must be int, str or None')
 
-        # Run PnP on undistorted points with zero distortion and K_undist
         use_guess = p0 is not None and r0 is not None
         if use_guess:
             assert p0 is not None and r0 is not None
@@ -128,7 +124,6 @@ class SpatialResection:
                 rvec_init, tvec_init, use_guess, int(method_flag)
             )
         if not ok:
-            # Fallback to ITERATIVE
             ok, rvec, tvec = cv2.solvePnP(
                 object_points, image_points_undist, K_undist, D_zeros,
                 rvec_init, tvec_init, use_guess, int(cv2.SOLVEPNP_ITERATIVE)

--- a/rosys/vision/spatial_resection.py
+++ b/rosys/vision/spatial_resection.py
@@ -56,15 +56,12 @@ class SpatialResection:
         D_zeros: np.ndarray = np.zeros((1, 5), dtype=np.float64)
 
         # Decide on algorithm
-        def is_planar(points: np.ndarray) -> bool:
-            centered = points.reshape(-1, 3) - points.reshape(-1, 3).mean(axis=0)
-            _, s, _ = np.linalg.svd(centered, full_matrices=False)
-            return s[-1] / max(s[0], 1e-12) < 1e-3
+        plane_frame = _fit_plane_frame(object_points)
 
         if algorithm is None:
             # Automatic selection
             num_points = object_points.shape[0]
-            if num_points >= 4 and is_planar(object_points):
+            if num_points >= 4 and plane_frame is not None:
                 method_flag = cv2.SOLVEPNP_IPPE
             elif num_points >= 6:
                 method_flag = cv2.SOLVEPNP_EPNP
@@ -103,10 +100,24 @@ class SpatialResection:
             rvec_init = None
             tvec_init = None
 
+        # IPPE only solves points on the z = 0 plane, so give it the object points in their own plane's frame
+        solve_in_plane_frame = method_flag == cv2.SOLVEPNP_IPPE and plane_frame is not None
+        if solve_in_plane_frame:
+            assert plane_frame is not None
+            plane_rotation, plane_centroid = plane_frame
+            solve_points = ((object_points.reshape(-1, 3) - plane_centroid) @ plane_rotation.T).reshape(-1, 1, 3)
+        else:
+            solve_points = object_points
+
         ok, rvec, tvec = cv2.solvePnP(
-            object_points, image_points_undist, K_undist, D_zeros,
+            solve_points, image_points_undist, K_undist, D_zeros,
             rvec_init, tvec_init, use_guess, int(method_flag)
         )
+        if ok and solve_in_plane_frame:
+            rmat = np.asarray(cv2.Rodrigues(rvec)[0], dtype=np.float64) @ plane_rotation
+            translation = np.asarray(tvec, dtype=np.float64).reshape(3) - rmat @ plane_centroid
+            rvec = np.asarray(cv2.Rodrigues(rmat)[0], dtype=np.float64)
+            tvec = np.ascontiguousarray(translation).reshape(3, 1)
         if not ok:
             # Fallback to ITERATIVE
             ok, rvec, tvec = cv2.solvePnP(
@@ -272,3 +283,18 @@ class SpatialResection:
                 for x, y, z in world_lines[:, :3] + world_lines[:, 3:] * res.x[7:, None]
             ],
         )
+
+
+def _fit_plane_frame(points: np.ndarray) -> tuple[np.ndarray, np.ndarray] | None:
+    """Find a right-handed frame whose z = 0 plane holds the given points.
+
+    :param points: The points in object space, shape (n, 3) or (n, 1, 3)
+    :return: The rotation from object space into the plane frame and the centroid it is anchored at,
+        or ``None`` if the points are not coplanar
+    """
+    centroid = points.reshape(-1, 3).mean(axis=0)
+    _, s, vt = np.linalg.svd(points.reshape(-1, 3) - centroid, full_matrices=False)
+    if s[-1] / max(s[0], 1e-12) >= 1e-3:
+        return None
+    rotation = vt if np.linalg.det(vt) > 0 else vt * np.array([[1.0], [1.0], [-1.0]])
+    return rotation, centroid

--- a/rosys/vision/spatial_resection.py
+++ b/rosys/vision/spatial_resection.py
@@ -37,8 +37,8 @@ class SpatialResection:
         :param world_points: The 3D coordinates of the points in object space, shape (n, 3)
         :param image_points: The 2D coordinates of the points in the image, shape (n, 2)
         :param algorithm: PnP algorithm flag or name (e.g., 'ITERATIVE', 'EPNP', 'P3P', 'AP3P', 'IPPE'). If None, choose automatically.
-        :param p0: Initial position of the camera (optional)
-        :param r0: Initial rotation of the camera (optional)
+        :param p0: Initial position of the camera, used by the ITERATIVE algorithm only (optional)
+        :param r0: Initial rotation of the camera, used by the ITERATIVE algorithm only (optional)
 
         :return: The result of the spatial resection
         """
@@ -100,24 +100,33 @@ class SpatialResection:
             rvec_init = None
             tvec_init = None
 
-        # IPPE only solves points on the z = 0 plane, so give it the object points in their own plane's frame
-        solve_in_plane_frame = method_flag == cv2.SOLVEPNP_IPPE and plane_frame is not None
-        if solve_in_plane_frame:
-            assert plane_frame is not None
-            plane_rotation, plane_centroid = plane_frame
-            solve_points = ((object_points.reshape(-1, 3) - plane_centroid) @ plane_rotation.T).reshape(-1, 1, 3)
-        else:
-            solve_points = object_points
+        def mean_reprojection_error(rvec: np.ndarray, tvec: np.ndarray) -> float:
+            projected, _ = cv2.projectPoints(object_points, rvec, tvec, K_undist, D_zeros)
+            residuals = np.asarray(projected, dtype=np.float64).reshape(-1, 2) - image_points_undist.reshape(-1, 2)
+            return float(np.mean(np.abs(residuals)))
 
-        ok, rvec, tvec = cv2.solvePnP(
-            solve_points, image_points_undist, K_undist, D_zeros,
-            rvec_init, tvec_init, use_guess, int(method_flag)
-        )
-        if ok and solve_in_plane_frame:
-            rmat = np.asarray(cv2.Rodrigues(rvec)[0], dtype=np.float64) @ plane_rotation
-            translation = np.asarray(tvec, dtype=np.float64).reshape(3) - rmat @ plane_centroid
-            rvec = np.asarray(cv2.Rodrigues(rmat)[0], dtype=np.float64)
-            tvec = np.ascontiguousarray(translation).reshape(3, 1)
+        if method_flag == cv2.SOLVEPNP_IPPE and plane_frame is not None:
+            # OpenCV's IPPE only solves a plane whose z axis points away from the camera, which the fit cannot know
+            plane_rotation, plane_centroid = plane_frame
+            candidates: list[tuple[float, np.ndarray, np.ndarray]] = []
+            for rotation in (plane_rotation, np.diag([1.0, -1.0, -1.0]) @ plane_rotation):
+                plane_points = ((object_points.reshape(-1, 3) - plane_centroid) @ rotation.T).reshape(-1, 1, 3)
+                ok, rvec, tvec = cv2.solvePnP(plane_points, image_points_undist, K_undist, D_zeros,
+                                              None, None, False, int(cv2.SOLVEPNP_IPPE))
+                if not ok or not np.isfinite(rvec).all() or not np.isfinite(tvec).all():
+                    continue
+                rmat = np.asarray(cv2.Rodrigues(rvec)[0], dtype=np.float64) @ rotation
+                tvec = (np.asarray(tvec, dtype=np.float64).reshape(3) - rmat @ plane_centroid).reshape(3, 1)
+                rvec = np.asarray(cv2.Rodrigues(rmat)[0], dtype=np.float64)
+                candidates.append((mean_reprojection_error(rvec, tvec), rvec, tvec))
+            ok = bool(candidates)
+            if ok:
+                _, rvec, tvec = min(candidates, key=lambda candidate: candidate[0])
+        else:
+            ok, rvec, tvec = cv2.solvePnP(
+                object_points, image_points_undist, K_undist, D_zeros,
+                rvec_init, tvec_init, use_guess, int(method_flag)
+            )
         if not ok:
             # Fallback to ITERATIVE
             ok, rvec, tvec = cv2.solvePnP(
@@ -142,17 +151,10 @@ class SpatialResection:
         tvec_arr = np.asarray(tvec, dtype=np.float64).reshape(3)
         C = (-rmat.T @ tvec_arr).reshape(3)
 
-        # Compute reprojection error on all observations (undistorted domain)
-        proj_all, _ = cv2.projectPoints(object_points, rvec, tvec, K_undist, D_zeros)
-        proj_all_np = np.asarray(proj_all, dtype=np.float64).reshape(-1, 2)
-        img_all_np = image_points_undist.reshape(-1, 2)
-        residuals_all = proj_all_np - img_all_np
-        avg_reproj_error = float(np.mean(np.abs(residuals_all)))
-
         return SpatialResectionResult(
             success=True,
             iterations=1,
-            average_reprojection_error=avg_reproj_error,
+            average_reprojection_error=mean_reprojection_error(rvec, tvec),
             camera_pose=Pose3d(x=float(C[0]), y=float(C[1]), z=float(C[2]), rotation=Rwc),
             running_variables=[],
             estimated_points_on_lines=[],

--- a/rosys/vision/spatial_resection.py
+++ b/rosys/vision/spatial_resection.py
@@ -55,9 +55,9 @@ class SpatialResection:
         image_points_undist = calibration.undistort_points(image_points.astype(np.float64).reshape(-1, 1, 2))
         D_zeros: np.ndarray = np.zeros((1, 5), dtype=np.float64)
 
-        # Decide on algorithm
         plane_frame = _fit_plane_frame(object_points)
 
+        # Decide on algorithm
         if algorithm is None:
             # Automatic selection
             num_points = object_points.shape[0]

--- a/tests/test_spatial_resections.py
+++ b/tests/test_spatial_resections.py
@@ -123,9 +123,13 @@ def test_spatial_resection_with_line_points(parallel_lines: bool):
 @pytest.mark.parametrize('algorithm', (None, 'IPPE'))
 @pytest.mark.parametrize('tilt', (0.0, 30.0))
 @pytest.mark.parametrize('offset', (0.0, 0.8))
-def test_spatial_resection_with_planar_points(offset: float, tilt: float, algorithm: str | None):
+@pytest.mark.parametrize('shift', (0.0, 0.15))
+@pytest.mark.parametrize('grid_shape', ((6, 6), (6, 5)))
+def test_spatial_resection_with_planar_points(grid_shape: tuple[int, int], shift: float, offset: float, tilt: float,
+                                              algorithm: str | None):
     """Test the spatial resection with a flat target whose plane is offset and tilted against z = 0.
 
+    The target is a square or an oblong grid, centred under the camera or shifted sideways.
     The camera hovers 0.6 m above the target, whatever plane the target sits on.
     """
     cam = CalibratableCamera(id='1')
@@ -133,9 +137,10 @@ def test_spatial_resection_with_planar_points(offset: float, tilt: float, algori
                                 x=0.1, y=0.2, z=offset + 0.6)
     assert cam.calibration is not None
 
-    grid = np.array([[x, y, 0.0] for x in np.linspace(-0.2, 0.2, 6) for y in np.linspace(-0.2, 0.2, 6)])
+    columns, rows = grid_shape
+    grid = np.array([[x, y, 0.0] for x in np.linspace(-0.2, 0.2, columns) for y in np.linspace(-0.2, 0.2, rows)])
     rotation = np.array(Rotation.from_euler(0.0, np.deg2rad(tilt), 0.0).matrix)
-    world_points = grid @ rotation.T + np.array([0.0, 0.0, offset])
+    world_points = grid @ rotation.T + np.array([shift, 0.0, offset])
     image_points = cam.calibration.project_to_image(world_points)
 
     result = SpatialResection(cam.calibration.intrinsics).pnp_with_lsa(

--- a/tests/test_spatial_resections.py
+++ b/tests/test_spatial_resections.py
@@ -118,3 +118,34 @@ def test_spatial_resection_with_line_points(parallel_lines: bool):
     # Check the estimated object space points on lines
     for line_point, world_point in zip(result.estimated_points_on_lines, world_points, strict=False):
         assert np.allclose(line_point.array, world_point, atol=5)
+
+
+@pytest.mark.parametrize('algorithm', (None, 'IPPE'))
+@pytest.mark.parametrize('tilt', (0.0, 30.0))
+@pytest.mark.parametrize('offset', (0.0, 0.8))
+def test_spatial_resection_with_planar_points(offset: float, tilt: float, algorithm: str | None):
+    """Test the spatial resection with a flat target whose plane is offset and tilted against z = 0.
+
+    The camera hovers 0.6 m above the target, whatever plane the target sits on.
+    """
+    cam = CalibratableCamera(id='1')
+    cam.set_perfect_calibration(width=1920, height=1080, distortion=[0.0, 0.0, 0.0, 0.0, 0.0],
+                                x=0.1, y=0.2, z=offset + 0.6)
+    assert cam.calibration is not None
+
+    grid = np.array([[x, y, 0.0] for x in np.linspace(-0.2, 0.2, 6) for y in np.linspace(-0.2, 0.2, 6)])
+    rotation = np.array(Rotation.from_euler(0.0, np.deg2rad(tilt), 0.0).matrix)
+    world_points = grid @ rotation.T + np.array([0.0, 0.0, offset])
+    image_points = cam.calibration.project_to_image(world_points)
+
+    result = SpatialResection(cam.calibration.intrinsics).pnp_with_lsa(
+        world_points=world_points,
+        image_points=image_points,
+        algorithm=algorithm,
+    )
+
+    assert result.success
+    ground_truth_translation = cam.calibration.extrinsics.point_3d
+    ground_truth_rotation = cam.calibration.extrinsics.rotation
+    assert np.allclose(result.camera_pose.point_3d.array, ground_truth_translation.array, atol=0.001)
+    assert np.allclose(result.camera_pose.rotation.quaternion, ground_truth_rotation.quaternion, atol=0.001)


### PR DESCRIPTION
### Motivation

`SpatialResection.pnp_with_lsa` picks `cv2.SOLVEPNP_IPPE` for coplanar object points. OpenCV centres those points and rotates them onto z = 0 itself, but it only returns a correct pose when that plane's z axis points *away* from the camera. With the axis pointing at the camera the pose comes back hundreds of millimetres wrong in an otherwise perfect scene, and for an exactly fronto-parallel plane OpenCV's `rot2vec` divides by `sin(π)` and returns `rvec = [nan nan nan]`. Both cases report `success=True`. Which way the axis points is whatever the plane fit's SVD produced, so whether a resection was right depended on the target's shape and where it sat, and a downstream application had no way to notice.

### Implementation

- Fit the plane once, run IPPE with its z axis pointing both ways, drop a non-finite pose, and keep the candidate with the lower reprojection error; the LM refinement afterwards is unchanged.
- Replace the nested `is_planar` predicate with `_fit_plane_frame`; the automatic algorithm choice reads "planar" off the same SVD.
- Compute the reprojection error in one place, used for the candidate choice and for the returned result.
- Update the docstring: the extrinsic guess applies to `ITERATIVE` only, the sole algorithm OpenCV uses it for.
- Add `test_spatial_resection_with_planar_points`: square and oblong grids, centred and shifted off the camera axis, flat and tilted, on and off z = 0.
- Remove the comments in `pnp_with_lsa` that restated the code.

<details><summary>Details</summary>

Measured on noise-free synthetic projections, so the only error is the algorithm's: default intrinsics at 1920x1080 without distortion, camera looking straight down from 0.6 m above the target. 96 scenes: grids of 6x6, 6x5 and 5x7 points spanning ±0.2 m, tilted 0° and 30°, centred and shifted 0.15 m off the camera axis, at plane offsets of 0, 0.4, 0.8 and 1.6 m, solved with `'IPPE'` and with the automatic choice. A scene counts as wrong when the camera position is more than 1 mm off or the pose is not finite.

| | wrong of 96 |
|---|---|
| before | 64 |
| now | 0 |

Rotating the points into their own plane frame before the IPPE call is not enough on its own. It repairs a centred square grid and changes nothing for an oblong or off-axis one, because the sign of the plane normal is still the SVD's. For a square grid the two in-plane singular values tie to 1e-16, so that sign is not even stable against the rounding an offset carries into the centroid: same physical scene, two object frames, opposite outcomes.

`cv2.solvePnPGeneric` is not a way out either. Both solutions it returns come from the same orientation, so in the wrong one both are wrong: 20 px and 194 px mean reprojection error, where the right orientation reaches 1e-13 px.

Deliberately left alone: `success` is hardcoded to `True` whenever OpenCV returns a pose, which is what makes a bad resection silent rather than loud. That is worth its own change.

</details>

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

[※](https://zauberzeug.github.io/colophon/#m=claude-fable-5-1&t=Defect%20analysis%2C%20fix%2C%20test%20and%20this%20description%20by%20agents%20over%20several%20sessions%3B%20direction%2C%20triage%20and%20severity%20by%20the%20author.&p=agent&a=claude-code "claude-fable-5-1: Defect analysis, fix, test and this description by agents over several sessions; direction, triage and severity by the author.")
