### PR TITLE
Keep the GNSS read buffer bounded while the receiver has no time

### DIFF
--- a/rosys/hardware/gnss/gnss_hardware.py
+++ b/rosys/hardware/gnss/gnss_hardware.py
@@ -14,7 +14,7 @@ from .nmea import Gga, GpsQuality, Gst, Pssn
 class GnssHardware(Gnss):
     """This hardware module connects to a Septentrio SimpleRTK3b (Mosaic-H) GNSS receiver."""
     NMEA_TYPES: ClassVar[set[str]] = {'GPGGA', 'GPGST', 'PSSN,HRP'}
-    NMEA_PATTERN = re.compile(r'\$(?P<type>[A-Z,]+),(?P<timestamp>\d{6}(?:\.\d+)?)[^*]*\*[0-9A-Fa-f]{2}\r\n')
+    NMEA_PATTERN = re.compile(r'\$(?P<type>[A-Z,]+),(?P<timestamp>\d{6}(?:\.\d+)?)[^*]*\*[0-9A-Fa-f]{2}')
 
     def __init__(self, *, antenna_pose: Pose | None, reconnect_interval: float = 3.0, max_measurement_age: float = 0.05) -> None:
         """
@@ -50,47 +50,37 @@ class GnssHardware(Gnss):
             result = self.serial_connection.read_all().decode('utf-8', errors='replace')
             if not result:
                 continue
-            buffer += result
-            matches = list(self.NMEA_PATTERN.finditer(buffer))
-            for match in reversed(matches):
+            *lines, buffer = (buffer + result).split('\n')
+            sentences: dict[str, str] | None = None
+            for line in lines:
+                match = self.NMEA_PATTERN.search(line)
+                if match is None:
+                    continue
                 type_, nmea_timestamp = match['type'], match['timestamp']
                 if type_ not in self.NMEA_TYPES:
                     self.log.debug('Skipping unknown type: %s', type_)
                     continue
                 sentence = match.group(0)
                 self.log.debug('%s, %s: %s', type_, nmea_timestamp, sentence)
-                sentence = sentence[:sentence.find('*')]
-                latest_messages[type_] = (nmea_timestamp, sentence)
-                buffer = buffer[:match.start()]
-                if not self.NMEA_TYPES.issubset(latest_messages):
-                    continue
-                timestamps = {latest_messages[msg_type][0] for msg_type in self.NMEA_TYPES}
-                if len(timestamps) != 1:
-                    latest_timestamp = max(timestamps)
-                    latest_messages = {msg_type: (timestamp, sentence)
-                                       for msg_type, (timestamp, sentence) in latest_messages.items()
-                                       if timestamp >= latest_timestamp}
-                    continue
-                if not self.NMEA_TYPES.issubset(latest_messages):
-                    continue
-                try:
-                    measurement = self._parse_measurement(latest_messages['GPGGA'][1],
-                                                          latest_messages['GPGST'][1],
-                                                          latest_messages['PSSN,HRP'][1])
-                except ValueError as e:
-                    self.log.debug('Failed to parse measurement: %s', e)
-                    continue
-                measurement_age = measurement.age
-                if abs(measurement_age) > self._max_measurement_age:
-                    self.log.warning('measurement age = %.3f (exceeds threshold of %s)',
-                                     measurement_age, self._max_measurement_age)
-                    continue
-                self.log.debug('dt: %.3f - %s', measurement_age, measurement)
-                self.last_measurement = measurement
-                self.NEW_MEASUREMENT.emit(measurement)
-                buffer = ''
-                latest_messages.clear()
-                break
+                latest_messages[type_] = (nmea_timestamp, sentence[:sentence.find('*')])
+                timestamps = {timestamp for timestamp, _ in latest_messages.values()}
+                if len(latest_messages) == len(self.NMEA_TYPES) and len(timestamps) == 1:
+                    sentences = {msg_type: text for msg_type, (_, text) in latest_messages.items()}
+            if sentences is None:
+                continue
+            try:
+                measurement = self._parse_measurement(sentences['GPGGA'], sentences['GPGST'], sentences['PSSN,HRP'])
+            except ValueError as e:
+                self.log.debug('Failed to parse measurement: %s', e)
+                continue
+            measurement_age = measurement.age
+            if abs(measurement_age) > self._max_measurement_age:
+                self.log.warning('measurement age = %.3f (exceeds threshold of %s)',
+                                 measurement_age, self._max_measurement_age)
+                continue
+            self.log.debug('dt: %.3f - %s', measurement_age, measurement)
+            self.last_measurement = measurement
+            self.NEW_MEASUREMENT.emit(measurement)
 
     async def _connect(self) -> bool:
         try:

--- a/tests/test_gnss_hardware.py
+++ b/tests/test_gnss_hardware.py
@@ -1,0 +1,57 @@
+import os
+import pty
+from collections.abc import Generator
+
+import pytest
+import serial
+
+from rosys.hardware import GnssHardware
+from rosys.testing import forward
+
+SENTENCES = ('$GPGGA,120000.00,4807.03800,N,01131.00000,E,4,12,0.9,545.4,M,46.9,M,,*47\r\n'
+             '$GPGST,120000.00,0.01,0.02,0.01,45.0,0.011,0.012,0.02*6A\r\n'
+             '$PSSN,HRP,120000.00,110926,90.0,0.0,0.0,0.1,0.1,0.1,12,4,*52\r\n')
+SENTENCES_WITHOUT_TIME = ('$GPGGA,,,,,,0,00,,,M,,M,,*66\r\n'
+                          '$PSSN,HRP,,,,,,,,,00,0,,*48\r\n'
+                          '$GPGST,,,,,,,,*57\r\n')
+
+
+@pytest.fixture
+def receiver(rosys_integration: None) -> Generator[tuple[GnssHardware, int], None, None]:
+    controller, device = pty.openpty()
+    gnss = GnssHardware(antenna_pose=None, max_measurement_age=float('inf'))
+    gnss.serial_connection = serial.Serial(os.ttyname(device))
+    yield gnss, controller
+    gnss.serial_connection.close()
+    os.close(controller)
+    os.close(device)
+
+
+async def test_measurement_from_a_complete_sentence_set(receiver: tuple[GnssHardware, int]) -> None:
+    gnss, controller = receiver
+    os.write(controller, SENTENCES.encode())
+    await forward(seconds=0.1)
+    assert gnss.last_measurement is not None
+    assert gnss.last_measurement.pose.degree_tuple[0] == pytest.approx(48.1173)
+    assert gnss.last_measurement.gps_quality == 4
+
+
+async def test_measurement_from_sentences_split_across_reads(receiver: tuple[GnssHardware, int]) -> None:
+    gnss, controller = receiver
+    split = SENTENCES.index('$GPGST') + 20
+    os.write(controller, SENTENCES[:split].encode())
+    await forward(seconds=0.1)
+    os.write(controller, SENTENCES[split:].encode())
+    await forward(seconds=0.1)
+    assert gnss.last_measurement is not None
+
+
+async def test_measurement_after_a_receiver_without_time(receiver: tuple[GnssHardware, int]) -> None:
+    gnss, controller = receiver
+    for _ in range(100):
+        os.write(controller, SENTENCES_WITHOUT_TIME.encode())
+        await forward(seconds=0.1)
+    assert gnss.last_measurement is None
+    os.write(controller, SENTENCES.encode())
+    await forward(seconds=0.1)
+    assert gnss.last_measurement is not None


### PR DESCRIPTION
### Motivation

`GnssHardware` cleared its read buffer only after a valid measurement. A receiver that has not had GNSS time since power-up (a robot standing indoors) sends NMEA sentences without a timestamp, which never match `NMEA_PATTERN`. The buffer then grows for as long as the receiver stays without time, and the pattern runs over all of it every 10 ms. After a few hours the main thread sat at 100 % CPU, the UI took minutes to load and socket.io connections to the detectors timed out.

### Implementation

- Split the incoming data into lines and keep only the unfinished tail, so the buffer never holds more than one partial sentence.
- Emit the newest complete GGA/GST/HRP set of a read, as before.
- Sentences split across two reads are no longer lost (the old cut before each match dropped them).

<details><summary>Details</summary>

- Profiling a robot in this state with py-spy put 96.8 % of the main thread's samples on the `finditer` line. The receiver was sending `$GPGGA,,,,,,0,00,,,M,,M,,*66`, `$PSSN,HRP,,,,,,,,,00,0,,*48` and `$GPGST,,,,,,,,*57`.
- A second robot, also indoors with 0 satellites, was not affected. Its receiver had got time earlier and kept stamping its sentences, so they matched and cut the buffer back.
- The tail is only unbounded if the receiver never sends a newline, which an NMEA stream does not do.
- The new tests drive the parser through a pseudo-terminal. The split-read test fails on the old parser. The growth itself is not asserted, because it is only visible in the internal buffer.

</details>

### Progress

- [x] I chose a meaningful title that completes the sentence: "If applied, this PR will..."
- [x] I chose meaningful labels (if GitHub allows me to so).
- [x] The implementation is complete.
- [x] Pytests have been added (or are not necessary).
- [x] Documentation has been added (or is not necessary).

[※](https://zauberzeug.github.io/colophon/#m=claude-opus-5&t=Diagnosed%20on%20the%20robot%20together%20with%20the%20author%3B%20code%2C%20test%20and%20wording%20by%20the%20model.&p=agent "claude-opus-5: Diagnosed on the robot together with the author; code, test and wording by the model.")
